### PR TITLE
Release v0.5.8

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.7",
-    "tag": "v0.5.7",
-    "released_at": "2026-06-04T16:42:02Z"
+    "version": "0.5.8",
+    "tag": "v0.5.8",
+    "released_at": "2026-06-05T00:18:17Z"
   },
   "beta": {
-    "version": "0.5.7",
-    "tag": "v0.5.7",
-    "released_at": "2026-06-04T16:42:02Z"
+    "version": "0.5.8",
+    "tag": "v0.5.8",
+    "released_at": "2026-06-05T00:18:17Z"
   }
 }

--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -80,12 +80,18 @@ cache path.
 
 Setup writes a local Claude Code marketplace under
 `~/.trajectory/claude-marketplace`, registers it, refreshes it, and installs or
-updates `trajectory@trajectory` at user scope.
+updates `trajectory@trajectory` at user scope. Claude Code caches installed
+plugins by plugin version, so setup generates the local marketplace and plugin
+manifest with Trajectory's bundled Claude plugin version. `trajectory update`
+can also refresh an already installed Claude plugin after the binary is current
+when it detects stale cached plugin metadata.
 
-The plugin registers Claude lifecycle hooks that post to the local capture
-server. Claude Code supports native HTTP hook entries, so most lifecycle events
-use HTTP hooks. The plugin also carries MCP configuration and skills, including
-`/incognito`.
+The plugin ships Claude `hooks/hooks.json`, which Claude Code loads
+automatically from that standard path. Those lifecycle hooks post to the local
+capture server. Claude Code supports native HTTP hook entries, so most lifecycle
+events use HTTP hooks. The plugin manifest intentionally omits a `hooks` entry
+for `hooks/hooks.json` to avoid duplicate hook-file loading. The plugin also
+carries MCP configuration and skills, including `/incognito`.
 
 Verify:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,6 +59,34 @@ Trace export is off by default. Set `export.traces` explicitly when you want ses
 
 Metrics export defaults to `true`, but still needs a working Datadog destination and credentials before points can be submitted.
 
+For metrics-only Datadog export, leave traces off and keep metrics enabled:
+
+```yaml
+export:
+  site: datadoghq.com
+  ml_app: coding-agents
+  traces: off
+  metrics: true
+```
+
+No `type:` field is needed in normal `~/.trajectory/config.yaml`. Trajectory
+uses `export.site`, `export.ml_app`, `export.traces`, and `export.metrics` to
+create the built-in Datadog destination named `_config_datadog`. With
+`traces: off` and `metrics: true`, Datadog metrics publish and LLM Observability
+trace spans do not.
+
+For explicit managed destinations, `type` chooses the backend or transport:
+`datadog`, `datadog_agent`, or `otlp`. Trace export is controlled by `level` on
+that destination. Metrics export is controlled by `export.metrics` and
+destination metric settings. Legacy aliases `dd_llmobs` and
+`dd_llmobs_via_agent` are still accepted.
+
+Trace export is off by default. Rerunning `trajectory setup` preserves an
+existing non-off trace setting and prints the effective level. If the existing
+setting is `full`, interactive setup asks before preserving it; the safe default
+is to switch back to `off`. Non-interactive setup cannot prompt, so it warns
+loudly when it preserves `full`.
+
 ## Example User Config
 
 This is a typical `~/.trajectory/config.yaml` for a user who wants local capture, Datadog metrics, and standard LLM Observability traces:
@@ -81,6 +109,34 @@ segmentation:
 ```
 
 Prefer `trajectory config set` for routine edits so Trajectory preserves the expected shape and validates values.
+
+## Global Publish Tags
+
+Use a top-level `tags:` map in `~/.trajectory/config.yaml` or managed
+`~/.trajectory/config.defaults.yaml` when every published Datadog coding-agent
+signal from that machine should carry the same deployment or fleet tags:
+
+```yaml
+tags:
+  team: platform
+  environment: development
+  workspace: cloud
+```
+
+These tags are added at publish time to Datadog LLM Observability spans and
+Trajectory Datadog metric series for base, marker, heartbeat, and task metrics.
+They are not written to local JSONL. They are not added to OTLP exports, Claude
+native OTLP proxy metrics, or process-level health/privacy counters.
+
+User and managed `tags:` maps are additive. When the same key appears in both,
+the managed `config.defaults.yaml` value wins. Destination-level `tags:` from
+trusted destinations or `publish.trajectory.yaml` remain destination-scoped, but
+managed top-level tags are reapplied for shared keys.
+
+Keep global tags low-cardinality and non-sensitive. Use stable values such as
+`team`, `environment`, `deployment`, or `workspace`; avoid prompts, file paths,
+URLs, arbitrary emails, SHAs, random IDs, and secrets. Use the `identity.*`
+settings for user/email/GitHub attribution instead of custom tag keys.
 
 ## Example Managed Defaults
 
@@ -229,6 +285,7 @@ Environment variables are best for temporary overrides, CI jobs, or one launched
 
 | Key | Default | What it controls |
 |---|---|---|
+| `tags` | `{}` | Low-cardinality deployment tags added to published Datadog spans and Trajectory Datadog metrics; managed defaults win on shared keys |
 | `deployment.ring` | `stable` | Release channel for updates, usually `stable` or `beta` |
 | `auth.credential_source` | `auto` | Pin standard Datadog credential resolution to `env`, `key_provider`, `keychain`, or `api_key_command`; `auto` uses the fallback chain |
 | `server.port` | `19222` | Local capture server port |

--- a/docs/LLM-CAPACITY.md
+++ b/docs/LLM-CAPACITY.md
@@ -154,7 +154,7 @@ configuration-wide guarantee of zero sensitivity-classifier calls.
 ## Cost reporting
 
 Trajectory emits best-effort Datadog Metrics v2 points for Trajectory-owned LLM
-capacity when a `dd_llmobs` metrics destination is enabled:
+capacity when a `datadog` metrics destination is enabled:
 
 | Metric | Type | Tags | Notes |
 |---|---|---|---|

--- a/docs/MARKERS.md
+++ b/docs/MARKERS.md
@@ -525,9 +525,9 @@ measures:
 
 ### Tags and dimensions
 
-Marker metric series include destination `tags:` from publish config, `session_id`, optional `ml_app`, best-effort repo tags (`git_remote_host`, `owner`, `repo`), and `trajectory.trace_type:session`. Per-emission dimensions from `dimensions` or legacy `tag_keys` are merged into point metric tags only. Add dashboard template variables only for tags that are present on the marker series you are querying; for example, `team`, `env`, `repo`, `owner`, or a bounded point dimension such as `branch`.
+Marker metric series include top-level Datadog publish `tags:`, destination `tags:` from publish config, `session_id`, optional `ml_app`, best-effort repo tags (`git_remote_host`, `owner`, `repo`), and `trajectory.trace_type:session`. Per-emission dimensions from `dimensions` or legacy `tag_keys` are merged into point metric tags only. Add dashboard template variables only for tags that are present on the marker series you are querying; for example, `team`, `env`, `repo`, `owner`, or a bounded point dimension such as `branch`.
 
-Keep metric tags low-cardinality. Avoid full prompts, command lines, paths, URLs, emails, SHAs, random IDs, and secret-looking values. If you need filters such as `trajectory.client_source` or `trajectory.user` on marker metrics, add them as destination tags or confirm they are present in Metrics Explorer before wiring dashboards or monitors to them.
+Keep metric tags low-cardinality. Avoid full prompts, command lines, paths, URLs, emails, SHAs, random IDs, and secret-looking values. Confirm tag presence in Metrics Explorer before wiring dashboards or monitors to them.
 
 To publish marker metrics, enable markers for a Datadog destination in publish config and validate the destination:
 
@@ -535,7 +535,7 @@ To publish marker metrics, enable markers for a Datadog destination in publish c
 # trajectory-doc-snippet: publish-config
 destinations:
   - name: team-llmobs
-    type: dd_llmobs
+    type: datadog
     site: us5.datadoghq.com
     ml_app: coding-agents
     service: trajectory

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -38,8 +38,15 @@ gauges for that reason.
 ## Emission Gates
 
 Base telemetry is emitted when `export.metrics: true` is enabled for an active
-Datadog or OTLP destination. Trace export can still be off; metrics-only mode is
-valid and common.
+Datadog or OTLP destination. For normal `~/.trajectory/config.yaml` Datadog
+config, `export.site` plus `export.metrics: true` creates the built-in
+`_config_datadog` destination even when `export.traces: off`. In that mode
+metrics publish and LLM Observability trace spans do not.
+
+Destination `type` is the backend or transport selector, not the metrics
+switch. For `type: datadog`, metrics use Datadog Metrics v2 when the metric
+gates are enabled. Legacy `type: dd_llmobs` is accepted as an alias for
+`datadog`.
 
 Marker-derived metrics require both marker evaluation and destination marker
 metrics:
@@ -86,8 +93,14 @@ unattributed.
 | `project_dir` | Project directory basename | Omitted |
 | `trajectory.trace_type` | Metric grain: `turn`, `session`, `task`, `commit`, or `pr` | Set by emitter |
 
-Destination tags may also be present. Keep custom tags low-cardinality and
-non-sensitive.
+Top-level config `tags:` are included on Trajectory-published Datadog metric
+series for Datadog destinations, including base, marker, heartbeat, and task
+metrics. User and managed tag maps are additive; managed `config.defaults.yaml`
+values win on key conflicts. They are not written to local JSONL, and they are
+not added to OTLP exports, Claude native OTLP proxy metrics, or process-level
+health/privacy counters. Destination tags and marker dimensions may also be
+present where those publish paths support them. Keep custom tags low-cardinality
+and non-sensitive.
 
 ## Per-Turn Metrics
 
@@ -102,6 +115,10 @@ Per-turn metrics are emitted on completed turn events.
 | `trajectory.turn.number` | gauge | turn | One-indexed turn number when known |
 | `trajectory.turn.cost.usd` | gauge | USD | Point-in-time turn cost; zero is valid |
 | `trajectory.turn.cost.usd.total` | distribution | USD | Completed-turn cost sample; use `p95:`/`avg:` queries |
+| `trajectory.turn.web_search.requests` | gauge | request | WebSearch requests in the completed turn |
+| `trajectory.turn.web_search.requests.total` | distribution | request | Completed-turn WebSearch request sample |
+| `trajectory.turn.web_search.cost.usd` | gauge | USD | WebSearch cost in the completed turn at $0.01 per request |
+| `trajectory.turn.web_search.cost.usd.total` | distribution | USD | Completed-turn WebSearch cost sample |
 | `trajectory.turn.duration_ms` | gauge | ms | Point-in-time completed-turn duration when derivable |
 | `trajectory.turn.duration_ms.total` | distribution | ms | Completed-turn duration sample |
 | `trajectory.turn.permission_wait_ms.total` | distribution | ms | Derivable human approval wait inside the turn |
@@ -137,6 +154,8 @@ Running session gauges:
 | `trajectory.session.turns.elapsed` | gauge | turn | Running turn count, refreshed on turn end |
 | `trajectory.session.tool_uses.elapsed` | gauge | call | Running tool-use count, refreshed on turn end |
 | `trajectory.session.cost.usd.accumulated` | gauge | USD | Running and final observed session cost |
+| `trajectory.session.web_search.requests` | gauge | request | Running and final observed WebSearch request count when present |
+| `trajectory.session.web_search.cost.usd.accumulated` | gauge | USD | Running and final observed WebSearch cost at $0.01 per request |
 | `trajectory.session.compactions.elapsed` | gauge | compaction | Running compaction count |
 | `trajectory.session.last_seen.unix` | gauge | second | Latest observed source event timestamp as Unix seconds |
 
@@ -148,6 +167,8 @@ Session-end metrics:
 | `trajectory.session.turns.total` | distribution | turn | Completed-session turn count |
 | `trajectory.session.tool_uses.total` | distribution | call | Completed-session tool-use count |
 | `trajectory.session.cost.usd.total` | distribution | USD | Completed-session cost sample; not an active-session coverage metric |
+| `trajectory.session.web_search.requests.total` | distribution | request | Completed-session WebSearch request sample |
+| `trajectory.session.web_search.cost.usd.total` | distribution | USD | Completed-session WebSearch cost sample |
 | `trajectory.session.compactions.total` | distribution | compaction | Completed-session compaction sample |
 | `trajectory.session.lines_changed` | gauge | line | Added plus removed lines when known |
 | `trajectory.session.yield_commit_count` | gauge | commit | Real git commits found in the session window by the yield tracker |
@@ -231,7 +252,7 @@ privacy/publish diagnostics.
 
 | Metric | Type | Tags | Notes |
 |---|---|---|---|
-| `trajectory.publish.active_destinations` | gauge | Canonical tags plus destination tags | Number of active destinations seen for a session |
+| `trajectory.publish.active_destinations` | gauge | Canonical tags plus top-level and destination tags on Datadog destinations | Number of active destinations seen for a session |
 | `trajectory.publish.turns` | count | OTLP publish path tags | Internal publish turn counter |
 | `trajectory.serve.incognito.enabled` | count | `client_source` | User or tool enabled incognito; intentionally not tagged by session ID |
 | `trajectory.serve.publish.sensitivity_suppressed` | count | `client_source`, `destination`, `category`, `label` | Sensitive spans dropped for a destination |

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -124,7 +124,7 @@ Install with setup:
 trajectory setup --clients cc
 ```
 
-Setup writes a local Claude Code marketplace under `~/.trajectory/claude-marketplace`, registers that local path with Claude, refreshes the marketplace, then installs the plugin at user scope. If `trajectory@trajectory` is already installed, setup refreshes the marketplace and runs `claude plugin update trajectory@trajectory --scope user` so an existing install moves to the bundled plugin version without requiring GitHub SSH or HTTPS credentials.
+Setup writes a local Claude Code marketplace under `~/.trajectory/claude-marketplace`, registers that local path with Claude, refreshes the marketplace, then installs the plugin at user scope. If `trajectory@trajectory` is already installed, setup refreshes the marketplace and runs `claude plugin update trajectory@trajectory --scope user` so an existing install moves to the bundled plugin version without requiring GitHub SSH or HTTPS credentials. Claude Code caches installed plugins by version, so the setup-generated marketplace and plugin manifest use Trajectory's bundled Claude plugin version. `trajectory update` also checks installed Claude plugin metadata and refreshes the plugin when the cached version is stale.
 
 Manual fallback after setup has staged the local marketplace:
 
@@ -136,7 +136,11 @@ claude plugin install trajectory@trajectory --scope user
 
 From a source checkout, use the checkout root instead of `~/.trajectory/claude-marketplace`.
 
-The plugin registers 12 lifecycle hooks, primarily HTTP, with command shims for startup, shutdown, and serve lifecycle handling.
+The plugin ships the standard Claude `hooks/hooks.json` file with 12 lifecycle
+hooks, primarily HTTP, with command shims for startup, shutdown, and serve
+lifecycle handling. Claude Code loads that standard hook file automatically; the
+plugin manifest intentionally does not list `hooks/hooks.json`, because doing so
+would load the same file twice.
 
 ## Gemini CLI
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -55,7 +55,34 @@ trajectory config set local_ui.auto_start false    # disable automatic local-ui 
 trajectory config set-secret dd-api-key             # prompts for the key securely
 ```
 
-Trace export is off by default. Set `export.traces` explicitly when you want sessions published to LLM Observability.
+For metrics-only Datadog export, keep `export.traces` off and set
+`export.metrics` true:
+
+```yaml
+export:
+  site: datadoghq.com
+  ml_app: coding-agents
+  traces: off
+  metrics: true
+```
+
+Do not add `type` under `export:` in normal `~/.trajectory/config.yaml`.
+Trajectory creates the built-in `_config_datadog` destination from the
+`export.*` fields. Destination `type` is only used in explicit `destinations:`
+or managed `required_destinations:` lists.
+
+These controls are separate: destination `type` chooses the backend/transport,
+`export.traces` or destination `level` controls LLM Observability trace spans,
+and `export.metrics` plus destination metric settings control metrics. Use
+`type: datadog` for direct Datadog destinations in new explicit configs. Legacy
+`type: dd_llmobs` still works.
+
+Trace export is off by default. Set `export.traces` explicitly when you want
+sessions published to LLM Observability. Rerunning `trajectory setup` preserves
+an existing non-off trace setting and prints the effective level. If the
+existing setting is `full`, interactive setup asks before preserving it; the
+safe default is to switch back to `off`. Non-interactive setup cannot prompt, so
+it warns loudly when it preserves `full`.
 
 Secret writes are defensive: `trajectory setup` and `trajectory config
 set-secret` snapshot an existing keychain value before updating it and attempt
@@ -366,6 +393,33 @@ Use these tags to filter in LLM Obs and Metrics Explorer:
 
 This is useful on shared machines or CI where multiple users generate sessions.
 
+## Custom publish tags
+
+Add a top-level `tags:` map to `~/.trajectory/config.yaml` or managed
+`~/.trajectory/config.defaults.yaml` when every published Datadog coding-agent
+signal from that machine should carry the same low-cardinality deployment tags:
+
+```yaml
+tags:
+  team: platform
+  environment: development
+  workspace: cloud
+```
+
+These tags are applied at publish time to Datadog LLM Observability spans and
+Trajectory Datadog metric series for base, marker, heartbeat, and task metrics.
+They are not written to local JSONL, and they are not added to OTLP exports,
+Claude native OTLP proxy metrics, or process-level health/privacy counters.
+
+User and managed `tags:` maps are additive. When the same key appears in both,
+the managed `config.defaults.yaml` value wins. Destination-level `tags:` in
+trusted destinations or `publish.trajectory.yaml` remain destination-scoped, but
+managed top-level tags are reapplied for shared keys.
+
+Keep custom tags stable and non-sensitive. Avoid prompts, paths, URLs,
+arbitrary emails, SHAs, random IDs, and secrets. Use `identity.*` settings for
+user/email/GitHub attribution instead of custom keys.
+
 ## Repo tags on metrics
 
 Trajectory automatically tags every DD metric with repository metadata extracted from the git remote:
@@ -385,10 +439,12 @@ Trajectory publishes distribution metrics for completed samples that are useful 
 
 - `trajectory.turn.tool_uses.total` - total tool calls in a completed turn. This is intentionally separate from the `trajectory.turn.tool_uses` gauge, which is split by `tool_name` for per-tool breakdowns.
 - `trajectory.turn.cost.usd.total` - estimated USD cost of a completed turn.
+- `trajectory.turn.web_search.requests.total` and `trajectory.turn.web_search.cost.usd.total` - completed-turn WebSearch request and cost samples.
 - `trajectory.turn.duration_ms.total` - duration of a completed turn when the client provides or Trajectory can derive it.
 - `trajectory.turn.permission_wait_ms.total` - estimated human approval wait inside a completed turn, emitted when Trajectory can derive a permission wait interval.
 - `trajectory.turn.duration_ms.excluding_permission_wait.total` - completed-turn duration minus derivable permission wait, useful when you want agent elapsed time with approval waits removed.
-- `trajectory.session.turns.total`, `trajectory.session.tool_uses.total`, `trajectory.session.cost.usd.total`, and `trajectory.session.compactions.total` - completed-session samples.
+- `trajectory.session.turns.total`, `trajectory.session.tool_uses.total`, `trajectory.session.cost.usd.total`, `trajectory.session.web_search.requests.total`, `trajectory.session.web_search.cost.usd.total`, and `trajectory.session.compactions.total` - completed-session samples.
+- `trajectory.session.web_search.requests` and `trajectory.session.web_search.cost.usd.accumulated` - running and final observed WebSearch request and cost gauges.
 - `trajectory.pr.cost.usd.attributed.total`, `trajectory.pr.attributed_turns.total`, and `trajectory.pr.containing_session.cost.usd.total` - completed-PR samples for PR cost attribution dashboards.
 - `trajectory.session.last_seen.unix` - latest observed session event time as Unix seconds, useful for recency-sorted session tables. Enable Historical Metrics Ingestion for this gauge before replaying sessions older than one hour.
 


### PR DESCRIPTION
## Summary
- promote public stable and beta release metadata to v0.5.8
- refresh public docs for metrics-only Datadog config, global publish tags, Claude plugin refresh behavior, and WebSearch metrics

Docs and release metadata update.