### PR TITLE
Install Claude intercept runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains:
 bash <(curl -fsSL https://raw.githubusercontent.com/datadog-labs/trajectory/main/install.sh)
 ```
 
-The installer downloads the latest Trajectory release asset for your platform, installs it under `~/.trajectory/bin/trajectory`, runs `trajectory setup`, and registers detected coding-agent plugins.
+The installer downloads the latest Trajectory release asset for your platform, installs it under `~/.trajectory/bin/trajectory`, stages the Claude wrapper intercept runtime, runs `trajectory setup`, and registers detected coding-agent plugins.
 
 To upgrade an install from this repository, rerun the installer.
 
@@ -61,6 +61,7 @@ plugin/trajectory-codex/  Codex plugin
 plugin/trajectory-gemini/ Gemini context assets
 plugin/trajectory-pi/     Pi extension
 plugin/trajectory-opencode/ OpenCode plugin
+intercepts/               Claude wrapper intercept runtime
 skills/                   Shared skill assets
 RELEASES.json             Release-channel selector
 install.sh                Installer

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ set -e
 
 INSTALL_DIR="$HOME/.trajectory"
 BIN_DIR="$INSTALL_DIR/bin"
+INTERCEPT_DIR="$INSTALL_DIR/intercepts"
 # BINARY and BINARY_SUFFIX are finalised after detect_platform() runs - they
 # become trajectory.exe on Windows (Git Bash / MSYS / Cygwin) and trajectory
 # on darwin/linux.
@@ -217,9 +218,32 @@ TRAJECTORY_SELF_UPDATE_URL=https://raw.githubusercontent.com/datadog-labs/trajec
 EOF
 }
 
+install_intercept_assets() {
+    local asset src dest tmp
+    mkdir -p "$INTERCEPT_DIR"
+
+    for asset in intercept-shared.mjs bun-llm-intercept.mjs node-llm-spy.cjs; do
+        src="$SCRIPT_DIR/intercepts/$asset"
+        dest="$INTERCEPT_DIR/$asset"
+        if [ -f "$src" ]; then
+            cp "$src" "$dest"
+        else
+            tmp="${dest}.tmp.$$"
+            if ! curl -sfL -o "$tmp" "https://raw.githubusercontent.com/$REPO/main/intercepts/$asset"; then
+                rm -f "$tmp"
+                fail "Could not install Claude intercept asset: $asset"
+            fi
+            mv "$tmp" "$dest"
+        fi
+        chmod 0644 "$dest" 2>/dev/null || true
+    done
+}
+
 info ""
 info "=== Trajectory Installer ==="
 info ""
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 PLATFORM="$(detect_platform)"
 case "$PLATFORM" in
@@ -271,6 +295,7 @@ else
 fi
 
 write_selfupdate_policy
+install_intercept_assets
 
 if [ "$NON_INTERACTIVE" = "1" ]; then
     info "[4/5] Running setup (non-interactive)..."
@@ -287,7 +312,6 @@ fi
 
 "$BINARY" setup "${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_INSTALLED=0
 
 # Claude Code plugin

--- a/intercepts/bun-llm-intercept.mjs
+++ b/intercepts/bun-llm-intercept.mjs
@@ -1,0 +1,433 @@
+import {
+  buildLLMCallEvent,
+  computeDurationMs,
+  computeTTFBMs,
+  extractTokenUsageFromSSEEvents,
+  nowHrtimeNs,
+  parseSSEStream,
+  postLLMCallEvent,
+  resolveSessionId,
+} from './intercept-shared.mjs';
+
+const INTERCEPT_GUARD = Symbol.for('trajectory-intercepted');
+
+function getRequestURL(input) {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input && typeof input.url === 'string') {
+    return input.url;
+  }
+  return '';
+}
+
+function shouldIntercept(url) {
+  if (typeof url !== 'string' || url.length === 0) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === 'api.anthropic.com') {
+      return true;
+    }
+    // dd-apm-test-agent also instruments custom Anthropic-compatible gateways
+    // by matching Anthropic API paths instead of only the public API host.
+    return /^\/v1\/(messages|complete)(\/|$)/.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function parseJsonSafe(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch {
+    // Silent by design.
+  }
+  return {};
+}
+
+function parseBodyFromInit(init) {
+  const body = init?.body;
+
+  if (typeof body === 'string') {
+    return Promise.resolve(parseJsonSafe(body));
+  }
+
+  if (body && typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+    return Promise.resolve(parseJsonSafe(body.toString()));
+  }
+
+  if (body && typeof body === 'object' && typeof body.byteLength === 'number') {
+    try {
+      const decoder = new TextDecoder();
+      return Promise.resolve(parseJsonSafe(decoder.decode(body)));
+    } catch {
+      return Promise.resolve({});
+    }
+  }
+
+  return null;
+}
+
+function extractRequestBody(input, init) {
+  const fromInit = parseBodyFromInit(init);
+  if (fromInit) {
+    return fromInit;
+  }
+
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    try {
+      return input
+        .clone()
+        .text()
+        .then((text) => parseJsonSafe(text))
+        .catch(() => ({}));
+    } catch {
+      return Promise.resolve({});
+    }
+  }
+
+  return Promise.resolve({});
+}
+
+function isNonEmpty(value) {
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return Boolean(value);
+}
+
+function extractRequestSummary(body) {
+  const request = body && typeof body === 'object' ? body : {};
+  const messages = Array.isArray(request.messages) ? request.messages : [];
+  const tools = Array.isArray(request.tools) ? request.tools : [];
+  const toolResultIds = [];
+
+  for (const message of messages) {
+    const content = message?.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+
+    for (const block of content) {
+      if (block?.type === 'tool_result' && typeof block?.tool_use_id === 'string') {
+        toolResultIds.push(block.tool_use_id);
+      }
+    }
+  }
+
+  return {
+    message_count: messages.length,
+    system_present: isNonEmpty(request.system),
+    tools_count: tools.length,
+    max_tokens: Number.isFinite(request.max_tokens) ? Math.trunc(request.max_tokens) : 0,
+    has_tool_results: toolResultIds.length > 0,
+    tool_result_ids: toolResultIds,
+  };
+}
+
+function extractResponseSummary(events) {
+  const contentBlockTypes = new Set();
+  const toolUseIds = new Set();
+  const toolUseNames = new Set();
+  let textLength = 0;
+  let thinkingLength = 0;
+
+  for (const event of Array.isArray(events) ? events : []) {
+    const eventType = event?.event || event?.data?.type || '';
+    const data = event?.data;
+
+    if (eventType === 'content_block_start') {
+      const block = data?.content_block;
+      if (typeof block?.type === 'string' && block.type.length > 0) {
+        contentBlockTypes.add(block.type);
+      }
+      if (block?.type === 'tool_use') {
+        if (typeof block?.id === 'string' && block.id.length > 0) {
+          toolUseIds.add(block.id);
+        }
+        if (typeof block?.name === 'string' && block.name.length > 0) {
+          toolUseNames.add(block.name);
+        }
+      }
+      continue;
+    }
+
+    if (eventType === 'content_block_delta') {
+      const delta = data?.delta;
+      if (typeof delta?.type === 'string' && delta.type === 'text_delta') {
+        contentBlockTypes.add('text');
+        if (typeof delta?.text === 'string') {
+          textLength += delta.text.length;
+        }
+      }
+      if (typeof delta?.type === 'string' && delta.type === 'thinking_delta') {
+        contentBlockTypes.add('thinking');
+        if (typeof delta?.thinking === 'string') {
+          thinkingLength += delta.thinking.length;
+        }
+      }
+    }
+  }
+
+  return {
+    content_block_types: Array.from(contentBlockTypes),
+    tool_use_ids: Array.from(toolUseIds),
+    tool_use_names: Array.from(toolUseNames),
+    text_length: textLength,
+    thinking_length: thinkingLength,
+  };
+}
+
+function extractResponseSummaryFromMessage(payload) {
+  const contentBlockTypes = new Set();
+  const toolUseIds = new Set();
+  const toolUseNames = new Set();
+  let textLength = 0;
+  let thinkingLength = 0;
+
+  const content = Array.isArray(payload?.content) ? payload.content : [];
+  for (const block of content) {
+    if (typeof block?.type === 'string' && block.type.length > 0) {
+      contentBlockTypes.add(block.type);
+    }
+    if (block?.type === 'tool_use') {
+      if (typeof block?.id === 'string' && block.id.length > 0) {
+        toolUseIds.add(block.id);
+      }
+      if (typeof block?.name === 'string' && block.name.length > 0) {
+        toolUseNames.add(block.name);
+      }
+    }
+    if (block?.type === 'text' && typeof block?.text === 'string') {
+      textLength += block.text.length;
+    }
+    if (block?.type === 'thinking' && typeof block?.thinking === 'string') {
+      thinkingLength += block.thinking.length;
+    }
+  }
+
+  return {
+    content_block_types: Array.from(contentBlockTypes),
+    tool_use_ids: Array.from(toolUseIds),
+    tool_use_names: Array.from(toolUseNames),
+    text_length: textLength,
+    thinking_length: thinkingLength,
+  };
+}
+
+function extractTokenUsageFromMessage(payload) {
+  const usage = payload?.usage || {};
+  return {
+    model: typeof payload?.model === 'string' && payload.model.length > 0 ? payload.model : 'unknown',
+    stop_reason:
+      typeof payload?.stop_reason === 'string' && payload.stop_reason.length > 0
+        ? payload.stop_reason
+        : 'unknown',
+    tokens: {
+      input_tokens: Number.isFinite(usage.input_tokens) ? Math.trunc(usage.input_tokens) : 0,
+      output_tokens: Number.isFinite(usage.output_tokens) ? Math.trunc(usage.output_tokens) : 0,
+      cache_read_input_tokens: Number.isFinite(usage.cache_read_input_tokens)
+        ? Math.trunc(usage.cache_read_input_tokens)
+        : 0,
+      cache_creation_input_tokens: Number.isFinite(usage.cache_creation_input_tokens)
+        ? Math.trunc(usage.cache_creation_input_tokens)
+        : 0,
+    },
+  };
+}
+
+function parseHeaderInt(headers, name) {
+  const raw = headers?.get?.(name);
+  if (raw == null) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function extractRateLimit(headers) {
+  const requestsRemaining = parseHeaderInt(headers, 'x-ratelimit-requests-remaining');
+  const requestsLimit = parseHeaderInt(headers, 'x-ratelimit-requests-limit');
+  const inputTokensRemaining = parseHeaderInt(headers, 'x-ratelimit-input-tokens-remaining');
+  const inputTokensLimit = parseHeaderInt(headers, 'x-ratelimit-input-tokens-limit');
+
+  if (
+    requestsRemaining === null &&
+    requestsLimit === null &&
+    inputTokensRemaining === null &&
+    inputTokensLimit === null
+  ) {
+    return null;
+  }
+
+  return {
+    requests_remaining: requestsRemaining ?? 0,
+    requests_limit: requestsLimit ?? 0,
+    input_tokens_remaining: inputTokensRemaining ?? 0,
+    input_tokens_limit: inputTokensLimit ?? 0,
+  };
+}
+
+function postWithOriginalFetch(originalFetch, event) {
+  postLLMCallEvent(event, (url, options) => originalFetch.call(globalThis, url, options));
+}
+
+async function processSSEBranch({
+  inspectorStream,
+  requestBodyPromise,
+  startNs,
+  responseHeaders,
+  originalFetch,
+}) {
+  try {
+    const [requestBody, parsedSSE] = await Promise.all([
+      requestBodyPromise,
+      parseSSEStream(inspectorStream),
+    ]);
+
+    const endNs = nowHrtimeNs();
+    const tokenExtraction = extractTokenUsageFromSSEEvents(parsedSSE.events);
+    const requestSummary = extractRequestSummary(requestBody);
+    const responseSummary = extractResponseSummary(parsedSSE.events);
+    const rateLimit = extractRateLimit(responseHeaders);
+
+    const event = buildLLMCallEvent({
+      session_id: resolveSessionId(),
+      model: tokenExtraction.model || requestBody?.model || 'unknown',
+      stop_reason: tokenExtraction.stop_reason,
+      stream: requestBody?.stream !== false,
+      tokens: tokenExtraction.tokens,
+      timing: {
+        start_ns: startNs,
+        ttfb_ms: computeTTFBMs(startNs, parsedSSE.firstChunkNs),
+        duration_ms: computeDurationMs(startNs, endNs),
+      },
+      request_summary: requestSummary,
+      response_summary: responseSummary,
+      rate_limit: rateLimit,
+      error: null,
+    });
+
+    postWithOriginalFetch(originalFetch, event);
+  } catch {
+    // Silent by design.
+  }
+}
+
+async function processJSONBranch({
+  response,
+  requestBodyPromise,
+  startNs,
+  responseHeaders,
+  originalFetch,
+}) {
+  try {
+    const [requestBody, payload] = await Promise.all([
+      requestBodyPromise,
+      response
+        .text()
+        .then((text) => parseJsonSafe(text))
+        .catch(() => ({})),
+    ]);
+    const endNs = nowHrtimeNs();
+    const tokenExtraction = extractTokenUsageFromMessage(payload);
+    const requestSummary = extractRequestSummary(requestBody);
+    const responseSummary = extractResponseSummaryFromMessage(payload);
+    const rateLimit = extractRateLimit(responseHeaders);
+
+    const event = buildLLMCallEvent({
+      session_id: resolveSessionId(),
+      model: tokenExtraction.model || requestBody?.model || 'unknown',
+      stop_reason: tokenExtraction.stop_reason,
+      stream: false,
+      tokens: tokenExtraction.tokens,
+      timing: {
+        start_ns: startNs,
+        ttfb_ms: computeTTFBMs(startNs, endNs),
+        duration_ms: computeDurationMs(startNs, endNs),
+      },
+      request_summary: requestSummary,
+      response_summary: responseSummary,
+      rate_limit: rateLimit,
+      error: payload && Object.keys(payload).length > 0 ? null : 'json_parse_failed',
+    });
+
+    postWithOriginalFetch(originalFetch, event);
+  } catch {
+    // Silent by design.
+  }
+}
+
+if (typeof globalThis.fetch === 'function' && !globalThis.fetch[INTERCEPT_GUARD]) {
+  const originalFetch = globalThis.fetch;
+
+  const patchedFetch = async function trajectoryInterceptFetch(input, init) {
+    const url = getRequestURL(input);
+    if (!shouldIntercept(url)) {
+      return originalFetch.call(this, input, init);
+    }
+
+    const requestBodyPromise = extractRequestBody(input, init);
+    const startNs = nowHrtimeNs();
+
+    const response = await originalFetch.call(this, input, init);
+
+    try {
+      if (!response?.body || typeof response.body.tee !== 'function') {
+        return response;
+      }
+
+      const [callerStream, inspectorStream] = response.body.tee();
+      const forwardedResponse = new Response(callerStream, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+
+      const contentType = response.headers?.get?.('content-type') || '';
+      if (contentType.toLowerCase().includes('text/event-stream')) {
+        void processSSEBranch({
+          inspectorStream,
+          requestBodyPromise,
+          startNs,
+          responseHeaders: response.headers,
+          originalFetch,
+        });
+      } else {
+        void processJSONBranch({
+          response: new Response(inspectorStream, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          }),
+          requestBodyPromise,
+          startNs,
+          responseHeaders: response.headers,
+          originalFetch,
+        });
+      }
+
+      return forwardedResponse;
+    } catch {
+      return response;
+    }
+  };
+
+  patchedFetch[INTERCEPT_GUARD] = true;
+  globalThis.fetch = patchedFetch;
+}

--- a/intercepts/intercept-shared.mjs
+++ b/intercepts/intercept-shared.mjs
@@ -1,0 +1,438 @@
+const DEFAULT_CAPTURE_URL = 'http://127.0.0.1:19222';
+const SESSION_ID_ENV_VAR = 'TRAJECTORY_SESSION_ID';
+const POST_TIMEOUT_MS = 2000;
+
+export function resolveCaptureURL() {
+  try {
+    const configured = process?.env?.TRAJECTORY_CAPTURE_URL;
+    if (typeof configured === 'string' && configured.trim().length > 0) {
+      return configured.trim().replace(/\/+$/, '');
+    }
+  } catch {
+    // Silent by design.
+  }
+  return DEFAULT_CAPTURE_URL;
+}
+
+export function resolveLLMCallEndpoint() {
+  return `${resolveCaptureURL()}/llm-call`;
+}
+
+function toInteger(value, fallback = 0) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.trunc(num);
+}
+
+function toSafeNumberFromBigInt(value, fallback = 0) {
+  if (typeof value !== 'bigint') {
+    return toInteger(value, fallback);
+  }
+
+  const max = BigInt(Number.MAX_SAFE_INTEGER);
+  const min = BigInt(Number.MIN_SAFE_INTEGER);
+  if (value > max) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  if (value < min) {
+    return Number.MIN_SAFE_INTEGER;
+  }
+  return Number(value);
+}
+
+function normalizeArray(input) {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input
+    .map((value) => (typeof value === 'string' ? value : String(value ?? '')))
+    .filter((value) => value.length > 0);
+}
+
+function normalizeTokenObject(tokens) {
+  return {
+    input_tokens: toInteger(tokens?.input_tokens, 0),
+    output_tokens: toInteger(tokens?.output_tokens, 0),
+    cache_read_input_tokens: toInteger(tokens?.cache_read_input_tokens, 0),
+    cache_creation_input_tokens: toInteger(tokens?.cache_creation_input_tokens, 0),
+  };
+}
+
+function normalizeRequestSummary(summary) {
+  const toolResultIds = normalizeArray(summary?.tool_result_ids);
+  return {
+    message_count: toInteger(summary?.message_count, 0),
+    system_present: Boolean(summary?.system_present),
+    tools_count: toInteger(summary?.tools_count, 0),
+    max_tokens: toInteger(summary?.max_tokens, 0),
+    has_tool_results: Boolean(summary?.has_tool_results) || toolResultIds.length > 0,
+    tool_result_ids: toolResultIds,
+  };
+}
+
+function normalizeResponseSummary(summary) {
+  return {
+    content_block_types: normalizeArray(summary?.content_block_types),
+    tool_use_ids: normalizeArray(summary?.tool_use_ids),
+    tool_use_names: normalizeArray(summary?.tool_use_names),
+    text_length: toInteger(summary?.text_length, 0),
+    thinking_length: toInteger(summary?.thinking_length, 0),
+  };
+}
+
+function parseSSEBlock(eventName, dataLines) {
+  if (!dataLines.length) {
+    return null;
+  }
+
+  const rawData = dataLines.join('\n');
+  if (rawData.trim() === '[DONE]') {
+    return { done: true };
+  }
+
+  try {
+    const parsed = JSON.parse(rawData);
+    return {
+      event: eventName || parsed?.type || '',
+      data: parsed,
+      done: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function takeUsageNumber(usage, key) {
+  const value = usage?.[key];
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.trunc(value));
+}
+
+function mergeUsage(tokens, usage) {
+  const keys = [
+    'input_tokens',
+    'output_tokens',
+    'cache_read_input_tokens',
+    'cache_creation_input_tokens',
+  ];
+
+  for (const key of keys) {
+    const value = takeUsageNumber(usage, key);
+    if (value === null) {
+      continue;
+    }
+    tokens[key] = Math.max(tokens[key] ?? 0, value);
+  }
+}
+
+function normalizeOptionalObject(obj) {
+  if (!obj || typeof obj !== 'object') {
+    return null;
+  }
+  return obj;
+}
+
+export function hrtimeToNs(value) {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return BigInt(Math.max(0, Math.trunc(value)));
+  }
+
+  if (Array.isArray(value) && value.length === 2) {
+    const seconds = toInteger(value[0], 0);
+    const nanos = toInteger(value[1], 0);
+    return BigInt(seconds) * 1_000_000_000n + BigInt(nanos);
+  }
+
+  return 0n;
+}
+
+export function nowHrtimeNs() {
+  try {
+    if (typeof process !== 'undefined' && process?.hrtime?.bigint) {
+      return process.hrtime.bigint();
+    }
+    if (typeof Bun !== 'undefined' && typeof Bun.nanoseconds === 'function') {
+      return hrtimeToNs(Bun.nanoseconds());
+    }
+  } catch {
+    // Silent by design.
+  }
+
+  return BigInt(Date.now()) * 1_000_000n;
+}
+
+export function computeTTFBMs(startNs, firstChunkNs) {
+  const start = hrtimeToNs(startNs);
+  const first = hrtimeToNs(firstChunkNs);
+  if (first <= 0n || first < start) {
+    return 0;
+  }
+  return toSafeNumberFromBigInt((first - start) / 1_000_000n, 0);
+}
+
+export function computeDurationMs(startNs, endNs = nowHrtimeNs()) {
+  const start = hrtimeToNs(startNs);
+  const end = hrtimeToNs(endNs);
+  if (end <= 0n || end < start) {
+    return 0;
+  }
+  return toSafeNumberFromBigInt((end - start) / 1_000_000n, 0);
+}
+
+export function resolveSessionId() {
+  try {
+    const sessionId = process?.env?.[SESSION_ID_ENV_VAR];
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
+      return sessionId;
+    }
+  } catch {
+    // Silent by design.
+  }
+  return 'unknown';
+}
+
+export async function parseSSEStream(stream) {
+  const events = [];
+  let sawDone = false;
+  let firstChunkNs = null;
+
+  if (!stream || typeof stream.getReader !== 'function') {
+    return { events, firstChunkNs, sawDone };
+  }
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let currentEvent = '';
+  let dataLines = [];
+
+  const flush = () => {
+    const parsed = parseSSEBlock(currentEvent, dataLines);
+    currentEvent = '';
+    dataLines = [];
+
+    if (!parsed) {
+      return;
+    }
+    if (parsed.done) {
+      sawDone = true;
+      return;
+    }
+
+    events.push(parsed);
+  };
+
+  const consumeLine = (line) => {
+    if (line === '') {
+      flush();
+      return;
+    }
+
+    if (line.startsWith(':')) {
+      return;
+    }
+
+    const separator = line.indexOf(':');
+    let field = line;
+    let value = '';
+
+    if (separator >= 0) {
+      field = line.slice(0, separator);
+      value = line.slice(separator + 1);
+      if (value.startsWith(' ')) {
+        value = value.slice(1);
+      }
+    }
+
+    if (field === 'event') {
+      currentEvent = value;
+      return;
+    }
+
+    if (field === 'data') {
+      dataLines.push(value);
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      if (firstChunkNs === null && value && value.byteLength > 0) {
+        firstChunkNs = nowHrtimeNs();
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      buffer = buffer.replace(/\r\n/g, '\n');
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        consumeLine(line);
+      }
+    }
+
+    buffer += decoder.decode();
+    buffer = buffer.replace(/\r\n/g, '\n');
+    if (buffer.length > 0) {
+      consumeLine(buffer);
+    }
+    flush();
+  } catch {
+    // Silent by design.
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Silent by design.
+    }
+  }
+
+  return { events, firstChunkNs, sawDone };
+}
+
+export function extractTokenUsageFromSSEEvents(events) {
+  const tokens = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  };
+
+  let model = 'unknown';
+  let stopReason = 'unknown';
+
+  for (const event of Array.isArray(events) ? events : []) {
+    const eventType = event?.event || event?.data?.type || '';
+    const data = event?.data;
+
+    if (eventType === 'message_start') {
+      const message = data?.message;
+      if (typeof message?.model === 'string' && message.model.length > 0) {
+        model = message.model;
+      }
+      mergeUsage(tokens, message?.usage);
+      if (typeof message?.stop_reason === 'string' && message.stop_reason.length > 0) {
+        stopReason = message.stop_reason;
+      }
+      continue;
+    }
+
+    if (eventType === 'message_delta') {
+      mergeUsage(tokens, data?.usage);
+      const deltaStopReason = data?.delta?.stop_reason;
+      if (typeof deltaStopReason === 'string' && deltaStopReason.length > 0) {
+        stopReason = deltaStopReason;
+      }
+      continue;
+    }
+
+    if (eventType === 'message_stop') {
+      const stop = data?.stop_reason;
+      if (typeof stop === 'string' && stop.length > 0) {
+        stopReason = stop;
+      }
+    }
+  }
+
+  return {
+    model,
+    stop_reason: stopReason,
+    tokens: normalizeTokenObject(tokens),
+  };
+}
+
+export function buildLLMCallEvent(fields = {}) {
+  const timingStartNs = fields?.timing?.start_ns;
+  const event = {
+    event_type: 'llm_call',
+    session_id: fields?.session_id || resolveSessionId(),
+    timestamp: typeof fields?.timestamp === 'string' ? fields.timestamp : new Date().toISOString(),
+    model: typeof fields?.model === 'string' && fields.model.length > 0 ? fields.model : 'unknown',
+    stop_reason:
+      typeof fields?.stop_reason === 'string' && fields.stop_reason.length > 0
+        ? fields.stop_reason
+        : 'unknown',
+    stream: fields?.stream !== false,
+    tokens: normalizeTokenObject(fields?.tokens),
+    timing: {
+      start_ns: toSafeNumberFromBigInt(hrtimeToNs(timingStartNs), 0),
+      ttfb_ms: toInteger(fields?.timing?.ttfb_ms, 0),
+      duration_ms: toInteger(fields?.timing?.duration_ms, 0),
+    },
+    request_summary: normalizeRequestSummary(fields?.request_summary),
+    response_summary: normalizeResponseSummary(fields?.response_summary),
+    error: fields?.error == null ? null : String(fields.error),
+  };
+
+  const contextBreakdown = normalizeOptionalObject(fields?.context_breakdown);
+  if (contextBreakdown) {
+    event.context_breakdown = contextBreakdown;
+  }
+
+  const costNanodollars = normalizeOptionalObject(fields?.cost_nanodollars);
+  if (costNanodollars) {
+    event.cost_nanodollars = costNanodollars;
+  }
+
+  const rateLimit = normalizeOptionalObject(fields?.rate_limit);
+  if (rateLimit) {
+    event.rate_limit = rateLimit;
+  }
+
+  return event;
+}
+
+export function postLLMCallEvent(event, fetchImpl = globalThis.fetch) {
+  try {
+    if (typeof fetchImpl !== 'function') {
+      return;
+    }
+
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const timeoutId = controller
+      ? setTimeout(() => {
+          try {
+            controller.abort();
+          } catch {
+            // Silent by design.
+          }
+        }, POST_TIMEOUT_MS)
+      : null;
+
+    Promise.resolve(
+      fetchImpl(resolveLLMCallEndpoint(), {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(event),
+        signal: controller?.signal,
+      })
+    )
+      .catch(() => {
+        // Silent by design.
+      })
+      .finally(() => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      });
+  } catch {
+    // Silent by design.
+  }
+}
+
+const LLM_CALL_ENDPOINT = resolveLLMCallEndpoint();
+export { LLM_CALL_ENDPOINT };

--- a/intercepts/node-llm-spy.cjs
+++ b/intercepts/node-llm-spy.cjs
@@ -1,0 +1,602 @@
+'use strict';
+
+(() => {
+  const ANTHROPIC_HOST = 'api.anthropic.com';
+  const ANTHROPIC_PATH_PATTERN = /^\/v1\/(messages|complete)(\/|$)/;
+  const CAPTURE_URL = process.env.TRAJECTORY_CAPTURE_URL || 'http://127.0.0.1:19222';
+  const CAPTURE_ENDPOINT = `${CAPTURE_URL}/llm-call`;
+  const PATCH_SENTINEL = Symbol.for('trajectory.nodeLlmSpy.patch');
+
+  const originalFetch = globalThis?.fetch;
+  if (typeof originalFetch !== 'function') {
+    return;
+  }
+  if (globalThis.fetch && globalThis.fetch[PATCH_SENTINEL]) {
+    return;
+  }
+
+  const { TextDecoder } = require('node:util');
+  const decoder = new TextDecoder();
+
+  function toInteger(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? Math.max(0, Math.floor(num)) : 0;
+  }
+
+  function shouldIntercept(urlString) {
+    if (!urlString) return false;
+    try {
+      const url = new URL(urlString);
+      return url.hostname === ANTHROPIC_HOST || ANTHROPIC_PATH_PATTERN.test(url.pathname);
+    } catch {
+      return false;
+    }
+  }
+
+  function getUrlFromFetchArgs(input) {
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.toString();
+    if (input && typeof input.url === 'string') return input.url;
+    return '';
+  }
+
+  function isEventStreamResponse(response) {
+    try {
+      const contentType = response.headers?.get?.('content-type') || '';
+      return contentType.toLowerCase().includes('text/event-stream');
+    } catch {
+      return false;
+    }
+  }
+
+  function safeParseJSON(text) {
+    if (typeof text !== 'string' || text.length === 0) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+
+  function decodeBodyBodyLike(body) {
+    if (!body) return '';
+    if (typeof body === 'string') return body;
+    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(body)) return body.toString('utf8');
+    if (body instanceof Uint8Array) return decoder.decode(body);
+    if (body instanceof ArrayBuffer) return decoder.decode(new Uint8Array(body));
+    return '';
+  }
+
+  async function parseRequestBody(input, init) {
+    try {
+      if (init && Object.prototype.hasOwnProperty.call(init, 'body')) {
+        return safeParseJSON(decodeBodyBodyLike(init.body));
+      }
+
+      if (input && typeof input === 'object' && typeof input.clone === 'function') {
+        const cloned = input.clone();
+        if (typeof cloned.text === 'function') {
+          return safeParseJSON(await cloned.text());
+        }
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  function concatChunks(chunks) {
+    let total = 0;
+    for (const chunk of chunks) total += chunk.byteLength;
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return out;
+  }
+
+  function parseSSEEvents(chunks) {
+    const text = decoder.decode(concatChunks(chunks));
+    const events = [];
+    let currentEvent = '';
+    let dataLines = [];
+
+    function flushEvent() {
+      if (!currentEvent && dataLines.length === 0) return;
+      const dataText = dataLines.join('\n');
+      if (dataText && dataText !== '[DONE]') {
+        const parsed = safeParseJSON(dataText);
+        if (parsed) events.push({ event: currentEvent, data: parsed });
+      }
+      currentEvent = '';
+      dataLines = [];
+    }
+
+    for (const line of text.split(/\r?\n/)) {
+      if (line.startsWith('event: ')) {
+        currentEvent = line.slice(7).trim();
+      } else if (line.startsWith('data: ')) {
+        dataLines.push(line.slice(6));
+      } else if (line.trim() === '') {
+        flushEvent();
+      }
+    }
+    flushEvent();
+    return events;
+  }
+
+  function extractFromSSEEvents(events) {
+    let model = '';
+    let stopReason = '';
+    const tokens = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    };
+
+    for (const entry of events) {
+      const event = entry?.event;
+      const data = entry?.data || {};
+
+      if (event === 'message_start') {
+        const message = data.message || {};
+        const usage = message.usage || {};
+        if (!model && typeof message.model === 'string') {
+          model = message.model;
+        }
+        tokens.input_tokens = toInteger(usage.input_tokens);
+        tokens.cache_read_input_tokens = toInteger(usage.cache_read_input_tokens);
+        tokens.cache_creation_input_tokens = toInteger(usage.cache_creation_input_tokens);
+      } else if (event === 'message_delta') {
+        const usage = data.usage || {};
+        if (usage.output_tokens !== undefined) {
+          tokens.output_tokens = toInteger(usage.output_tokens);
+        }
+        const delta = data.delta || {};
+        if (typeof delta.stop_reason === 'string' && delta.stop_reason.length > 0) {
+          stopReason = delta.stop_reason;
+        }
+      } else if (event === 'message_stop') {
+        if (!stopReason && typeof data.stop_reason === 'string' && data.stop_reason.length > 0) {
+          stopReason = data.stop_reason;
+        }
+      }
+    }
+
+    return { model, stopReason, tokens };
+  }
+
+  function extractFromJSONResponse(payload) {
+    const usage = payload?.usage || {};
+    return {
+      model: typeof payload?.model === 'string' ? payload.model : '',
+      stopReason: typeof payload?.stop_reason === 'string' ? payload.stop_reason : '',
+      tokens: {
+        input_tokens: toInteger(usage.input_tokens),
+        output_tokens: toInteger(usage.output_tokens),
+        cache_read_input_tokens: toInteger(usage.cache_read_input_tokens),
+        cache_creation_input_tokens: toInteger(usage.cache_creation_input_tokens),
+      },
+    };
+  }
+
+  function extractRequestSummary(body) {
+    const request = body && typeof body === 'object' ? body : {};
+    const messages = Array.isArray(request.messages) ? request.messages : [];
+    const tools = Array.isArray(request.tools) ? request.tools : [];
+    const toolResultIds = [];
+
+    for (const message of messages) {
+      const content = message?.content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        if (block?.type === 'tool_result' && typeof block?.tool_use_id === 'string') {
+          toolResultIds.push(block.tool_use_id);
+        }
+      }
+    }
+
+    return {
+      message_count: messages.length,
+      system_present: Boolean(request.system),
+      tools_count: tools.length,
+      max_tokens: Number.isFinite(request.max_tokens) ? Math.trunc(request.max_tokens) : 0,
+      has_tool_results: toolResultIds.length > 0,
+      tool_result_ids: toolResultIds,
+    };
+  }
+
+  function extractResponseSummaryFromJSON(payload) {
+    const content = Array.isArray(payload?.content) ? payload.content : [];
+    const contentBlockTypes = new Set();
+    const toolUseIds = new Set();
+    const toolUseNames = new Set();
+    let textLength = 0;
+    let thinkingLength = 0;
+
+    for (const block of content) {
+      if (typeof block?.type === 'string' && block.type.length > 0) {
+        contentBlockTypes.add(block.type);
+      }
+      if (block?.type === 'text' && typeof block?.text === 'string') {
+        textLength += block.text.length;
+      }
+      if (block?.type === 'thinking' && typeof block?.thinking === 'string') {
+        thinkingLength += block.thinking.length;
+      }
+      if (block?.type === 'tool_use') {
+        if (typeof block?.id === 'string' && block.id.length > 0) {
+          toolUseIds.add(block.id);
+        }
+        if (typeof block?.name === 'string' && block.name.length > 0) {
+          toolUseNames.add(block.name);
+        }
+      }
+    }
+
+    return {
+      content_block_types: Array.from(contentBlockTypes),
+      tool_use_ids: Array.from(toolUseIds),
+      tool_use_names: Array.from(toolUseNames),
+      text_length: textLength,
+      thinking_length: thinkingLength,
+    };
+  }
+
+  function extractResponseSummaryFromSSEEvents(events) {
+    const contentBlockTypes = new Set();
+    const toolUseIds = new Set();
+    const toolUseNames = new Set();
+    let textLength = 0;
+    let thinkingLength = 0;
+
+    for (const entry of events) {
+      const event = entry?.event || entry?.data?.type || '';
+      const data = entry?.data || {};
+      if (event === 'content_block_start') {
+        const block = data.content_block || {};
+        if (typeof block.type === 'string' && block.type.length > 0) {
+          contentBlockTypes.add(block.type);
+        }
+        if (block.type === 'tool_use') {
+          if (typeof block.id === 'string' && block.id.length > 0) toolUseIds.add(block.id);
+          if (typeof block.name === 'string' && block.name.length > 0) toolUseNames.add(block.name);
+        }
+        continue;
+      }
+      if (event === 'content_block_delta') {
+        const delta = data.delta || {};
+        if (delta.type === 'text_delta') {
+          contentBlockTypes.add('text');
+          if (typeof delta.text === 'string') textLength += delta.text.length;
+        }
+        if (delta.type === 'thinking_delta') {
+          contentBlockTypes.add('thinking');
+          if (typeof delta.thinking === 'string') thinkingLength += delta.thinking.length;
+        }
+      }
+    }
+
+    return {
+      content_block_types: Array.from(contentBlockTypes),
+      tool_use_ids: Array.from(toolUseIds),
+      tool_use_names: Array.from(toolUseNames),
+      text_length: textLength,
+      thinking_length: thinkingLength,
+    };
+  }
+
+  function parseHeaderInt(headers, name) {
+    const raw = headers?.get?.(name);
+    if (raw == null) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function extractRateLimit(headers) {
+    const requestsRemaining = parseHeaderInt(headers, 'x-ratelimit-requests-remaining');
+    const requestsLimit = parseHeaderInt(headers, 'x-ratelimit-requests-limit');
+    const inputTokensRemaining = parseHeaderInt(headers, 'x-ratelimit-input-tokens-remaining');
+    const inputTokensLimit = parseHeaderInt(headers, 'x-ratelimit-input-tokens-limit');
+    if (
+      requestsRemaining === null &&
+      requestsLimit === null &&
+      inputTokensRemaining === null &&
+      inputTokensLimit === null
+    ) {
+      return null;
+    }
+    return {
+      requests_remaining: requestsRemaining ?? 0,
+      requests_limit: requestsLimit ?? 0,
+      input_tokens_remaining: inputTokensRemaining ?? 0,
+      input_tokens_limit: inputTokensLimit ?? 0,
+    };
+  }
+
+  function buildEvent({
+    sessionId,
+    model,
+    stopReason,
+    stream,
+    tokens,
+    startMs,
+    ttfbMs,
+    durationMs,
+    requestSummary,
+    responseSummary,
+    rateLimit,
+    error,
+  }) {
+    const event = {
+      event_type: 'llm_call',
+      session_id: sessionId || '',
+      timestamp: new Date().toISOString(),
+      provider: 'anthropic',
+      operation: 'messages',
+      model: model || 'unknown',
+      stop_reason: stopReason || 'unknown',
+      stream: Boolean(stream),
+      tokens: tokens || {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      timing: {
+        start_ns: Math.max(0, toInteger(startMs) * 1000000),
+        ttfb_ms: Math.max(0, toInteger(ttfbMs)),
+        duration_ms: Math.max(0, toInteger(durationMs)),
+      },
+      request_summary: requestSummary || {
+        message_count: 0,
+        system_present: false,
+        tools_count: 0,
+        max_tokens: 0,
+        has_tool_results: false,
+        tool_result_ids: [],
+      },
+      response_summary: responseSummary || {
+        content_block_types: [],
+        tool_use_ids: [],
+        tool_use_names: [],
+        text_length: 0,
+        thinking_length: 0,
+      },
+      error: error || null,
+    };
+    if (rateLimit) {
+      event.rate_limit = rateLimit;
+    }
+    return event;
+  }
+
+  function legacyBuildEvent(sessionId, model, stopReason, stream, tokens, startMs, ttfbMs, durationMs, error) {
+    return {
+      event_type: 'llm_call',
+      session_id: sessionId || '',
+      timestamp: new Date().toISOString(),
+      model: model || '',
+      stop_reason: stopReason || '',
+      stream: Boolean(stream),
+      tokens: tokens || {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      timing: {
+        start_ns: Math.max(0, toInteger(startMs) * 1000000),
+        ttfb_ms: Math.max(0, toInteger(ttfbMs)),
+        duration_ms: Math.max(0, toInteger(durationMs)),
+      },
+      request_summary: {
+        message_count: 0,
+        system_present: false,
+        tools_count: 0,
+        max_tokens: 0,
+        has_tool_results: false,
+        tool_result_ids: [],
+      },
+      response_summary: {
+        content_block_types: [],
+        tool_use_ids: [],
+        tool_use_names: [],
+        text_length: 0,
+        thinking_length: 0,
+      },
+      error: error || null,
+    };
+  }
+
+  function postEvent(eventPayload) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 2000);
+      Promise.resolve(
+        originalFetch.call(globalThis, CAPTURE_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(eventPayload),
+          signal: controller.signal,
+        }),
+      )
+        .catch(() => {})
+        .finally(() => clearTimeout(timeoutId));
+    } catch {
+      // Never break host process.
+    }
+  }
+
+  function emitFromSSE(chunks, context, ttfbMs, durationMs, error) {
+    try {
+      const events = parseSSEEvents(chunks);
+      const extracted = extractFromSSEEvents(events);
+      postEvent(
+        buildEvent({
+          sessionId: context.sessionId,
+          model: extracted.model,
+          stopReason: extracted.stopReason,
+          stream: context.stream,
+          tokens: extracted.tokens,
+          startMs: context.startMs,
+          ttfbMs,
+          durationMs,
+          requestSummary: extractRequestSummary(context.requestBody),
+          responseSummary: extractResponseSummaryFromSSEEvents(events),
+          rateLimit: extractRateLimit(context.responseHeaders),
+          error,
+        }),
+      );
+    } catch {
+      postEvent(
+        legacyBuildEvent(context.sessionId, '', '', context.stream, null, context.startMs, ttfbMs, durationMs, 'sse_parse_failed'),
+      );
+    }
+  }
+
+  async function processNonStreamingResponse(clonedResponse, context, ttfbMs) {
+    try {
+      const payload = safeParseJSON(await clonedResponse.text());
+      const durationMs = Date.now() - context.startMs;
+      const extracted = payload ? extractFromJSONResponse(payload) : { model: '', stopReason: '', tokens: null };
+      postEvent(
+        buildEvent({
+          sessionId: context.sessionId,
+          model: extracted.model,
+          stopReason: extracted.stopReason,
+          stream: context.stream,
+          tokens: extracted.tokens,
+          startMs: context.startMs,
+          ttfbMs,
+          durationMs,
+          requestSummary: extractRequestSummary(context.requestBody),
+          responseSummary: payload ? extractResponseSummaryFromJSON(payload) : null,
+          rateLimit: extractRateLimit(context.responseHeaders),
+          error: payload ? null : 'json_parse_failed',
+        }),
+      );
+    } catch {
+      const durationMs = Date.now() - context.startMs;
+      postEvent(
+        legacyBuildEvent(context.sessionId, '', '', context.stream, null, context.startMs, ttfbMs, durationMs, 'response_read_failed'),
+      );
+    }
+  }
+
+  function interceptStreamingResponse(response, context, headerTtfbMs) {
+    if (!response.body || typeof response.body.getReader !== 'function') {
+      return response;
+    }
+
+    const reader = response.body.getReader();
+    const capturedChunks = [];
+    let firstChunkSeen = false;
+    let streamTtfbMs = headerTtfbMs;
+
+    const teedStream = new ReadableStream({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            const durationMs = Date.now() - context.startMs;
+            emitFromSSE(capturedChunks, context, streamTtfbMs, durationMs, null);
+            return;
+          }
+
+          if (value instanceof Uint8Array) {
+            capturedChunks.push(value);
+          } else if (value) {
+            capturedChunks.push(new Uint8Array(value));
+          }
+
+          if (!firstChunkSeen) {
+            firstChunkSeen = true;
+            const firstChunkTtfb = Date.now() - context.startMs;
+            streamTtfbMs = headerTtfbMs > 0 ? Math.min(headerTtfbMs, firstChunkTtfb) : firstChunkTtfb;
+          }
+          controller.enqueue(value);
+        } catch (err) {
+          try {
+            controller.error(err);
+          } catch {
+            // ignore
+          }
+          const durationMs = Date.now() - context.startMs;
+          emitFromSSE(capturedChunks, context, streamTtfbMs, durationMs, 'stream_read_failed');
+        }
+      },
+      cancel(reason) {
+        try {
+          return reader.cancel(reason);
+        } catch {
+          return undefined;
+        }
+      },
+    });
+
+    return new Response(teedStream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  async function patchedFetch(input, init) {
+    const url = getUrlFromFetchArgs(input);
+    if (!shouldIntercept(url)) {
+      return originalFetch.call(this, input, init);
+    }
+
+    const startMs = Date.now();
+    const sessionId = process.env.TRAJECTORY_SESSION_ID || '';
+    const requestBody = await parseRequestBody(input, init);
+    const requestStream = typeof requestBody?.stream === 'boolean' ? requestBody.stream : undefined;
+
+    let response;
+    try {
+      response = await originalFetch.call(this, input, init);
+    } catch (err) {
+      throw err;
+    }
+
+    if (!response || response.status !== 200) {
+      return response;
+    }
+
+    const headerTtfbMs = Date.now() - startMs;
+    const context = {
+      startMs,
+      stream: requestStream !== undefined ? requestStream : isEventStreamResponse(response),
+      sessionId,
+      requestBody,
+      responseHeaders: response.headers,
+    };
+
+    try {
+      if (context.stream) {
+        return interceptStreamingResponse(response, context, headerTtfbMs);
+      }
+      void processNonStreamingResponse(response.clone(), context, headerTtfbMs);
+      return response;
+    } catch {
+      return response;
+    }
+  }
+
+  try {
+    Object.defineProperty(patchedFetch, PATCH_SENTINEL, {
+      value: true,
+      enumerable: false,
+      writable: false,
+    });
+  } catch {
+    // ignore
+  }
+
+  globalThis.fetch = patchedFetch;
+})();


### PR DESCRIPTION
Summary:
- add the Claude wrapper intercept runtime files to the public install payload
- stage Bun, shared, and Node intercept assets into ~/.trajectory/intercepts during install
- document the intercept runtime in the repository contents

Checks:
- python3 -m json.tool RELEASES.json >/dev/null
- bash -n install.sh
- git diff --check
- public-scaffold validation passed
- clean-room installer smoke staged all intercept files