### PR TITLE
Release v0.5.7

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.6",
-    "tag": "v0.5.6",
-    "released_at": "2026-06-03T19:12:27Z"
+    "version": "0.5.7",
+    "tag": "v0.5.7",
+    "released_at": "2026-06-04T16:42:02Z"
   },
   "beta": {
-    "version": "0.5.6",
-    "tag": "v0.5.6",
-    "released_at": "2026-06-03T19:12:27Z"
+    "version": "0.5.7",
+    "tag": "v0.5.7",
+    "released_at": "2026-06-04T16:42:02Z"
   }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,7 +117,8 @@ trajectory publish validate
 value-shape diagnostics for each destination. A healthy Datadog API key reports
 `normalized_shape=datadog-api-key` and `valid_format=true`. If
 `valid_format=false`, re-enter the API key with `trajectory config set-secret
-dd-api-key` or fix the `DD_API_KEY` or `api_key_command` source.
+dd-api-key` or fix the `DD_API_KEY`, `DATADOG_API_KEY`, or `api_key_command`
+source.
 
 Use OS keychain storage for secrets. Avoid putting API keys or provider keys in
 YAML files.
@@ -126,13 +127,37 @@ YAML files.
 for an existing value first, writes the new value, and attempts to restore the
 previous value if the write fails. If setup or `set-secret` reports a keychain
 problem, recover with `trajectory config set-secret dd-api-key`, or set
-`DD_API_KEY` temporarily and run `trajectory publish validate`.
+`DD_API_KEY` or `DATADOG_API_KEY` temporarily and run `trajectory publish
+validate`.
 
 For temporary shells and CI-style runs, environment variables can provide credentials:
 
 ```bash
 DD_API_KEY=... trajectory publish validate
+DATADOG_API_KEY=... trajectory publish validate
 ```
+
+Standard publish credential lookup order:
+
+1. Environment variable derived from the configured key ref, then `DD_API_KEY`,
+   then `DATADOG_API_KEY`.
+2. Default key provider from `auth.key_command`, for the default Datadog ref.
+3. OS keychain account matching the key ref.
+4. Destination `api_key_command`.
+
+Set `auth.credential_source` when you need to force one standard source and
+stop fallback. Valid values are `auto`, `env`, `key_provider`, `keychain`, and
+`api_key_command`:
+
+```bash
+trajectory config set auth.credential_source keychain
+trajectory config set auth.credential_source auto
+```
+
+`trajectory doctor`, `trajectory publish validate`, and serve logs report the
+active policy, resolved source, and non-secret value shape. Serve also warns at
+startup when `auto` mode would select a malformed Datadog env var, before the
+first publish attempt.
 
 ## Local Capture Without Remote Export
 
@@ -189,6 +214,7 @@ Environment variables are best for temporary overrides, CI jobs, or one launched
 | `TRAJECTORY_PORT` | Override `server.port` |
 | `DD_SITE` | Override `export.site` |
 | `DD_API_KEY` | Provide a Datadog API key without editing config |
+| `DATADOG_API_KEY` | Provide a Datadog API key without editing config |
 | `TRAJECTORY_SEGMENTATION_DISABLED=1` | Disable segmentation for the current runtime |
 | `TRAJECTORY_ROOT` | Change where trajectory JSONL files are written |
 | `TRAJECTORY_DEBUG=1` | Enable verbose logging |
@@ -204,6 +230,7 @@ Environment variables are best for temporary overrides, CI jobs, or one launched
 | Key | Default | What it controls |
 |---|---|---|
 | `deployment.ring` | `stable` | Release channel for updates, usually `stable` or `beta` |
+| `auth.credential_source` | `auto` | Pin standard Datadog credential resolution to `env`, `key_provider`, `keychain`, or `api_key_command`; `auto` uses the fallback chain |
 | `server.port` | `19222` | Local capture server port |
 | `local_ui.auto_start` | `true` | Automatic local-ui startup from non-manual flows |
 | `capture.redact_pii` | `true` | PII redaction in captured content |

--- a/docs/LLM-CAPACITY.md
+++ b/docs/LLM-CAPACITY.md
@@ -90,7 +90,8 @@ Scanning modes:
   segmentation: about every 10 completed turns, plus a final session-end scan on
   the non-incognito publish path.
 - `near_realtime` scans active sessions on a time window when new content
-  exists. The default interval is 30 minutes.
+  exists. The default interval is 30 minutes, and the durable per-session window
+  is enforced across concurrent serve processes.
 - `off` disables sensitivity classifier calls and disables the sensitivity
   publish gate.
 
@@ -145,10 +146,10 @@ near_realtime: active windows with new content / interval + at most 1 session-en
 off:           0 calls
 ```
 
-Incognito is a privacy control, not a capacity control. It suppresses publish
-for ordinary destinations and skips the final non-incognito publish-drain scan,
-but active-session sensitivity scanning can still run while the session is
-active. Use `scanning_mode: off` for a capacity guarantee.
+Incognito is a privacy control, not a global capacity control. It suppresses
+publish for ordinary destinations and skips active-session and final sensitivity
+scans for that session. Use `scanning_mode: off` when you want a
+configuration-wide guarantee of zero sensitivity-classifier calls.
 
 ## Cost reporting
 
@@ -164,6 +165,10 @@ The cost metric uses estimated token counts from prompt and output size, then
 prices those counts with Trajectory's existing model pricing table. It is not a
 provider invoice. Calls whose model is not visible or not priced still emit
 `trajectory.serve.llm_capacity.calls.total` with `cost_source:pricing_unknown`.
+Classifier backend errors can also represent attempted calls that consumed
+provider-side capacity before failing or returning unparseable output. Check
+`trajectory.serve.sensitivity.classifier_backend_error` alongside the capacity
+metrics when investigating unexpected spend.
 
 Useful queries:
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -2,7 +2,10 @@
 Trajectory captures local JSONL first, then publishes according to config and destination policy. Use the controls below when a session may involve sensitive content.
 
 ## Incognito
-Use `/incognito` when ordinary observability destinations should not receive the current session. Local JSONL capture continues, publish to non-exempt remote destinations is suppressed, and the toggle resets when the session ends.
+Use `/incognito` when ordinary observability destinations should not receive
+the current session. Local JSONL capture continues, publish to non-exempt remote
+destinations is suppressed, active-session sensitivity scans are skipped, and
+the toggle resets when the session ends.
 
 Clients with the Trajectory skill installed accept:
 
@@ -49,6 +52,10 @@ privacy:
 ```
 
 Sensitivity gating applies to span publish. Metrics, marker evaluations, and some event logs can still flow depending on destination policy. Keep metric tags and marker details low-cardinality and non-sensitive.
+
+Incognito sessions skip active-session sensitivity classifier calls.
+`TRAJECTORY_DISABLED=1` is stronger: it prevents local capture for the launched
+process, so there is no local session for the sensitivity scanner to read.
 
 ## Disable All Capture
 For a one-off process where local capture should also stop, use:

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -60,7 +60,23 @@ Trace export is off by default. Set `export.traces` explicitly when you want ses
 Secret writes are defensive: `trajectory setup` and `trajectory config
 set-secret` snapshot an existing keychain value before updating it and attempt
 to restore the old value if the write fails. Recover a missing Datadog key with
-`trajectory config set-secret dd-api-key` or a temporary `DD_API_KEY`.
+`trajectory config set-secret dd-api-key` or a temporary `DD_API_KEY` /
+`DATADOG_API_KEY`.
+
+Standard Datadog credential resolution uses `auto`: env var for the configured
+key ref, `DD_API_KEY`, `DATADOG_API_KEY`, the default key provider, keychain,
+then destination `api_key_command`. If an environment variable contains a
+secret-manager reference instead of the Datadog API key, pin the intended
+source:
+
+```bash
+trajectory config set auth.credential_source keychain  # auto | env | key_provider | keychain | api_key_command
+trajectory doctor
+```
+
+Managed `auth.mode: managed_keychain` policy uses exact keychain refs only.
+`trajectory serve` logs an early warning when `auto` would select a malformed
+Datadog env var, before the first publish attempt.
 
 Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml`, or `placeholder_llm_span: false` on a managed/trusted `publish.trajectory.yaml` destination, to stop publishing Trajectory's synthetic LLM child span for turn-level token/cost enrichment. The turn span still carries `metrics.estimated_total_cost` plus cost fallback metadata and the `trajectory.cost_source:turn_metrics` tag, so cost remains queryable without the placeholder child span. Project configs may disable this for a trusted destination, but cannot re-enable it if the trusted or managed destination disabled it.
 
@@ -115,6 +131,12 @@ read-only SQLite access.
 
 For SQLite queries, call `trajectory_schema` first so the agent uses the live
 database path and schema before calling `trajectory_query`.
+
+`trajectory_incognito` can be called with only `enable` when the MCP server can
+resolve the active session from environment variables or the active-session
+registry. Responses include `resolved_session_id` and `resolution_source`. If
+resolution fails, call `list_active_sessions` and retry with an explicit
+`session_id`.
 
 ```bash
 trajectory user-guide mcp
@@ -228,7 +250,7 @@ Use the default `raw` format for Datadog dashboard API workflows. Use `--format 
 
 ## Privacy Controls
 
-Use `/incognito` when the current session should not publish to ordinary Datadog observability destinations. Local JSONL capture continues, publish to non-exempt Datadog destinations is suppressed, and the toggle resets when the session ends. Org-managed destinations configured with `incognito_exempt: true` may still receive events for approved security or audit use cases.
+Use `/incognito` when the current session should not publish to ordinary Datadog observability destinations. Local JSONL capture continues, publish to non-exempt Datadog destinations is suppressed, active-session sensitivity scans are skipped, and the toggle resets when the session ends. Org-managed destinations configured with `incognito_exempt: true` may still receive events for approved security or audit use cases.
 
 Use `<sensitive>...</sensitive>` blocks as an explicit signal to the agent and to human readers:
 


### PR DESCRIPTION
## Summary
- promote public stable and beta release metadata to v0.5.7
- refresh credential-resolution, incognito, and LLM-capacity docs for v0.5.7

Docs and release metadata update.