### PR TITLE
Refresh public documentation

### DIFF
--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -7,6 +7,11 @@ capture server on `localhost:19222` through the transport each client supports.
 
 For installation status and version support, see
 [SUPPORTED-CLIENTS.md](SUPPORTED-CLIENTS.md).
+For the built-in user-facing client guides, run:
+
+```bash
+trajectory user-guide clients
+```
 
 ## Summary
 
@@ -21,6 +26,7 @@ For installation status and version support, see
 | Factory Droid | `trajectory setup --clients droid` | Beta Factory command hooks plus MCP | None |
 | Pi | `trajectory setup --clients pi` | TypeScript extension plus eager MCP | Pi/OMP session backfill |
 | OpenCode | `trajectory setup --clients opencode` | OpenCode plugin SDK events plus MCP | SQLite backfill |
+| OpenClaw | Plugin package plus optional-client binary | Beta OpenClaw plugin SDK hooks | None |
 
 ## Shared Local Flow
 
@@ -108,7 +114,7 @@ trajectory doctor
 
 Setup writes a local Copilot marketplace under
 `~/.trajectory/copilot-marketplace`, registers it, and installs
-`trajectory@trajectory`. The plugin includes command hooks, MCP config, and an
+`trajectory@trajectory`. The plugin includes command hooks, `.mcp.json`, and an
 incognito skill.
 
 Capture is beta live CLI capture only. There is no Copilot historical backfill
@@ -149,10 +155,10 @@ derived from transcript structure.
 
 Setup writes a local Factory marketplace under
 `~/.trajectory/factory-marketplace`, registers it with Droid, and installs
-`trajectory@trajectory`. The plugin includes command hooks, MCP config, and an
+`trajectory@trajectory`. The plugin includes command hooks, `mcp.json`, and an
 incognito skill.
 
-Capture is beta live CLI capture only. There is no Factory Droid historical
+Capture is beta live CLI capture only. There is no Factory/Droid historical
 backfill or transcript import path.
 
 ## Pi
@@ -180,6 +186,16 @@ directory.
 The plugin SDK events cover chat messages, tool execution before/after events,
 and lifecycle events. Historical import uses OpenCode SQLite databases. OpenCode
 does not install a `hooks.json` file.
+
+## OpenClaw
+
+OpenClaw support is a live-capture beta. It is not included in default
+Trajectory binaries; build with `-tags optionalclients` and install the
+`plugin/trajectory-openclaw` package through OpenClaw's plugin system.
+
+The plugin maps OpenClaw lifecycle, model, tool, compaction, and session hooks
+to `/capture/openclaw/...`. Backfill, resume, MCP, and setup-managed install are
+out of scope for the current beta.
 
 ## Troubleshooting
 

--- a/docs/LLM-CAPACITY.md
+++ b/docs/LLM-CAPACITY.md
@@ -1,0 +1,204 @@
+# LLM Capacity and Expense Controls
+
+Trajectory mostly records local events, derives metrics, and publishes to
+Datadog without asking another LLM to reprocess the session. The features below
+are the Trajectory-owned paths that can create additional LLM calls.
+
+This document is also available from the binary:
+
+```bash
+trajectory user-guide llm-capacity
+```
+
+## Quick summary
+
+| Feature | Default | What it does | How often it can call an LLM | Primary controls |
+|---|---|---|---|---|
+| Task segmentation | On | Splits sessions into tasks and scores task dimensions such as outcome, autonomy, risk, and reversibility | About every `segmentation.interval` completed turns, default 10, plus one final pass at session end for sessions with at least 2 turns | `segmentation.enabled`, `segmentation.interval`, `segmentation.model`, `TRAJECTORY_SEGMENTATION_DISABLED=1` |
+| Sensitivity classification | On, `balanced` mode | Classifies session content for the publish gate as public, internal, confidential, or restricted | In `balanced` mode, about every 10 completed turns, plus a session-end scan on the non-incognito publish path. In `near_realtime` mode, active sessions are scanned only when new content exists, default every 30 minutes. | `export.sensitivity.scanning_mode`, `export.sensitivity.near_realtime_interval_minutes` |
+
+For zero Trajectory-owned LLM calls from the capture server, disable both:
+
+```bash
+trajectory config set segmentation.enabled false
+trajectory config set export.sensitivity.scanning_mode off
+```
+
+## Task segmentation
+
+Task segmentation is enabled by default and is independent of trace export. It
+can run even when `export.traces` is `off`, because it feeds the local task
+cache and optional task-derived metrics/traces.
+
+By default it runs asynchronously for non-headless interactive sessions:
+
+- Every 10 completed turns.
+- Every 20 completed turns when the previous segment is still open, because the
+  adaptive trigger backs off to twice the interval.
+- Once at session end for final task boundaries.
+- Zero LLM calls for 0-turn or 1-turn sessions, which get a trivial local
+  segment instead.
+
+Approximate default upper bound for an interactive session with `N >= 2` turns:
+
+```text
+floor(N / 10) incremental calls + 1 final call
+```
+
+For example, a 23-turn session normally means about 3 segmentation calls: turn
+10, turn 20, and final session end. Adaptive backoff can reduce that.
+
+Segmentation uses a headless CLI provider. The default model is
+`claude-haiku-4-5-20251001`; set `segmentation.model` to override it when the
+selected provider supports a model flag.
+
+Disable segmentation:
+
+```bash
+trajectory config set segmentation.enabled false
+```
+
+Disable it for one launched server or shell:
+
+```bash
+TRAJECTORY_SEGMENTATION_DISABLED=1 trajectory serve
+```
+
+Reduce incremental frequency:
+
+```bash
+trajectory config set segmentation.interval 25
+```
+
+Changing `segmentation.publish_metrics`, `segmentation.publish_traces`, or a
+destination-level `segmentation.enabled: false` controls whether
+segmentation-derived outputs publish. Those settings do not stop local
+segmentation work. Use `segmentation.enabled: false` when the goal is to stop
+LLM capacity use.
+
+## Sensitivity classification
+
+Sensitivity classification is enabled by default in `balanced` mode. It is
+primarily used by trace publish privacy gates, but `export.traces=off` is not a
+guaranteed capacity control by itself. If you want no sensitivity-classifier LLM
+calls and no sensitivity publish gate, set `export.sensitivity.scanning_mode`
+to `off`.
+
+Scanning modes:
+
+- `balanced` is the default. It scans on the same default turn cadence as
+  segmentation: about every 10 completed turns, plus a final session-end scan on
+  the non-incognito publish path.
+- `near_realtime` scans active sessions on a time window when new content
+  exists. The default interval is 30 minutes.
+- `off` disables sensitivity classifier calls and disables the sensitivity
+  publish gate.
+
+Before any server-side classifier call, Trajectory checks the session watermark.
+If there are no new events since `last_scanned_seq`, the scan is a no-op. This
+idle no-op applies to both `balanced` and `near_realtime` mode.
+
+Extension-supplied sensitivity verdicts are used as a server-side no-op signal:
+when a recent verdict exists, Trajectory skips the duplicate server-side scan.
+
+The classifier reads a bounded session summary, not an unbounded raw file: up
+to 100 session events, with user prompts and agent responses truncated to 1000
+characters per event. The summary can still include project metadata, file
+paths, commands, prompts, and assistant text.
+
+Classifier backend selection prefers an available local/headless path before
+direct provider APIs. In practice, capacity may come from the installed agent
+CLI account, MCP sampling, or direct provider API keys such as
+`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`. If no classifier
+path is available, Trajectory fails closed for publish gating and does not make
+a paid classifier call.
+
+Disable sensitivity classification:
+
+```bash
+trajectory config set export.sensitivity.scanning_mode off
+```
+
+The legacy switch is still accepted:
+
+```bash
+trajectory config set export.sensitivity.enabled false
+```
+
+Use near-realtime scanning only when short-delay publish is worth the additional
+classifier calls:
+
+```bash
+trajectory config set export.sensitivity.scanning_mode near_realtime
+trajectory config set export.sensitivity.near_realtime_interval_minutes 30
+```
+
+Lower `near_realtime_interval_minutes` values can release held spans sooner, but
+they can increase LLM capacity and cost. In `balanced` mode, the near-realtime
+interval is ignored.
+
+Approximate sensitivity-classifier call count:
+
+```text
+balanced:      floor(turns / 10) calls + at most 1 session-end call
+near_realtime: active windows with new content / interval + at most 1 session-end call
+off:           0 calls
+```
+
+Incognito is a privacy control, not a capacity control. It suppresses publish
+for ordinary destinations and skips the final non-incognito publish-drain scan,
+but active-session sensitivity scanning can still run while the session is
+active. Use `scanning_mode: off` for a capacity guarantee.
+
+## Cost reporting
+
+Trajectory emits best-effort Datadog Metrics v2 points for Trajectory-owned LLM
+capacity when a `dd_llmobs` metrics destination is enabled:
+
+| Metric | Type | Tags | Notes |
+|---|---|---|---|
+| `trajectory.serve.llm_capacity.calls.total` | count | `feature`, `backend`, `gen_ai.request.model`, `pass`, `cost_source` | One successful background LLM call. `feature` is `segmentation` or `sensitivity`. |
+| `trajectory.serve.llm_capacity.cost.usd.total` | count | `feature`, `backend`, `gen_ai.request.model`, `pass`, `cost_source` | Estimated USD cost for calls whose model can be priced. |
+
+The cost metric uses estimated token counts from prompt and output size, then
+prices those counts with Trajectory's existing model pricing table. It is not a
+provider invoice. Calls whose model is not visible or not priced still emit
+`trajectory.serve.llm_capacity.calls.total` with `cost_source:pricing_unknown`.
+
+Useful queries:
+
+```text
+sum:trajectory.serve.llm_capacity.cost.usd.total{*} by {feature}
+sum:trajectory.serve.llm_capacity.calls.total{*} by {feature,backend}
+```
+
+## What does not add Trajectory-owned LLM calls
+
+These settings and features do not by themselves ask another LLM to process the
+session:
+
+- `export.traces`: controls whether captured spans publish to LLM Observability.
+- `export.metrics`: controls metrics publish.
+- `export.placeholder_llm_span`: controls a synthetic Datadog LLM span for cost
+  enrichment; it does not call an LLM.
+- Marker evaluation: built-in and YAML markers are rule-based over local SQLite
+  data.
+- `segmentation.publish_metrics` and `segmentation.publish_traces`: control
+  publish of already-derived task outputs.
+
+## Check current settings
+
+```bash
+trajectory config show
+trajectory config get segmentation.enabled
+trajectory config get segmentation.interval
+trajectory config get export.sensitivity.scanning_mode
+trajectory config get export.sensitivity.near_realtime_interval_minutes
+```
+
+Check recent activity in the serve logs:
+
+```bash
+trajectory logs --grep 'segmentation:'
+trajectory logs --grep 'sensitivity:'
+```

--- a/docs/MARKERS.md
+++ b/docs/MARKERS.md
@@ -2,6 +2,12 @@
 
 Markers are Trajectory's YAML-defined behavioral signals. They turn captured agent sessions into named observations that can be evaluated locally, stored in Trajectory's SQLite database, and exported to Datadog as marker metrics and structured marker context.
 
+A concise version of this guide is built into the binary:
+
+```bash
+trajectory user-guide markers
+```
+
 Use markers when you want durable answers to questions such as:
 
 - Did the agent force-push, run a destructive command, or expose a secret in a shell command?
@@ -27,20 +33,13 @@ Later layers override earlier layers by marker name. An org marker with `enforce
 
 Trajectory always starts with embedded built-ins for common agent outcomes and friction:
 
-- Points such as `user-frustration`, `agent-course-correction`, `git-commit`, `pr-created`, `git-push`, `test-passed`, `test-failed`, `skill-invoked`, workflow lifecycle points, `tool-error`, `permission-denied`, `language-activity`, `code-change`, `files-touched`, `compaction`, `fork-detected`, and `backtrack-detected`.
+- Points such as `user-frustration`, `agent-course-correction`, `git-commit`, `pr-created`, `git-push`, `test-passed`, `test-failed`, `skill-invoked`, skill and workflow lifecycle points, `tool-error`, `permission-denied`, `language-activity`, `code-change`, `files-touched`, `compaction`, `fork-detected`, and `backtrack-detected`.
 - The `test-fix-cycle` multi-turn range.
 - Measures such as `frustration-count`, `commit-count`, `commit-cost-usd`, `commit-attributed-turns`, task metrics, and error/interruption counts.
 
 The setup default profile adds Datadog-oriented signals such as `force-push`, `destructive-command`, `secret-in-command`, `high-cost-turn`, CI and infrastructure touch points, retry ranges, and language/code-change measures.
 
-The built-in `test-passed` and `test-failed` command regexes are intentionally
-examples, not an exhaustive test-runner catalog. They cover common
-high-confidence commands such as `go test`, `cargo test`, `pytest`, JavaScript
-package-manager test scripts, `make test`-style targets, shell scripts under
-`tests/`, and representative language-native runners like Maven/Gradle,
-`dotnet test`, RSpec, PHPUnit/Composer, Swift, and CTest. If your team uses
-more specific commands, override those points in org, user, or project marker
-config:
+The built-in `test-passed` and `test-failed` command regexes are intentionally examples, not an exhaustive test-runner catalog. They cover common high-confidence commands such as `go test`, `cargo test`, `pytest`, JavaScript package-manager test scripts, `make test`-style targets, shell scripts under `tests/`, and representative language-native runners like Maven/Gradle, `dotnet test`, RSpec, PHPUnit/Composer, Swift, and CTest. If your team uses more specific commands, override those points in org, user, or project marker config:
 
 ```yaml
 version: 2
@@ -497,7 +496,15 @@ Examples of the derivation:
 
 Built-in per-turn metrics intentionally publish both gauges and distributions where the questions differ. `trajectory.turn.tool_uses` is a gauge split by `tool_name` for per-tool breakdowns within a turn; `trajectory.turn.tool_uses.total` is a distribution sample of the total tools used by a completed turn and does not carry `tool_name`. Similarly, `trajectory.turn.cost.usd` and `trajectory.turn.duration_ms` are gauges for the latest turn values, while `trajectory.turn.cost.usd.total` and `trajectory.turn.duration_ms.total` are completed-turn distribution samples for percentile queries. `trajectory.turn.permission_wait_ms.total` and `trajectory.turn.duration_ms.excluding_permission_wait.total` break out derivable human approval wait from completed-turn duration. PR attribution metrics are also completed samples: `trajectory.pr.cost.usd.attributed.total` is the cost attributed to turns that contributed to a PR, `trajectory.pr.attributed_turns.total` counts those turns, and `trajectory.pr.containing_session.cost.usd.total` records the cost of sessions containing PR activity. `trajectory.session.last_seen.unix` is a session-scoped gauge whose value is the latest observed session event time as Unix seconds; use it for recency-sorted session tables. Enable Historical Metrics Ingestion for this gauge before replaying sessions older than one hour.
 
-Older `trajectory.marker.measure.<measure_name>` and `trajectory.marker.point.<measure_name>` namespaces are deprecated. Use the current `trajectory.<scope>.<concept>` metric names described in this guide.
+Managed `required_destinations` can opt in to structured `pr_attribution` records for PR/MR drilldown. Those records are derived from persisted `pr-created` marker detail and session summaries. They may include PR/MR URL, owner, repo, number, bounded attributed cost/turns, and containing-session cost; they do not include prompts, tool input/output, commands, diffs, file contents, or local file paths. Repo `publish.trajectory.yaml` files cannot enable records, and security destinations never receive them. Historical replay uses `trajectory backfill-records --kind pr_attribution` for dry-run and `--yes` to submit.
+
+Any marker detail intended to feed a structured record must be durable,
+schema-stable, and safe to publish without reading raw transcript or tool
+payload tables. Marker detail may carry normalized identifiers and numeric
+attribution values; it must not embed prompts, responses, command text, diffs,
+file contents, local paths, or secret-bearing URLs.
+
+Older `trajectory.marker.measure.<measure_name>` and `trajectory.marker.point.<measure_name>` namespaces are deprecated. Use the metric naming convention above for migration guidance.
 
 Range markers are still exported as marker context/evaluation records. To make them easy to graph in dashboards, add a range-backed measure:
 
@@ -547,12 +554,7 @@ trajectory publish validate
 
 ### Dashboard query examples
 
-Trajectory submits marker metrics according to `metric_kind`. Most session
-measures are gauges with completed-session `.completed_count` mirrors for
-dashboard totals; raw per-commit samples are distributions. Use `sum:` on the
-`.completed_count` mirrors for count-like session totals, `avg:` for
-ratios/scores, and percentile aggregators such as `p95:` for distribution
-samples.
+Trajectory submits marker metrics according to `metric_kind`. Most session measures are gauges with completed-session `.completed_count` mirrors for dashboard totals; raw per-commit samples are distributions. Use `sum:` on the `.completed_count` mirrors for count-like session totals, `avg:` for ratios/scores, and percentile aggregators such as `p95:` for distribution samples.
 
 | Widget | Example Datadog query | Notes |
 | --- | --- | --- |
@@ -565,11 +567,11 @@ samples.
 | P95 permission wait per completed turn | `p95:trajectory.turn.permission_wait_ms.total{repo:trajectory}` | Estimated from permission request and matching tool result timing when derivable. |
 | P95 completed-turn duration excluding permission wait | `p95:trajectory.turn.duration_ms.excluding_permission_wait.total{repo:trajectory}` | Subtracts derivable approval wait; missing wait intervals remain part of duration. |
 | Average per-commit cost | `avg:trajectory.commit.cost.usd.total{repo:trajectory} by {branch}` | Uses the built-in commit-cost-usd branch tag; confirm the `branch` point dimension is present in Metrics Explorer. |
-| Total PR-attributed cost | `sum:trajectory.pr.cost.usd.attributed.total{repo:trajectory}` | Metrics-only aggregate; Trajectory does not publish a PR URL table or records/log payload for this dashboard view. |
+| Total PR-attributed cost | `sum:trajectory.pr.cost.usd.attributed.total{repo:trajectory}` | Metrics aggregate. Optional managed `pr_attribution` records provide PR/MR drilldown separately from metric series. |
 | PR-attributed turns | `sum:trajectory.pr.attributed_turns.total{repo:trajectory}` | Counts turns attributed to PR activity. |
 | Average containing-session cost for PRs | `avg:trajectory.pr.containing_session.cost.usd.total{repo:trajectory}` | Compares attributed PR cost with the broader session cost that contained PR activity. |
 | P95 range duration | `p95:trajectory.session.test_fix_cycle.duration.ms{*}` | Backed by a range distribution using `@range_duration_ms` and `metric_kind: distribution`. |
-| Test success ratio | `avg:trajectory.session.test_success_rate{repo:trajectory}` | Ratio measures are session-level gauges; graph with `avg:`. |
+| Range success ratio | `avg:trajectory.session.test_success_rate{repo:trajectory}` | Ratio measures are session-level gauges; graph with `avg:`. |
 | Marker density formula | `sum:trajectory.session.force_pushes.completed_count{*}.rollup(sum, 86400) / count_not_null(avg:trajectory.session.turns.total{*} by {gen_ai.conversation.id})` | Use a formula widget to normalize marker counts by completed sessions. |
 
 ### Monitor examples
@@ -579,8 +581,8 @@ Adapt scopes and thresholds to your org. These are metric monitor query shapes, 
 - Page on high-risk security markers in production:
   `sum(last_15m):sum:trajectory.session.security_risky_shell_secret_exfils{env:prod}.rollup(sum) > 0`
 - Alert when force pushes happen outside a break-glass repo/team:
-  `sum(last_1h):sum:trajectory.session.force_pushes{team:agent-platform,!repo:release-tools}.rollup(sum) > 0`
-- Watch test success rate after defining a ratio measure:
+  `sum(last_1h):sum:trajectory.session.force_pushes.completed_count{team:agent-platform,!repo:release-tools}.rollup(sum) > 0`
+- Watch range-backed retry health:
   `avg(last_4h):avg:trajectory.session.test_success_rate{team:agent-platform} < 0.8`
 - Catch unusually long range cycles after defining a duration distribution:
   `max(last_1h):max:trajectory.session.test_fix_cycle.duration.ms{team:agent-platform} > 1800000`
@@ -609,7 +611,7 @@ measures:
 
 Useful starter widgets are a 24-hour query value for total security markers, a toplist by `repo` or `team`, and a timeseries split by the specific count metric. Keep extracted security details out of metric tags unless they are normalized to a bounded, non-sensitive category.
 
-The packaged Datadog dashboard templates are embedded in the binary. For one-off analysis, prefer ad hoc dashboard queries like the examples above.
+Packaged Datadog dashboard templates are embedded in the binary. For one-off analysis, prefer ad hoc dashboard queries like the examples above.
 
 ## CLI commands
 
@@ -633,11 +635,42 @@ trajectory reevaluate [--db PATH] [--session SESSION_ID] [--since YYYY-MM-DD] [-
 # Validate captured marker expectations in a DB fixture/session.
 trajectory validate-markers [--db PATH] [--session SESSION_ID] [--corpus] [--self-test]
 
+# Run the isolated marker canary and print Datadog query examples.
+trajectory markers canary [--source-home PATH] [--home PATH] [--keep-home]
+
 # Validate publish destinations and marker metric settings.
 trajectory publish validate
 ```
 
 `trajectory markers validate` checks all resolved marker layers; pass `--config PATH` to validate a specific marker YAML file. Validation reports the file, schema path, and message for each error.
+
+## Marker canary
+
+Use `trajectory markers canary --keep-home` after marker, publish, or client-capture changes that could affect marker fidelity. The command copies the current Trajectory config into an isolated `TRAJECTORY_HOME`, disables ambient Codex/Cursor transcript watchers, disables segmentation/self-update/token backfill, starts a local capture server on an ephemeral port, and posts a synthetic Pi session.
+
+The synthetic session intentionally exercises:
+
+- Three interleaved assistant-message turns so `assistant_messages_json` must be present for every turn.
+- Skill detection through a `Skill` tool call, a `SKILL.md` file read, and tool provenance.
+- Failed test, code edit, passed test, commit, push, PR, compaction, tool error, permission denial, language activity, cost, and token metrics.
+- Session, commit, and PR cost attribution from per-turn cost rather than cumulative turn totals.
+
+Local `PASS` means the SQLite cache contains the expected session/turn shape, non-null assistant-message data, marker points, grouped measures, cost, token totals, and commit/PR distribution point dimensions. When the copied config contains a Datadog metrics destination with marker metrics enabled, the command can publish to that destination and print Metrics Explorer query examples.
+
+Expected readback includes:
+
+```text
+trajectory.session.skill_invocations by skill_name: setup-markers=1, integ-validate=1, e2e-test=1
+trajectory.session.tool_errors by category: command-failed=1
+trajectory.session.language_activity by language: go=2, markdown=1
+trajectory.session.cost.usd.total: 0.0343
+trajectory.commit.cost.usd.total by branch: feature/marker-canary=0.0343
+trajectory.pr.cost.usd.attributed.total: 0.0343
+gen_ai.usage.input_tokens: 4300
+gen_ai.usage.output_tokens: 1240
+```
+
+The expected metric tags include `environment:test`, `session_id:<id>`, `trajectory.client_source:pi`, `trajectory.client_version:marker-canary/dev`, `gen_ai.request.model:openai/gpt-5.1`, and `project_dir:trajectory-marker-canary-fixture`. Marker detail fields such as `detected_from` and `source_scope` are validated locally; they are not Datadog metric tags unless a measure explicitly maps them to bounded dimensions.
 
 ## End-to-end authoring workflow
 

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -1,11 +1,14 @@
 # Metrics Reference
 
-This page catalogs the metric surface emitted by the current Trajectory binary.
-Metric names, types, and tags are treated as part of the public distribution
-contract.
+This page catalogs the metric surface emitted by the current Trajectory binary. Metric names, types, and tags are treated as part of the public distribution contract.
 
 For marker syntax and dashboard examples, see [MARKERS.md](MARKERS.md). For
 configuration and destination trust, see [USER-GUIDE.md](USER-GUIDE.md).
+For the built-in metric guide, run:
+
+```bash
+trajectory user-guide metrics
+```
 
 ## Naming Model
 
@@ -156,7 +159,10 @@ Session-end metrics:
 
 Task metrics come from closed task segments. They are emitted with
 `trajectory.trace_type:task` and the dimensions `task_type`, `outcome_label`,
-and `task_id` when task metric publishing is enabled for the destination.
+and `task_id` when `segmentation.publish_metrics` is enabled. The legacy
+`segmentation.publish_traces` gate also enables these metrics for existing
+trace-publish opt-ins. Destinations can suppress all task-segmentation-derived
+publish outputs with `segmentation.enabled: false`.
 
 | Metric | Type | Unit |
 |---|---|---|
@@ -184,22 +190,23 @@ Built-in and setup-default metrics include:
 | `trajectory.session.skill_invocations` | gauge | session | Skill activity grouped by `skill_name` |
 | `trajectory.session.subagents` | gauge | session | Setup-default subagent count |
 | `trajectory.session.tests_written` | gauge | session | Setup-default new-test count |
+| `trajectory.session.test_success_rate` | gauge | session | Setup-default Bazel retry success ratio |
 | `trajectory.session.force_pushes` | gauge | session | Setup-default force-push count |
 | `trajectory.session.ci_iterations` | gauge | session | Setup-default CI feedback ranges |
 | `trajectory.session.code_added` | gauge | session | Setup-default code-change count |
 | `trajectory.session.files_modified` | gauge | session | Setup-default files-touched count |
-| `trajectory.session.tasks` | gauge | session | Task segment count when task metrics publishing is enabled |
-| `trajectory.session.task_outcome_mean` | gauge | session | Mean task outcome score when task metrics publishing is enabled |
-| `trajectory.session.task_autonomy_mean` | gauge | session | Mean task autonomy score when task metrics publishing is enabled |
-| `trajectory.session.high_risk_tasks` | gauge | session | Tasks with high risk score when task metrics publishing is enabled |
+| `trajectory.session.tasks` | gauge | session | Task segment count when `segmentation.publish_metrics` or `segmentation.publish_traces` is enabled and destination segmentation is enabled |
+| `trajectory.session.task_outcome_mean` | gauge | session | Mean task outcome score when task-segmentation publish is enabled for the destination |
+| `trajectory.session.task_autonomy_mean` | gauge | session | Mean task autonomy score when task-segmentation publish is enabled for the destination |
+| `trajectory.session.high_risk_tasks` | gauge | session | Tasks with high risk score when task-segmentation publish is enabled for the destination |
 
 Count-like session gauges that represent one final value per completed session
 also publish a `.completed_count` mirror, for example
 `trajectory.session.force_pushes.completed_count`,
 `trajectory.session.language_activity.completed_count`, and
-`trajectory.session.prs.completed_count`. Datadog gauge rollups can repeat final
-values across dashboard buckets, so dashboards that ask "how many?" should sum
-the `.completed_count` mirror rather than summing the gauge.
+`trajectory.session.prs.completed_count`. Datadog gauge rollups can repeat final values
+across dashboard buckets, so dashboards that ask "how many?" should sum the
+`.completed_count` mirror rather than summing the gauge.
 
 Commit and PR attribution metrics are distribution samples:
 
@@ -229,11 +236,18 @@ privacy/publish diagnostics.
 | `trajectory.serve.publish.sensitivity_held` | count | `client_source`, `destination`, `reason` | Spans held while classification is pending or unresolved |
 | `trajectory.serve.publish.spans_suppressed_total` | count | `client_source`, `destination`, `category`, `label` | Number of spans suppressed by sensitivity policy |
 | `trajectory.serve.publish.spans_held_total` | count | `client_source`, `destination` | Number of spans held pending sensitivity classification |
+| `trajectory.serve.llm_capacity.calls.total` | count | `feature`, `backend`, `gen_ai.request.model`, `pass`, `cost_source` | Successful Trajectory-owned background LLM calls for segmentation or sensitivity classification |
+| `trajectory.serve.llm_capacity.cost.usd.total` | count | `feature`, `backend`, `gen_ai.request.model`, `pass`, `cost_source` | Estimated USD cost for priced Trajectory-owned background LLM calls |
 | `trajectory.serve.sensitivity.classifier_unavailable` | count | `client_source`, `reason` | No classifier path was available; rate-limited |
 | `trajectory.serve.sensitivity.classifier_backend_error` | count | `backend`, `error_class` | One classifier backend failed before fallback |
 | `trajectory.serve.sensitivity.watermark_write_error` | count | `error_class` | Sensitivity watermark write failed |
 | `trajectory.serve.sensitivity.watermark_parse_error` | count | `error_class` | Sensitivity watermark read/parse failed |
 | `trajectory.serve.sensitivity.sensitivity_held_at_session_end` | count | `reason` | Session ended while sensitivity was still held |
+
+LLM-capacity cost is estimated from prompt/output size and the existing model
+pricing table. It is useful for directional spend dashboards, not provider
+invoice reconciliation. Calls whose model is not visible or priced still emit
+the call count with `cost_source:pricing_unknown`.
 
 ## Companion Metrics
 
@@ -309,17 +323,16 @@ in-progress spend.
 
 Use `.completed_count` mirrors for count-like session markers such as
 `trajectory.session.commits.completed_count` and
-`trajectory.session.force_pushes.completed_count`. The unsuffixed gauges remain
-available for latest-value inspection, but Datadog gauge rollups can repeat
-final session values across buckets and are not trustworthy for dashboard
-totals. For running gauges such as `trajectory.session.turns.elapsed`, use
-last-value or max-style views instead of summing repeated updates for the same
-session.
+`trajectory.session.force_pushes.completed_count`. The unsuffixed gauges remain available
+for latest-value inspection, but Datadog gauge rollups can repeat final session
+values across buckets and are not trustworthy for dashboard totals. For running
+gauges such as `trajectory.session.turns.elapsed`, use last-value or max-style
+views instead of summing repeated updates for the same session.
 
 For active users and recent activity, do not use
 `trajectory.session.evaluated`. That metric is a marker-evaluation heartbeat
-for absence monitoring and can be sparse when marker evaluation or marker metric
-publishing is not enabled for a user. Use
+for absence monitoring and can be sparse when marker evaluation or marker
+metric publishing is not enabled for a user. Use
 `max:trajectory.session.last_seen.unix{...} by {trajectory.user}` with
 `count_nonzero(query1)` for active-user counts, and use
 `trajectory.session.turns.total` grouped by `session_id` when counting
@@ -332,8 +345,8 @@ non-token metrics when the model tag is absent. Prefer model as a grouping on
 intentionally require model-tagged data.
 
 Use max-style queries for `trajectory.publish.active_destinations` when asking
-"how many destinations were active?" It is a per-session gauge; averaging it can
-produce fractional destination counts that are not meaningful.
+"how many destinations were active?" It is a per-session gauge; averaging it
+can produce fractional destination counts that are not meaningful.
 
 Serve-side counters are not uniformly tagged with the canonical tag set.
 `trajectory.serve.incognito.enabled` and `trajectory.serve.publish.*` use the

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -7,6 +7,12 @@ backfill boundaries per client, see
 [CLIENT-INSTRUMENTATION.md](CLIENT-INSTRUMENTATION.md).
 
 For the shared MCP tool and resource catalog, run `trajectory user-guide mcp`.
+For the built-in client overview and per-client guides, run:
+
+```bash
+trajectory user-guide clients
+trajectory user-guide clients/codex
+```
 
 ## Quick Reference
 
@@ -21,6 +27,7 @@ For the shared MCP tool and resource catalog, run `trajectory user-guide mcp`.
 | Factory Droid | `trajectory setup --clients droid` | Beta | Factory plugin command hooks + MCP |
 | Pi | `trajectory setup --clients pi` | Beta | TypeScript extension + MCP |
 | OpenCode | `trajectory setup --clients opencode` | Beta | Plugin SDK events + MCP |
+| OpenClaw | OpenClaw plugin package + optional-client binary | Beta | Plugin SDK hooks + runtime binary resolver |
 
 ## Feature Coverage Matrix
 
@@ -28,19 +35,29 @@ For the shared MCP tool and resource catalog, run `trajectory user-guide mcp`.
 |--------|--------------|-------------------|------------------|------------------|----------|--------|
 | Claude Code | Yes, HTTP hooks | Yes | Yes | Yes | Transcript backfill | Yes |
 | Codex CLI | Yes, command hooks plus rollout watcher fallback | Yes | Yes | Yes | Codex rollout backfill | Yes |
-| GitHub Copilot CLI | Beta command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Gemini CLI | Yes, managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
 | Cursor Desktop | Yes, command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
 | cursor-agent CLI | Yes, transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
-| Factory Droid | Beta command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Pi | Yes, TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Yes, plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
+| OpenClaw | Capture beta, plugin SDK hooks | Yes, with conversation access for prompts/responses | Token usage when OpenClaw hook payloads expose it; cost is estimated downstream or passed through when present | Not yet | Not yet | Not in scope |
+
+OpenClaw support in this repository is intentionally scoped to live capture for
+now. The server-side endpoint is excluded from default Trajectory binaries and
+compiled only with the neutral `optionalclients` build tag. It adds a
+Trajectory `/capture/openclaw` endpoint and a plugin package that maps OpenClaw
+hooks into canonical Trajectory events; it does not add OpenClaw historical
+import, setup-managed install, or resume support.
 
 ## Recommended vs Manual Installs
 
 `trajectory setup --clients ...` is the recommended path for normal installs because it wires the plugin together with the companion config each client expects: hooks, MCP entries, skills, commands, local binaries, and local marketplace metadata.
 
 Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, or the capture hooks needed for complete telemetry.
+
+OpenClaw is the current exception: its plugin package plus a Trajectory binary
+built with `-tags optionalclients` is the supported beta install surface for
+live capture until setup-managed install is added.
 
 ## Codex CLI
 
@@ -85,13 +102,18 @@ Install the Copilot CLI plugin with setup:
 trajectory setup --clients copilot
 ```
 
-Setup writes a local Copilot marketplace under
-`~/.trajectory/copilot-marketplace`, registers it with Copilot, and installs
-`trajectory@trajectory`. The plugin includes command hooks, MCP config, and an
-incognito skill.
+Setup writes a local Copilot marketplace under `~/.trajectory/copilot-marketplace`, registers it with `copilot plugin marketplace add`, and installs `trajectory@trajectory`. The plugin includes `hooks.json`, `.mcp.json`, and an incognito skill. Copilot launches `trajectory mcp` from the plugin's MCP config; that MCP process starts Trajectory's embedded local capture server, matching the same setup-managed lifecycle path used by other local agents. The hooks are Copilot command hooks that `curl` POST the hook JSON from stdin to `/capture/copilot/<event>`.
 
-Capture is live local CLI capture only. There is no Copilot historical backfill,
-transcript watcher, cloud-agent capture path, or session import path.
+Manual fallback from a checkout:
+
+```bash
+copilot plugin marketplace add /path/to/trajectory
+copilot plugin install trajectory@trajectory
+```
+
+Capture is live local CLI capture only. There is no Copilot historical backfill, transcript watcher, cloud-agent capture path, or session import path. The implementation is based on GitHub's public Copilot CLI plugin, MCP, skills, and hooks documentation and is tested with local fixtures that match the documented hook payloads; it has not been validated against a live Copilot CLI install in CI.
+
+Registered documented events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `permissionRequest`, `notification`, `Stop`, `subagentStart`, `SubagentStop`, `ErrorOccurred`, `PreCompact`, and `SessionEnd`. The plugin uses command hooks, not Copilot HTTP hooks, because Copilot requires HTTPS for HTTP hooks that can affect permissions.
 
 ## Claude Code
 
@@ -103,7 +125,7 @@ Install with setup:
 trajectory setup --clients cc
 ```
 
-Setup writes a local Claude Code marketplace under `~/.trajectory/claude-marketplace`, registers that local path with Claude, refreshes the marketplace, then installs the plugin at user scope. If `trajectory@trajectory` is already installed, setup refreshes the marketplace and runs `claude plugin update trajectory@trajectory --scope user` so an existing install moves to the bundled plugin version without requiring remote marketplace access.
+Setup writes a local Claude Code marketplace under `~/.trajectory/claude-marketplace`, registers that local path with Claude, refreshes the marketplace, then installs the plugin at user scope. If `trajectory@trajectory` is already installed, setup refreshes the marketplace and runs `claude plugin update trajectory@trajectory --scope user` so an existing install moves to the bundled plugin version without requiring GitHub SSH or HTTPS credentials.
 
 Manual fallback after setup has staged the local marketplace:
 
@@ -113,7 +135,7 @@ claude plugin marketplace update trajectory
 claude plugin install trajectory@trajectory --scope user
 ```
 
-From this repository checkout, use the checkout root instead of `~/.trajectory/claude-marketplace`.
+From a source checkout, use the checkout root instead of `~/.trajectory/claude-marketplace`.
 
 The plugin registers 12 lifecycle hooks, primarily HTTP, with command shims for startup, shutdown, and serve lifecycle handling.
 
@@ -192,13 +214,18 @@ Install the Factory Droid plugin with setup:
 trajectory setup --clients droid
 ```
 
-Setup writes a local Factory marketplace under
-`~/.trajectory/factory-marketplace`, registers it with Droid, and installs
-`trajectory@trajectory` at user scope. The plugin includes command hooks, MCP
-config, and an incognito skill.
+Setup writes a local Factory marketplace under `~/.trajectory/factory-marketplace`, registers it with `droid plugin marketplace add`, and installs `trajectory@trajectory` at user scope. The plugin includes `hooks/hooks.json`, `mcp.json`, and an incognito skill. Droid launches `trajectory mcp` from the plugin's `mcp.json`; that MCP process starts Trajectory's embedded local capture server, matching the same lifecycle path used by the other setup-managed clients. The hooks themselves stay simple Factory command hooks that `curl` POST the hook JSON from stdin to `/capture/droid/<event>`.
 
-Capture is live only. There is no Factory Droid historical backfill, transcript
-watcher, or session import path.
+Manual fallback from the repo:
+
+```bash
+droid plugin marketplace add /path/to/trajectory
+droid plugin install trajectory@trajectory --scope user
+```
+
+Capture is live only. There is no Factory/Droid historical backfill, transcript watcher, or session import path. The implementation is based on Factory's public plugin, hook, skills, and MCP documentation and is tested with local fixtures that match the documented hook payloads; it has not been validated against a live Droid install in CI.
+
+Registered documented events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, and `SessionEnd`. Factory's public docs do not currently document `PostToolUseFailure`, `PermissionRequest`, `SubagentStart`, or `PostCompact` for Droid; the server accepts those Claude-compatible names as best-effort future compatibility, but the packaged Droid plugin does not register them.
 
 ## OpenCode
 
@@ -218,6 +245,44 @@ Manual fallback: copy `plugin/trajectory-opencode` to `~/.config/opencode/plugin
 
 **Source:** [github.com/anomalyco/opencode](https://github.com/anomalyco/opencode)
 
+## OpenClaw
+
+**Status: Capture beta** (live capture path: OpenClaw plugin hooks)
+
+OpenClaw uses a plugin SDK with typed lifecycle, model, tool, compaction, and
+session hooks. The Trajectory plugin lives in `plugin/trajectory-openclaw` and
+maps those hooks into `/capture/openclaw/...` so events are attributed as
+`client_source=openclaw`.
+
+The npm or ClawHub package installs the JavaScript plugin; the Go `trajectory`
+binary remains a separate executable and must include the optional-client build
+tag. At runtime, the plugin prefers a configured `captureUrl`, then a
+configured or existing binary, then `~/.trajectory/bin/trajectory`, then
+`trajectory` on `PATH`. `binaryInstallMode=auto` is explicit opt-in and should
+only target a release channel that publishes optional-client binaries.
+
+For full prompt, response, token, and cost capture, external OpenClaw installs
+must opt in to raw conversation hooks:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "trajectory-openclaw": {
+        "hooks": {
+          "allowConversationAccess": true
+        }
+      }
+    }
+  }
+}
+```
+
+Backfill and resume are intentionally out of scope for this plugin. The
+OpenClaw plugin is scoped to live capture; historical OpenClaw session import,
+sidecar import, and any future resume adapter should be implemented under
+Trajectory CLI packages rather than hidden in plugin startup.
+
 ## Version Check
 
 To verify your client version:
@@ -225,10 +290,11 @@ To verify your client version:
 ```bash
 claude --version          # Claude Code
 codex --version           # Codex CLI
+copilot version           # GitHub Copilot CLI
 gemini --version          # Gemini CLI
 cursor --version          # Cursor (desktop) / cursor-agent --version (CLI)
+droid --version           # Factory Droid
 pi --version              # Pi
 opencode --version        # OpenCode (note: takes cwd as argument)
-droid --version           # Factory Droid
-copilot version           # GitHub Copilot CLI
+openclaw --version        # OpenClaw
 ```

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -6,6 +6,7 @@ Trajectory captures sessions from AI coding agents and exports them to Datadog L
 
 ```bash
 trajectory status                    # Terminal dashboard with session metrics
+trajectory view                      # Open the local browser viewer
 trajectory doctor                    # Diagnose issues (binary, config, hooks, data)
 trajectory diagnose publish          # Explain capture, local mapping, and publish expectations
 trajectory logs [-f] [--grep PAT]   # View capture server logs
@@ -13,6 +14,8 @@ trajectory version                   # Print version
 ```
 
 `trajectory doctor` is the first thing to run if something isn't working. It checks the binary, config, capture server, database, credentials, and hook registration.
+
+Use `trajectory view --session <id>` to inspect one captured session in the local browser viewer. If local-ui is not already running, `view` starts it and opens the session deep link. Use `trajectory user-guide local-ui` for cache repair and Lapdog-compatible local inspection.
 
 Use `trajectory diagnose publish --session <id>` when Datadog data is missing or surprising. It compares local capture and local JSONL-to-span mapping against the transcript, then explains whether traces or metrics are expected from the current config. It does not query Datadog readback.
 
@@ -49,13 +52,9 @@ trajectory config set-secret dd-api-key             # prompts for the key secure
 
 Trace export is off by default. Set `export.traces` explicitly when you want sessions published to LLM Observability.
 
-Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml` to stop
-publishing Trajectory's synthetic LLM child span for turn-level token and cost
-enrichment. The turn span still carries cost fallback metadata so cost remains
-queryable without the placeholder child span.
+Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml`, or `placeholder_llm_span: false` on a managed/trusted `publish.trajectory.yaml` destination, to stop publishing Trajectory's synthetic LLM child span for turn-level token/cost enrichment. The turn span still carries `metrics.estimated_total_cost` plus cost fallback metadata and the `trajectory.cost_source:turn_metrics` tag, so cost remains queryable without the placeholder child span. Project configs may disable this for a trusted destination, but cannot re-enable it if the trusted or managed destination disabled it.
 
-Set `local_ui.auto_start: false` to disable automatic local-ui startup. Explicit
-`trajectory local-ui` and `trajectory view` commands still work.
+For fleet-wide local-ui auto-start rollback, deploy `local_ui.auto_start: false` in managed `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` and `trajectory view` commands still work.
 
 ## Capture server
 
@@ -72,10 +71,16 @@ The server starts automatically when your agent launches a session (via plugin h
 
 ```bash
 trajectory status                    # Overview of recent sessions
-trajectory query --schema            # Show database tables
-trajectory query "SELECT * FROM sessions ORDER BY start_time DESC LIMIT 5"
-trajectory query --named list_named_queries   # List built-in queries
+trajectory status --session <id> --json
+trajectory view --session <id>
+trajectory user-guide query          # Local data and safe MCP query workflow
 ```
+
+The current OSS binary does not expose a general-purpose `trajectory query`
+CLI. Use `trajectory status`, `trajectory view`, `get_session_trajectory`, and
+the MCP `trajectory_schema` / `trajectory_query` tools for local inspection.
+The embedded query guide documents the schema-first workflow and
+`TRAJECTORY_CACHE_DB` handling.
 
 ## MCP tools
 
@@ -113,13 +118,17 @@ trajectory setup --uninstall codex   # Remove one client integration
 |--------|--------------|-------------------|------------------|------------------|----------|--------|
 | Claude Code | HTTP hooks | Yes | Yes | Yes | Transcript backfill | Yes |
 | Codex CLI | Command hooks plus rollout watcher fallback | Yes | Yes | Yes | Codex rollout backfill | Yes |
-| GitHub Copilot CLI | Beta command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Gemini CLI | Managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
 | Cursor Desktop | Command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
 | cursor-agent CLI | Transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
-| Factory Droid | Beta command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
+| Factory Droid | Beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Pi | TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
+| OpenClaw | Capture beta plugin hooks with optional-client binary | Yes, with conversation access for prompts/responses | Token usage when OpenClaw exposes it; cost estimated downstream or passed through when present | Not yet | Not yet | Not in scope |
+
+OpenClaw is live-capture only in the current beta and is installed through its
+OpenClaw plugin package, not `trajectory setup`. Default Trajectory binaries
+omit this route; use a binary built with `-tags optionalclients`.
 
 ## Publishing and export
 
@@ -132,15 +141,58 @@ trajectory diagnose publish          # Explain whether traces/metrics should pub
 
 `trajectory publish validate` checks configuration, trust policy, and credentials. `trajectory publish status` shows the effective mode, including metrics-only and trace-off states. Neither command verifies Datadog intake or readback.
 
+For the publish operations runbook covering validate/status/preview, missing
+Datadog data, `publish sync`, and publish ledger repair:
+
+```bash
+trajectory user-guide publish
+```
+
+For marker-metric readback, use `trajectory markers canary --keep-home`. It runs an isolated synthetic session, validates local marker/cost/token/assistant-message invariants, and prints Datadog queries for metric destination verification.
+
 `trajectory audit --deep` adds an interpretation block for local capture fidelity, config-driven trace-off states, missing model/cost attribution, and the 24-hour LLMO trace intake backfill limit.
 
-`trajectory audit --source-data` checks the local SQLite cache contracts used by
-local-ui, including completed-session finalization, session and turn aggregate
-consistency, tool-call parentage, model and cost attribution, sparse turn IDs,
-and contentless active turns. Use `--json` for machine-readable output or
-`--db <path>` to inspect a non-default cache.
+`trajectory audit --source-data` checks the local SQLite cache contracts used by local-ui, including completed-session finalization, session/turn aggregate consistency, tool-call parentage, model/cost attribution, sparse turn IDs, and contentless active turns. Use `--json` for machine-readable output or `--db <path>` to inspect a non-default cache.
+
+For a cleaner troubleshooting flow across doctor, diagnose, audit, validate-spans, and support bundles:
+
+```bash
+trajectory user-guide diagnostics
+```
 
 For the full metric catalog, see [METRICS-REFERENCE.md](METRICS-REFERENCE.md).
+
+## Local UI and resume
+
+Open the local viewer:
+
+```bash
+trajectory view
+trajectory view --session <id>
+```
+
+Run local-ui manually when you need a stable port or Lapdog-compatible local
+inspection:
+
+```bash
+trajectory local-ui --port 8890
+trajectory local-ui --lapdog
+```
+
+Reconstruct a captured session into another supported client:
+
+```bash
+trajectory resume --list-targets
+trajectory resume --session <id> --target codex --dry-run
+trajectory resume --session <id> --target codex
+```
+
+Read the embedded guides for details:
+
+```bash
+trajectory user-guide local-ui
+trajectory user-guide resume
+```
 
 ## Datadog dashboards
 
@@ -167,7 +219,7 @@ Customer details, HR/legal content, credentials, or private investigation notes.
 
 These tags are a convention, not a redaction boundary. Trajectory may capture the tags and enclosed text locally. If ordinary publish should be suppressed, enable `/incognito` before sharing the content, and keep sensitive values out of metric tags and marker dimensions.
 
-The embedded `privacy` topic gives the full privacy-controls guide:
+The embedded `privacy` topic gives the managed-install and sensitivity-scanning version of this guidance:
 
 ```bash
 trajectory user-guide privacy
@@ -175,31 +227,22 @@ trajectory user-guide privacy
 
 ## Backfill
 
-Import sessions from before trajectory was installed:
+Use backfill when you need to import historical sessions, refresh the local UI
+cache, or repair historical dashboard metrics.
 
 ```bash
-trajectory backfill --from-claude-code                 # Claude Code transcripts
+trajectory backfill --from-claude-code --republish-local  # Claude Code transcripts + local UI
+trajectory backfill --republish-local                  # Refresh local UI from cached sessions
 trajectory backfill --from-codex-sessions --limit 100  # Codex rollout files, newest first
-trajectory backfill --from-codex-sessions --continue   # Continue the previous Codex page
-trajectory backfill --index-local --limit 100          # Index trajectory JSONL into local-ui cache
-trajectory backfill --republish-local --all            # Re-forward cached sessions to local-ui
-trajectory backfill --status                           # Show saved paged backfill status
+trajectory backfill-my-metrics                         # Dry-run historical dashboard metrics
 ```
 
-Paged backfills are manual maintenance commands. They do not run during agent startup. Codex rollout repair and local-ui cache indexing process newest files first and skip active files whose modification time is less than 2 minutes old. Rerun the same command after active sessions are quiet if doctor still reports missing data.
-
-`trajectory doctor` detects recent Codex rollout files that have not been converted and recent trajectory JSONL files that are missing from the local-ui cache. It prints the matching `trajectory backfill ...` command instead of running repair automatically.
-
-Re-publish historical dashboard and marker metrics from local records:
+Read the full embedded guide for modes, local UI repair, historical metric
+readback, and structured record backfill:
 
 ```bash
-trajectory backfill-metrics --dry-run
-trajectory backfill-metrics --since YYYY-MM-DD --destination NAME
+trajectory user-guide backfill
 ```
-
-This reconstructs the known dashboard metric suite from the local SQLite cache, including session, turn, cost, tool-call, and marker metrics. Use `--since YYYY-MM-DD`, `--until YYYY-MM-DD`, or `--destination NAME` when you need a narrower repair.
-
-Historical metric backfill only works when Datadog Historical Metrics Ingestion is enabled for the destination org and metric types. Without that Datadog-side setting, old points may be dropped even when `backfill-metrics` submits successfully. LLMO trace intake is stricter: historical trace backfill is only accepted for recent data, so sessions older than 24 hours should be treated as local-fidelity evidence rather than a promise that missing LLMO traces can be repaired.
 
 ## Viewing logs
 
@@ -236,16 +279,27 @@ The binary includes a full user guide with detailed topics:
 ```bash
 trajectory user-guide                # List all topics
 trajectory user-guide config         # Configuration deep-dive
+trajectory user-guide llm-capacity   # LLM capacity and expense controls
+trajectory user-guide backfill       # Historical import, local UI repair, and metric backfill
+trajectory user-guide local-ui       # Browser viewer, local-ui, and cache repair
 trajectory user-guide publish        # Per-repo publish config
 trajectory user-guide dashboards     # Datadog dashboard export and MCP import
 trajectory user-guide markers        # Marker authoring and metrics
 trajectory user-guide metrics        # Metric gates, names, tags, and queries
 trajectory user-guide mcp            # MCP tools, resources, and SQL query workflow
+trajectory user-guide query          # Local cache data and guarded MCP SQL workflow
 trajectory user-guide privacy        # Incognito, sensitive tags, and sensitivity scanning
+trajectory user-guide diagnostics    # Doctor, diagnose, audit, validate-spans, support bundles
+trajectory user-guide resume         # Reconstruct captured sessions into other clients
 trajectory user-guide clients        # All supported clients
+trajectory user-guide clients/claude-code # Claude Code-specific details
 trajectory user-guide clients/codex  # Codex-specific details
 trajectory user-guide clients/copilot # GitHub Copilot CLI beta details
+trajectory user-guide clients/cursor # Cursor-specific details
 trajectory user-guide clients/droid  # Factory Droid beta details
+trajectory user-guide clients/gemini # Gemini-specific details
+trajectory user-guide clients/pi     # Pi-specific details
+trajectory user-guide clients/opencode # OpenCode-specific details
 trajectory user-guide install        # Installation methods
 ```
 
@@ -253,23 +307,13 @@ trajectory user-guide install        # Installation methods
 
 Every span and metric emitted by trajectory carries a `trajectory.user` tag set to your Unix username. Override it with the `TRAJECTORY_USER` environment variable.
 
-Trajectory can also emit `trajectory.user_email` when configured. Resolution
-uses the first successful value: `TRAJECTORY_USER_EMAIL`, then
-`identity.user_email`, then `identity.user_email_command`, then
-`identity.user_email_suffix` appended to `trajectory.user`.
+Trajectory can also emit `trajectory.user_email` when configured. Resolution uses the first successful value: `TRAJECTORY_USER_EMAIL`, then `identity.user_email`, then `identity.user_email_command`, then `identity.user_email_suffix` appended to `trajectory.user`. Config values follow normal layering first (`config.defaults.yaml`, then `config.yaml`). If both command and suffix are set, the command wins when it returns a valid email; otherwise Trajectory falls through to the suffix.
 
 ```bash
-trajectory config set identity.user_email_suffix example.com
+trajectory config set identity.user_email_suffix datadoghq.com
 ```
 
-GitHub identity tags are optional. `github.email` resolves from
-`TRAJECTORY_GITHUB_EMAIL`, then `identity.github_email`, then
-`identity.github_email_command`, then repo-local `git config user.email`, then
-global `git config user.email`. `github.username` resolves from
-`TRAJECTORY_GITHUB_USERNAME`, then `identity.github_username`, then
-`identity.github_username_command`, then repo-local `git config github.user` or
-`github.username`, then global Git config. Repo-local values win over global
-values, and commands win over Git config when they return valid values.
+GitHub identity tags are optional. `github.email` resolves from `TRAJECTORY_GITHUB_EMAIL`, then `identity.github_email`, then `identity.github_email_command`, then repo-local `git config user.email`, then global `git config user.email`. `github.username` resolves from `TRAJECTORY_GITHUB_USERNAME`, then `identity.github_username`, then `identity.github_username_command`, then repo-local `git config github.user` or `github.username`, then global Git config. Repo-local values win over global values, and commands win over Git config when they return valid values.
 
 Use these tags to filter in LLM Obs and Metrics Explorer:
 
@@ -284,7 +328,7 @@ This is useful on shared machines or CI where multiple users generate sessions.
 Trajectory automatically tags every DD metric with repository metadata extracted from the git remote:
 
 - `repo` - repository name (e.g., `trajectory`)
-- `owner` - org or user (e.g., `datadog-labs`)
+- `owner` - org or user (e.g., `DataDog`)
 - `git_remote_host` - host (e.g., `github.com`)
 
 These tags appear on all metric series, so you can filter and group by repository in Metrics Explorer without any configuration.
@@ -316,4 +360,4 @@ Marker compute blocks (`sum` and `count` over turn windows) enable per-commit co
 
 This powers the `trajectory.commit.cost.usd.total` and `trajectory.commit.attributed_turns.total` distribution metrics, letting you answer "how much did this commit cost?" and percentile questions such as p95 cost per commit in Metrics Explorer, optionally split by the `branch` tag.
 
-PR attribution uses metrics only. Trajectory emits `trajectory.pr.cost.usd.attributed.total` for the cost attributed to turns that contributed to a PR, `trajectory.pr.attributed_turns.total` for the number of attributed turns, and `trajectory.pr.containing_session.cost.usd.total` for the total cost of sessions that contained PR activity. These power aggregate dashboards and Metrics Explorer queries without publishing PR URL tables or record/log payloads.
+PR attribution metrics remain aggregate-only. Trajectory emits `trajectory.pr.cost.usd.attributed.total` for the cost attributed to turns that contributed to a PR, `trajectory.pr.attributed_turns.total` for the number of attributed turns, and `trajectory.pr.containing_session.cost.usd.total` for the total cost of sessions that contained PR activity. Managed installs may separately enable `pr_attribution` structured records for PR/MR drilldown; repo configs and security destinations cannot enable those records.


### PR DESCRIPTION
## Summary
- add the LLM capacity and expense controls guide
- refresh public docs for client instrumentation, markers, metrics, supported clients, and day-to-day usage
- align examples and wording with the public distribution

Docs-only update.