### PR TITLE
Add public configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 ## Reference
 
 - [docs/USER-GUIDE.md](docs/USER-GUIDE.md): CLI workflows and day-to-day operation
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md): config files, managed defaults, environment overrides, and common settings
 - [docs/PRIVACY.md](docs/PRIVACY.md): incognito, sensitive tags, and sensitivity scanning
 - [docs/METRICS-REFERENCE.md](docs/METRICS-REFERENCE.md): emitted metric names, types, tags, and query guidance
 - [docs/MARKERS.md](docs/MARKERS.md): marker authoring and marker-derived metrics

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,222 @@
+# Configuration Guide
+
+Trajectory reads a small YAML configuration, a managed defaults file when one is present, and a few environment variables. Most users only need `trajectory config show` and `trajectory config set`.
+
+## Start Here
+
+```bash
+trajectory config show               # View the effective runtime config
+trajectory config path               # Print the config file paths Trajectory uses
+trajectory config                    # Open the interactive config editor
+trajectory config set <key> <value>  # Set one supported scalar value
+trajectory config get <key>          # Read one value
+```
+
+Use `trajectory config show` when behavior is surprising. It shows the merged config the binary will use after defaults and user settings are loaded.
+
+## Config Files
+
+By default, Trajectory uses these files under `~/.trajectory/`:
+
+| File | Purpose | Who usually edits it |
+|---|---|---|
+| `config.yaml` | Normal per-machine user configuration | The user, usually through `trajectory config set` |
+| `config.defaults.yaml` | Managed defaults and policy-style settings | An installer, administrator, or configuration management tool |
+
+Set `TRAJECTORY_HOME` to move the whole Trajectory home directory, including both config files, to another location.
+
+## How Layering Works
+
+Trajectory starts with built-in defaults, then loads `config.defaults.yaml` if it exists, then loads `config.yaml` if it exists. Runtime environment variables can override specific values for the current shell or launched process.
+
+The practical model is:
+
+1. Built-in defaults provide safe behavior.
+2. `config.defaults.yaml` supplies managed defaults.
+3. `config.yaml` supplies user preferences.
+4. Environment variables apply temporary runtime overrides.
+
+For ordinary scalar settings, `config.yaml` can override `config.defaults.yaml`. Some settings are intentionally policy-like when they come from `config.defaults.yaml`:
+
+- `local_ui.auto_start: false` disables automatic local-ui startup even if `config.yaml` sets it back to `true`. Manual `trajectory local-ui` and `trajectory view` commands still work.
+- `required_destinations` describes managed publish destinations that user and project configuration cannot remove.
+
+Project files named `publish.trajectory.yaml` are separate from the user config. They can add trusted publish destinations when allowed by `publish_trust`, but they do not replace `config.yaml` and should not be used for general capture, local UI, or identity settings.
+
+## Common Settings
+
+```bash
+trajectory config set export.site datadoghq.com
+trajectory config set export.traces standard       # off | minimal | standard | full
+trajectory config set export.metrics true
+trajectory config set export.placeholder_llm_span false
+trajectory config set local_ui.auto_start false
+trajectory config set capture.retention_days 30
+trajectory config set-secret dd-api-key            # prompts securely
+```
+
+Trace export is off by default. Set `export.traces` explicitly when you want sessions published to Datadog LLM Observability.
+
+Metrics export defaults to `true`, but still needs a working Datadog destination and credentials before points can be submitted.
+
+## Example User Config
+
+This is a typical `~/.trajectory/config.yaml` for a user who wants local capture, Datadog metrics, and standard LLM Observability traces:
+
+```yaml
+export:
+  site: datadoghq.com
+  traces: standard
+  metrics: true
+  placeholder_llm_span: true
+
+local_ui:
+  auto_start: true
+
+capture:
+  retention_days: 30
+
+segmentation:
+  enabled: true
+```
+
+Prefer `trajectory config set` for routine edits so Trajectory preserves the expected shape and validates values.
+
+## Example Managed Defaults
+
+`config.defaults.yaml` is useful when an installation should start from the same defaults on many machines.
+
+```yaml
+export:
+  site: datadoghq.com
+  traces: off
+  metrics: true
+
+local_ui:
+  auto_start: false
+
+capture:
+  retention_days: 30
+```
+
+In this example, users may still opt in to trace export from `config.yaml`, but automatic local-ui startup remains disabled because a managed `false` value is authoritative for that setting.
+
+## Export And Credentials
+
+Set the Datadog site, store an API key, and validate the publish configuration:
+
+```bash
+trajectory config set export.site datadoghq.com
+trajectory config set-secret dd-api-key
+trajectory config set export.traces standard
+trajectory config set export.metrics true
+trajectory publish validate
+```
+
+Use OS keychain storage for secrets. Avoid putting API keys or provider keys in YAML files.
+
+For temporary shells and CI-style runs, environment variables can provide credentials:
+
+```bash
+DD_API_KEY=... trajectory publish validate
+```
+
+## Local Capture Without Remote Export
+
+To keep local JSONL capture and the local viewer while disabling remote export:
+
+```bash
+trajectory config set export.traces off
+trajectory config set export.metrics false
+```
+
+Captured JSONL remains under `~/.trajectory/trajectories/` unless you also disable capture for a launched process.
+
+For one command where nothing should be recorded:
+
+```bash
+TRAJECTORY_DISABLED=1 claude "review this repo without recording"
+```
+
+For session privacy where local capture should continue, use `/incognito` inside the agent session. See [PRIVACY.md](PRIVACY.md).
+
+## LLM Capacity Controls
+
+Most capture, marker evaluation, local UI, and Datadog publish paths do not ask another LLM to process a session. The default features that may consume additional LLM capacity are task segmentation and sensitivity classification.
+
+Disable both Trajectory-owned LLM paths:
+
+```bash
+trajectory config set segmentation.enabled false
+trajectory config set export.sensitivity.scanning_mode off
+```
+
+For more detail, see [LLM-CAPACITY.md](LLM-CAPACITY.md).
+
+## Identity Tags
+
+Every exported span and metric includes `trajectory.user`, resolved from `TRAJECTORY_USER` or the system username.
+
+Optional identity fields add `trajectory.user_email`, `github.email`, and `github.username` when values can be resolved:
+
+```bash
+trajectory config set identity.user_email_suffix example.com
+trajectory config set identity.github_username your-github-username
+```
+
+GitHub identity can also resolve from repository-local Git config and then global Git config.
+
+## Environment Overrides
+
+Environment variables are best for temporary overrides, CI jobs, or one launched command.
+
+| Variable | Effect |
+|---|---|
+| `TRAJECTORY_HOME` | Move Trajectory files to a different directory |
+| `TRAJECTORY_PORT` | Override `server.port` |
+| `DD_SITE` | Override `export.site` |
+| `DD_API_KEY` | Provide a Datadog API key without editing config |
+| `TRAJECTORY_SEGMENTATION_DISABLED=1` | Disable segmentation for the current runtime |
+| `TRAJECTORY_ROOT` | Change where trajectory JSONL files are written |
+| `TRAJECTORY_DEBUG=1` | Enable verbose logging |
+| `TRAJECTORY_AUTO_UPDATE=0` | Disable startup auto-update checks |
+| `TRAJECTORY_DISABLED=1` | Disable capture for the launched process |
+| `TRAJECTORY_USER` | Override the `trajectory.user` tag |
+| `TRAJECTORY_USER_EMAIL` | Override `trajectory.user_email` |
+| `TRAJECTORY_GITHUB_EMAIL` | Override `github.email` |
+| `TRAJECTORY_GITHUB_USERNAME` | Override `github.username` |
+
+## Frequently Edited Keys
+
+| Key | Default | What it controls |
+|---|---|---|
+| `deployment.ring` | `stable` | Release channel for updates, usually `stable` or `beta` |
+| `server.port` | `19222` | Local capture server port |
+| `local_ui.auto_start` | `true` | Automatic local-ui startup from non-manual flows |
+| `capture.redact_pii` | `true` | PII redaction in captured content |
+| `capture.retention_days` | `30` | Local JSONL retention in days; `0` keeps files indefinitely |
+| `export.site` | site selected during setup | Datadog site, such as `datadoghq.com`, `us5.datadoghq.com`, or `datadoghq.eu` |
+| `export.ml_app` | `coding-agents` for implicit destinations | LLM Observability ML app name |
+| `export.traces` | `off` | LLM Observability trace export level: `off`, `minimal`, `standard`, or `full` |
+| `export.metrics` | `true` | Cost, token, marker, and operations metric export |
+| `export.placeholder_llm_span` | `true` | Synthetic LLM child span for turn-level token and cost enrichment |
+| `export.sensitivity.scanning_mode` | `balanced` | Sensitivity classification mode: `balanced`, `near_realtime`, or `off` |
+| `segmentation.enabled` | `true` | Async task segmentation |
+| `segmentation.interval` | `10` | Number of turns between segmentation passes |
+| `segmentation.publish_metrics` | `false` | Publish task-derived segmentation metrics |
+| `segmentation.publish_traces` | `false` | Publish segmentation task traces and logs |
+| `publish_trust.allowed_origins` | empty | Git origins allowed to load project `publish.trajectory.yaml` overlays |
+| `publish_trust.require_committed` | `false` | Require project publish configs to be git-tracked |
+| `publish_trust.allowed_sites` | empty | Optional Datadog site allowlist for project-created destinations |
+| `cross_client_resume.enabled` | `false` | Enable cross-client transcript reconstruction |
+
+## Troubleshooting
+
+If a config value does not seem to apply:
+
+1. Run `trajectory config show` and check the effective value.
+2. Run `trajectory config path` and confirm you edited the file Trajectory is reading.
+3. Check for environment variables such as `TRAJECTORY_HOME`, `DD_SITE`, or `TRAJECTORY_PORT`.
+4. Check whether `config.defaults.yaml` exists and provides a managed value.
+5. If a project `publish.trajectory.yaml` is involved, confirm the project origin is allowed by `publish_trust`.
+6. Run `trajectory doctor` for a broader diagnostic report.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -39,6 +39,10 @@ trajectory config set-secret <name>  # Store a secret in the OS keychain
 trajectory config get <key>          # Read a single value
 ```
 
+Most users edit `~/.trajectory/config.yaml` through `trajectory config set`. Installers or administrators may provide `~/.trajectory/config.defaults.yaml` to seed managed defaults, and environment variables can override specific values for the current shell or launched process.
+
+See [CONFIGURATION.md](CONFIGURATION.md) for the full config file model, examples, `config.defaults.yaml` behavior, environment overrides, and common settings.
+
 Common settings:
 
 ```bash
@@ -54,7 +58,7 @@ Trace export is off by default. Set `export.traces` explicitly when you want ses
 
 Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml`, or `placeholder_llm_span: false` on a managed/trusted `publish.trajectory.yaml` destination, to stop publishing Trajectory's synthetic LLM child span for turn-level token/cost enrichment. The turn span still carries `metrics.estimated_total_cost` plus cost fallback metadata and the `trajectory.cost_source:turn_metrics` tag, so cost remains queryable without the placeholder child span. Project configs may disable this for a trusted destination, but cannot re-enable it if the trusted or managed destination disabled it.
 
-For fleet-wide local-ui auto-start rollback, deploy `local_ui.auto_start: false` in managed `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` and `trajectory view` commands still work.
+For managed local-ui auto-start rollback, deploy `local_ui.auto_start: false` in `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` and `trajectory view` commands still work.
 
 ## Capture server
 


### PR DESCRIPTION
## Summary
- add a public configuration guide covering config files, managed defaults, environment overrides, and common settings
- link the guide from the README and user guide
- clarify how config.defaults.yaml, config.yaml, environment variables, and project publish overlays interact

Docs-only update.