### PR TITLE
Improve public product docs

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,7 +3,6 @@ actions/checkout@v4,https://github.com/actions/checkout,MIT,See upstream license
 @types/node@^22.19.0,https://www.npmjs.com/package/@types/node,MIT,See upstream license notice
 fastmcp>=3.2.4,https://pypi.org/project/fastmcp/,Apache-2.0,See upstream license notice
 mcp>=1.26.0,https://pypi.org/project/mcp/,MIT,See upstream license notice
-openclaw>=2026.5.21,https://www.npmjs.com/package/openclaw,MIT,See upstream license notice
 PyYAML>=6.0,https://pypi.org/project/PyYAML/,MIT,See upstream license notice
 typescript@^5.9.0,https://www.npmjs.com/package/typescript,Apache-2.0,See upstream license notice
 cel.dev/expr@v0.25.1,https://cel.dev/expr,Apache-2.0,See upstream license notice

--- a/README.md
+++ b/README.md
@@ -1,51 +1,97 @@
 # Trajectory
 
-Trajectory is Datadog's observability layer for AI coding agents. It turns local
-agent sessions into inspectable timelines, behavioral signals, operational
-metrics, and Datadog LLM Observability traces so teams can understand what their
-agents are doing, how much they cost, where they get stuck, and which workflows
-are working.
+Observe AI coding agents like production systems.
 
-Trajectory instruments coding-agent workflows at the client boundary: hooks,
-watchers, plugin runtimes, and MCP surfaces capture session lifecycle, turns,
-tool calls, model usage, token and cost signals, repository context, and
-attribution metadata. You get a local record first, then optional Datadog export
-when configured.
+See the whole run. Measure the behavior. Improve the workflow.
 
-## Why Trajectory
+Trajectory captures coding-agent sessions across Claude Code, Codex, Gemini,
+Cursor, Pi, OpenCode, GitHub Copilot CLI, and Factory Droid, then turns them
+into local timelines, Datadog LLM Observability traces, operational metrics,
+and Markers: programmable signals for how agents work.
 
-AI coding agents are becoming part of the software delivery loop, but their work
-is often hard to inspect after the terminal scrolls away. Trajectory gives that
-work an observability model:
+## What It Answers
 
-- What did the agent do during the session?
-- Which tools, files, repositories, commits, and pull requests were involved?
-- How much did the session cost, and where did time go?
-- Did the workflow show signs of retries, confusion, repeated failures, or
-  successful task completion?
-- Which behavior patterns are improving or regressing across users and teams?
+- What happened in this session?
+- Where did time, tokens, and cost go?
+- Which repos, files, commits, and pull requests were involved?
+- Did the agent make progress, loop, retry, or stall?
+- Which agent workflows are improving across users and teams?
 
-## Feature Highlights
+## Markers
 
-- **Markers**: a flagship YAML-based signal layer for detecting workflow
-  patterns across turns, sessions, tasks, commits, and pull requests. Marker
-  results can be inspected locally and exported as Datadog metrics, making
-  qualitative agent behavior measurable over time.
-- **Multi-client instrumentation**: capture from Claude Code, Codex CLI, Gemini
-  CLI, Cursor, Pi, OpenCode, GitHub Copilot CLI beta, and Factory Droid beta
-  with client-specific hooks, watchers, plugins, and backfill paths.
-- **Datadog-native export**: publish configurable LLM Observability traces and
-  operational metrics for tokens, cost, duration, tool use, capture health,
-  marker results, and attribution workflows.
-- **Local investigation loop**: inspect sessions with `trajectory status`,
-  `trajectory view`, diagnostics, support bundles, MCP tools, and historical
-  backfill before deciding what to export.
-- **Privacy and capacity controls**: use `/incognito`, local-only capture,
+Markers are Trajectory's signature feature: YAML-defined measurements for agent
+behavior. Write a rule once, then evaluate it across turns, sessions, tasks,
+commits, and pull requests.
+
+Example: add this to `.trajectory/markers.yaml` in a repo to turn an agent
+force-push into a measurable signal.
+
+```yaml
+version: 2
+
+points:
+  - name: force-push
+    description: Agent force-pushed to a remote
+    severity: warn
+    confidence: high
+    emit: metric
+    scope: session
+    match:
+      tool: [Bash, Shell, exec_command, run_shell]
+      command: '(?i)^git\s+push\b.*--force'
+      not_input: '--force-with-lease'
+
+measures:
+  - name: force-pushes
+    scope: session
+    count:
+      point: force-push
+```
+
+How it works:
+
+- `points` define behavior to detect. This point watches shell-like tool calls
+  for `git push --force`.
+- `not_input` excludes the safer `--force-with-lease` path.
+- `emit: metric` makes the point eligible for marker metric export.
+- `scope: session` says the signal describes the session, not just one turn.
+- `measures` turns point hits into a count named `force-pushes`.
+
+When the command appears in a captured session, Trajectory records a
+`force-push` marker and can publish `trajectory.session.force_pushes` plus a
+completed-session count metric. Raw behavior becomes something you can query by
+repo, team, environment, or release workflow.
+
+Use Markers to detect patterns such as:
+
+- retry loops
+- repeated failures
+- tool thrash
+- context churn
+- approval friction
+- cost spikes
+- task progress
+- pull-request attribution
+
+Marker results are available locally and can be exported as Datadog metrics, so
+agent behavior becomes something you can graph, alert on, compare, and improve.
+
+## Core Capabilities
+
+- **Multi-client instrumentation** for Claude Code, Codex CLI, Gemini CLI,
+  Cursor, Pi, OpenCode, GitHub Copilot CLI beta, and Factory Droid beta.
+- **Local-first timelines** for session lifecycle, turns, tool calls, model
+  usage, cost signals, and repository context.
+- **Datadog-native export** for configurable LLM Observability traces and
+  operational metrics for tokens, cost, duration, tool use, capture health, and
+  attribution workflows.
+- **Investigation tools** including `trajectory status`, `trajectory view`,
+  diagnostics, support bundles, MCP tools, and historical backfill.
+- **Privacy and capacity controls** including `/incognito`, local-only capture,
   sensitivity scanning, configurable trace detail, and controls for
   Trajectory-owned LLM calls.
-- **Workflow attribution**: connect agent activity to repositories, commits,
-  pull requests, and completed-session samples so agent impact can be explored
-  alongside delivery outcomes.
+- **Workflow attribution** across repositories, commits, pull requests, and
+  completed-session samples.
 
 ## Install
 

--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -26,7 +26,6 @@ trajectory user-guide clients
 | Factory Droid | `trajectory setup --clients droid` | Beta Factory command hooks plus MCP | None |
 | Pi | `trajectory setup --clients pi` | TypeScript extension plus eager MCP | Pi/OMP session backfill |
 | OpenCode | `trajectory setup --clients opencode` | OpenCode plugin SDK events plus MCP | SQLite backfill |
-| OpenClaw | Plugin package plus optional-client binary | Beta OpenClaw plugin SDK hooks | None |
 
 ## Shared Local Flow
 
@@ -186,16 +185,6 @@ directory.
 The plugin SDK events cover chat messages, tool execution before/after events,
 and lifecycle events. Historical import uses OpenCode SQLite databases. OpenCode
 does not install a `hooks.json` file.
-
-## OpenClaw
-
-OpenClaw support is a live-capture beta. It is not included in default
-Trajectory binaries; build with `-tags optionalclients` and install the
-`plugin/trajectory-openclaw` package through OpenClaw's plugin system.
-
-The plugin maps OpenClaw lifecycle, model, tool, compaction, and session hooks
-to `/capture/openclaw/...`. Backfill, resume, MCP, and setup-managed install are
-out of scope for the current beta.
 
 ## Troubleshooting
 

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -27,7 +27,6 @@ trajectory user-guide clients/codex
 | Factory Droid | `trajectory setup --clients droid` | Beta | Factory plugin command hooks + MCP |
 | Pi | `trajectory setup --clients pi` | Beta | TypeScript extension + MCP |
 | OpenCode | `trajectory setup --clients opencode` | Beta | Plugin SDK events + MCP |
-| OpenClaw | OpenClaw plugin package + optional-client binary | Beta | Plugin SDK hooks + runtime binary resolver |
 
 ## Feature Coverage Matrix
 
@@ -35,29 +34,19 @@ trajectory user-guide clients/codex
 |--------|--------------|-------------------|------------------|------------------|----------|--------|
 | Claude Code | Yes, HTTP hooks | Yes | Yes | Yes | Transcript backfill | Yes |
 | Codex CLI | Yes, command hooks plus rollout watcher fallback | Yes | Yes | Yes | Codex rollout backfill | Yes |
+| GitHub Copilot CLI | Yes, beta plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Gemini CLI | Yes, managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
 | Cursor Desktop | Yes, command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
 | cursor-agent CLI | Yes, transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
+| Factory Droid | Yes, beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Pi | Yes, TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Yes, plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
-| OpenClaw | Capture beta, plugin SDK hooks | Yes, with conversation access for prompts/responses | Token usage when OpenClaw hook payloads expose it; cost is estimated downstream or passed through when present | Not yet | Not yet | Not in scope |
-
-OpenClaw support in this repository is intentionally scoped to live capture for
-now. The server-side endpoint is excluded from default Trajectory binaries and
-compiled only with the neutral `optionalclients` build tag. It adds a
-Trajectory `/capture/openclaw` endpoint and a plugin package that maps OpenClaw
-hooks into canonical Trajectory events; it does not add OpenClaw historical
-import, setup-managed install, or resume support.
 
 ## Recommended vs Manual Installs
 
 `trajectory setup --clients ...` is the recommended path for normal installs because it wires the plugin together with the companion config each client expects: hooks, MCP entries, skills, commands, local binaries, and local marketplace metadata.
 
 Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, or the capture hooks needed for complete telemetry.
-
-OpenClaw is the current exception: its plugin package plus a Trajectory binary
-built with `-tags optionalclients` is the supported beta install surface for
-live capture until setup-managed install is added.
 
 ## Codex CLI
 
@@ -245,44 +234,6 @@ Manual fallback: copy `plugin/trajectory-opencode` to `~/.config/opencode/plugin
 
 **Source:** [github.com/anomalyco/opencode](https://github.com/anomalyco/opencode)
 
-## OpenClaw
-
-**Status: Capture beta** (live capture path: OpenClaw plugin hooks)
-
-OpenClaw uses a plugin SDK with typed lifecycle, model, tool, compaction, and
-session hooks. The Trajectory plugin lives in `plugin/trajectory-openclaw` and
-maps those hooks into `/capture/openclaw/...` so events are attributed as
-`client_source=openclaw`.
-
-The npm or ClawHub package installs the JavaScript plugin; the Go `trajectory`
-binary remains a separate executable and must include the optional-client build
-tag. At runtime, the plugin prefers a configured `captureUrl`, then a
-configured or existing binary, then `~/.trajectory/bin/trajectory`, then
-`trajectory` on `PATH`. `binaryInstallMode=auto` is explicit opt-in and should
-only target a release channel that publishes optional-client binaries.
-
-For full prompt, response, token, and cost capture, external OpenClaw installs
-must opt in to raw conversation hooks:
-
-```json
-{
-  "plugins": {
-    "entries": {
-      "trajectory-openclaw": {
-        "hooks": {
-          "allowConversationAccess": true
-        }
-      }
-    }
-  }
-}
-```
-
-Backfill and resume are intentionally out of scope for this plugin. The
-OpenClaw plugin is scoped to live capture; historical OpenClaw session import,
-sidecar import, and any future resume adapter should be implemented under
-Trajectory CLI packages rather than hidden in plugin startup.
-
 ## Version Check
 
 To verify your client version:
@@ -296,5 +247,4 @@ cursor --version          # Cursor (desktop) / cursor-agent --version (CLI)
 droid --version           # Factory Droid
 pi --version              # Pi
 opencode --version        # OpenCode (note: takes cwd as argument)
-openclaw --version        # OpenClaw
 ```

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -122,17 +122,13 @@ trajectory setup --uninstall codex   # Remove one client integration
 |--------|--------------|-------------------|------------------|------------------|----------|--------|
 | Claude Code | HTTP hooks | Yes | Yes | Yes | Transcript backfill | Yes |
 | Codex CLI | Command hooks plus rollout watcher fallback | Yes | Yes | Yes | Codex rollout backfill | Yes |
+| GitHub Copilot CLI | Beta Copilot plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Gemini CLI | Managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
 | Cursor Desktop | Command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
 | cursor-agent CLI | Transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
 | Factory Droid | Beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Pi | TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
-| OpenClaw | Capture beta plugin hooks with optional-client binary | Yes, with conversation access for prompts/responses | Token usage when OpenClaw exposes it; cost estimated downstream or passed through when present | Not yet | Not yet | Not in scope |
-
-OpenClaw is live-capture only in the current beta and is installed through its
-OpenClaw plugin package, not `trajectory setup`. Default Trajectory binaries
-omit this route; use a binary built with `-tags optionalclients`.
 
 ## Publishing and export
 


### PR DESCRIPTION
## Summary
- make the README opening shorter and more direct
- add a concrete Marker configuration example and explain how it works
- refresh supported-client docs to match the default public install surface
- keep the public docs reference consistent across README, user guide, and client instrumentation docs

Docs-only update.