### PR TITLE
Refresh v0.5.6 public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 - [docs/CONFIGURATION.md](docs/CONFIGURATION.md): config files, managed defaults, environment overrides, and common settings
 - [docs/SUPPORTED-CLIENTS.md](docs/SUPPORTED-CLIENTS.md): supported coding-agent clients and version requirements
 - [docs/CLIENT-INSTRUMENTATION.md](docs/CLIENT-INSTRUMENTATION.md): per-client hook, watcher, MCP, and backfill surfaces
+- [docs/COSTS.md](docs/COSTS.md): local cost summaries, turn evidence, objective observations, and fidelity checks
 - [docs/PRIVACY.md](docs/PRIVACY.md): incognito, sensitive tags, and sensitivity scanning
 - [docs/LLM-CAPACITY.md](docs/LLM-CAPACITY.md): which features use additional LLM capacity and how to control them
 - [docs/METRICS-REFERENCE.md](docs/METRICS-REFERENCE.md): emitted metric names, types, tags, and query guidance

--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -50,7 +50,11 @@ for the client:
   expects one.
 
 Plugin-only manual installs can miss these companion pieces. Use
-`trajectory setup --clients <client>` for normal installs.
+`trajectory setup --clients <client>` for normal installs and refreshes. That
+client-only path updates hooks, MCP entries, skills, commands, local binaries,
+and local marketplace files without prompting for Datadog site, service name,
+or API key values. Run `trajectory setup` without `--clients` when you want to
+change export settings.
 
 The authoritative MCP catalog, including safe query examples, is embedded in
 the binary:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,7 +113,20 @@ trajectory config set export.metrics true
 trajectory publish validate
 ```
 
-Use OS keychain storage for secrets. Avoid putting API keys or provider keys in YAML files.
+`trajectory publish validate` prints credential source and non-secret
+value-shape diagnostics for each destination. A healthy Datadog API key reports
+`normalized_shape=datadog-api-key` and `valid_format=true`. If
+`valid_format=false`, re-enter the API key with `trajectory config set-secret
+dd-api-key` or fix the `DD_API_KEY` or `api_key_command` source.
+
+Use OS keychain storage for secrets. Avoid putting API keys or provider keys in
+YAML files.
+
+`trajectory config set-secret` updates keychain values defensively: it checks
+for an existing value first, writes the new value, and attempts to restore the
+previous value if the write fails. If setup or `set-secret` reports a keychain
+problem, recover with `trajectory config set-secret dd-api-key`, or set
+`DD_API_KEY` temporarily and run `trajectory publish validate`.
 
 For temporary shells and CI-style runs, environment variables can provide credentials:
 

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -1,0 +1,79 @@
+# Cost Tracking
+
+Trajectory records local token and cost telemetry for supported coding-agent
+sessions. Use `trajectory cost` when you want a local, read-only cost view
+without querying Datadog or inferring invoice totals.
+
+## Commands
+
+```bash
+trajectory cost
+trajectory cost top --since 7d
+trajectory cost inspect --session <session-id>
+trajectory cost observations --session <session-id>
+trajectory cost validate --since 7d
+```
+
+`trajectory cost` shows a recent summary by agent and the highest-cost local
+sessions in the selected window. Use `--since all`, `--since 24h`, or
+`--since 2026-06-01` when you need a different window.
+
+`trajectory cost inspect --session <session-id>` shows turn-level cost evidence:
+cost, model, token counts, tool counts, and cost provenance. This is the best
+first command when a session looks expensive or unexpectedly cheap.
+
+`trajectory cost observations --session <session-id>` reports objective
+local-cache observations. It does not claim root cause or waste. Examples
+include the highest-cost turn, dominant model by recorded cost, cost source mix,
+failed or denied tool counts, and token-positive turns that recorded zero cost.
+
+`trajectory cost validate` checks recent sessions for the six main supported
+agents: Claude Code, Codex, Gemini, Pi, OpenCode, and Cursor. It reports whether
+each agent has recent data, positive recorded turn costs, zero-cost turns with
+tokens, and the observed cost sources.
+
+## Cost Sources
+
+Turn rows include provenance columns when the cache has them:
+
+- `cost_source`: where the turn cost came from, such as
+  `native:materialized_token_usage`, `token_derived:materialized`, or
+  `content_length_estimate`.
+- `token_source`: where token counts came from.
+- `tokens_status`: whether token counts were real, corrected, estimated, or
+  unavailable.
+
+These fields are important for fidelity. A cost number is more useful when you
+can tell whether it came from a native agent field or from token-derived
+pricing.
+
+## Objective Observations
+
+`trajectory cost observations` intentionally uses objective language. It should
+say what the local cache shows, not why the agent behaved that way.
+
+Good observations:
+
+- "Turn 14 accounted for 41% of recorded session cost."
+- "Model claude-opus-4 accounted for 72% of recorded session cost."
+- "The session recorded 6 failed tool calls and 1 denied tool call."
+- "2 turns have token counts but recorded zero cost."
+
+Avoid treating these as causal explanations by themselves. A high-cost turn may
+reflect a genuinely difficult task. The command is meant to give evidence that a
+human or agent can inspect further.
+
+## JSON Output
+
+Every subcommand supports `--json` for agents and scripts:
+
+```bash
+trajectory cost --json
+trajectory cost inspect --session <session-id> --json
+trajectory cost observations --session <session-id> --json
+trajectory cost validate --json
+```
+
+The command reads the local SQLite cache in read-only mode. Override the cache
+path with `--db <path>` or `TRAJECTORY_CACHE_DB` when inspecting an isolated
+test cache.

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -80,11 +80,13 @@ unattributed.
 | `ml_app` | Destination ML app | Omitted |
 | `gen_ai.request.model` | Model name | Omitted |
 | `trajectory.client_version` | Client or harness version | Omitted |
+| `repo` | Git repository name from the remote origin, or project directory basename when the origin is unavailable | `unknown` |
+| `owner` | Git repository owner from the remote origin | `unknown` |
+| `git_remote_host` | Git remote host from the remote origin | `unknown` |
 | `project_dir` | Project directory basename | Omitted |
 | `trajectory.trace_type` | Metric grain: `turn`, `session`, `task`, `commit`, or `pr` | Set by emitter |
 
-Destination tags and repo-derived tags such as `repo`, `owner`, and
-`git_remote_host` may also be present. Keep custom tags low-cardinality and
+Destination tags may also be present. Keep custom tags low-cardinality and
 non-sensitive.
 
 ## Per-Turn Metrics
@@ -190,7 +192,7 @@ Built-in and setup-default metrics include:
 | `trajectory.session.skill_invocations` | gauge | session | Skill activity grouped by `skill_name` |
 | `trajectory.session.subagents` | gauge | session | Setup-default subagent count |
 | `trajectory.session.tests_written` | gauge | session | Setup-default new-test count |
-| `trajectory.session.test_success_rate` | gauge | session | Setup-default Bazel retry success ratio |
+| `trajectory.session.test_success_rate` | gauge | session | Setup-default test retry success ratio |
 | `trajectory.session.force_pushes` | gauge | session | Setup-default force-push count |
 | `trajectory.session.ci_iterations` | gauge | session | Setup-default CI feedback ranges |
 | `trajectory.session.code_added` | gauge | session | Setup-default code-change count |

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -42,9 +42,19 @@ trajectory user-guide clients/codex
 | Pi | Yes, TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Yes, plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
 
+For local cost readback and supported-agent fidelity checks, run `trajectory
+cost`, `trajectory cost inspect --session <id>`, and `trajectory cost
+validate`. The validation command reports recent cost coverage for supported
+clients, including token-positive turns that recorded zero cost.
+
 ## Recommended vs Manual Installs
 
-`trajectory setup --clients ...` is the recommended path for normal installs because it wires the plugin together with the companion config each client expects: hooks, MCP entries, skills, commands, local binaries, and local marketplace metadata.
+`trajectory setup --clients ...` is the recommended path for normal installs
+and refreshes because it wires the plugin together with the companion config
+each client expects: hooks, MCP entries, skills, commands, local binaries, and
+local marketplace metadata. It skips Datadog site, service name, and API key
+prompts, so it is also the right path when you only want to add, repair, or
+update one client integration.
 
 Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, or the capture hooks needed for complete telemetry.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -6,6 +6,7 @@ Trajectory captures sessions from AI coding agents and exports them to Datadog L
 
 ```bash
 trajectory status                    # Terminal dashboard with session metrics
+trajectory cost                      # Local cost summary and top sessions
 trajectory view                      # Open the local browser viewer
 trajectory doctor                    # Diagnose issues (binary, config, hooks, data)
 trajectory diagnose publish          # Explain capture, local mapping, and publish expectations
@@ -56,6 +57,11 @@ trajectory config set-secret dd-api-key             # prompts for the key secure
 
 Trace export is off by default. Set `export.traces` explicitly when you want sessions published to LLM Observability.
 
+Secret writes are defensive: `trajectory setup` and `trajectory config
+set-secret` snapshot an existing keychain value before updating it and attempt
+to restore the old value if the write fails. Recover a missing Datadog key with
+`trajectory config set-secret dd-api-key` or a temporary `DD_API_KEY`.
+
 Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml`, or `placeholder_llm_span: false` on a managed/trusted `publish.trajectory.yaml` destination, to stop publishing Trajectory's synthetic LLM child span for turn-level token/cost enrichment. The turn span still carries `metrics.estimated_total_cost` plus cost fallback metadata and the `trajectory.cost_source:turn_metrics` tag, so cost remains queryable without the placeholder child span. Project configs may disable this for a trusted destination, but cannot re-enable it if the trusted or managed destination disabled it.
 
 For managed local-ui auto-start rollback, deploy `local_ui.auto_start: false` in `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` and `trajectory view` commands still work.
@@ -76,8 +82,12 @@ The server starts automatically when your agent launches a session (via plugin h
 ```bash
 trajectory status                    # Overview of recent sessions
 trajectory status --session <id> --json
+trajectory cost inspect --session <id>
+trajectory cost observations --session <id>
+trajectory cost validate
 trajectory view --session <id>
 trajectory user-guide query          # Local data and safe MCP query workflow
+trajectory user-guide costs          # Cost tracking commands and fidelity checks
 ```
 
 The current OSS binary does not expose a general-purpose `trajectory query`
@@ -85,6 +95,11 @@ CLI. Use `trajectory status`, `trajectory view`, `get_session_trajectory`, and
 the MCP `trajectory_schema` / `trajectory_query` tools for local inspection.
 The embedded query guide documents the schema-first workflow and
 `TRAJECTORY_CACHE_DB` handling.
+
+Use `trajectory cost` for local cost tracking. It reads the local SQLite cache
+in read-only mode, shows recent cost totals, inspects turn-level cost evidence,
+reports objective cost observations without causal claims, and validates recent
+cost fidelity for supported clients. See [COSTS.md](COSTS.md).
 
 ## MCP tools
 
@@ -109,12 +124,18 @@ trajectory user-guide mcp
 
 ```bash
 trajectory setup                     # Interactive setup (site, API key, agents)
-trajectory setup --clients codex     # Register one client integration
-trajectory setup --clients copilot   # Register GitHub Copilot CLI beta live capture
-trajectory setup --clients droid     # Register Factory Droid beta live capture
-trajectory setup --clients all       # Register all setup-managed clients
+trajectory setup --clients codex     # Add or refresh one client integration
+trajectory setup --clients copilot   # Add or refresh GitHub Copilot CLI beta live capture
+trajectory setup --clients droid     # Add or refresh Factory Droid beta live capture
+trajectory setup --clients all       # Add or refresh all setup-managed clients
 trajectory setup --uninstall codex   # Remove one client integration
 ```
+
+`trajectory setup --clients ...` updates only client wiring. It skips Datadog
+site, service name, and API key prompts, and leaves existing export config
+unchanged. If no config file exists yet, it creates a capture-only config so
+local session capture can start; run `trajectory setup` later to configure
+Datadog export.
 
 ### Feature coverage matrix
 
@@ -139,7 +160,7 @@ trajectory publish preview           # Preview what would be published
 trajectory diagnose publish          # Explain whether traces/metrics should publish
 ```
 
-`trajectory publish validate` checks configuration, trust policy, and credentials. `trajectory publish status` shows the effective mode, including metrics-only and trace-off states. Neither command verifies Datadog intake or readback.
+`trajectory publish validate` checks configuration, trust policy, and credentials, including credential source and non-secret value-shape diagnostics. `trajectory publish status` shows the effective mode, including metrics-only and trace-off states. Neither command verifies Datadog intake or readback.
 
 For the publish operations runbook covering validate/status/preview, missing
 Datadog data, `publish sync`, and publish ledger repair:
@@ -331,7 +352,10 @@ Trajectory automatically tags every DD metric with repository metadata extracted
 - `owner` - org or user (e.g., `DataDog`)
 - `git_remote_host` - host (e.g., `github.com`)
 
-These tags appear on all metric series, so you can filter and group by repository in Metrics Explorer without any configuration.
+These tags appear on all metric series, so you can filter and group by
+repository in Metrics Explorer without any configuration. When a remote origin
+is unavailable, Trajectory falls back to the project directory basename for
+`repo` when possible and uses `unknown` for unavailable owner or host values.
 
 ## Completed-sample distributions
 


### PR DESCRIPTION
## Summary
- add a public cost tracking guide for v0.5.6
- refresh client setup docs for client-only install and repair flows
- document credential validation and repository metric tag fallback behavior

Docs-only update.