### PR TITLE
Release v0.5.13

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.12",
-    "tag": "v0.5.12",
-    "released_at": "2026-06-17T03:58:47Z"
+    "version": "0.5.13",
+    "tag": "v0.5.13",
+    "released_at": "2026-06-18T15:02:49Z"
   },
   "beta": {
-    "version": "0.5.12",
-    "tag": "v0.5.12",
-    "released_at": "2026-06-17T03:58:47Z"
+    "version": "0.5.13",
+    "tag": "v0.5.13",
+    "released_at": "2026-06-18T15:02:49Z"
   }
 }

--- a/docs/MARKERS.md
+++ b/docs/MARKERS.md
@@ -1,6 +1,6 @@
 # Marker Usage Guide
 
-Markers are Trajectory's YAML-defined behavioral signals. They turn captured agent sessions into named observations that can be evaluated locally, stored in Trajectory's SQLite database, and exported to Datadog as marker metrics and structured marker context.
+Markers are Trajectory's YAML-defined behavioral signals. They turn captured agent sessions into named observations that can be evaluated locally, stored in Trajectory's SQLite database, and exported to Datadog as marker metrics and structured marker context. LLM Observability marker evaluations are a separate experimental output path and stay off unless a destination explicitly sets `markers.evaluations: true`.
 
 A concise version of this guide is built into the binary:
 
@@ -517,7 +517,7 @@ file contents, local paths, or secret-bearing URLs.
 
 Older `trajectory.marker.measure.<measure_name>` and `trajectory.marker.point.<measure_name>` namespaces are deprecated. Use the metric naming convention above for migration guidance.
 
-Range markers are still exported as marker context/evaluation records. To make them easy to graph in dashboards, add a range-backed measure:
+Range markers can be published as marker context and, when explicitly enabled, LLM Observability evaluation records. To make them easy to graph in dashboards, add a range-backed measure:
 
 ```yaml
 measures:
@@ -558,6 +558,11 @@ destinations:
       enabled: true
       metrics: true
 ```
+
+To opt in to experimental LLM Observability marker evaluations for a Datadog
+destination, set `markers.evaluations: true` explicitly. Keep this off unless
+the destination is prepared to consume marker results as LLM Observability
+evaluations.
 
 ```bash
 trajectory publish validate

--- a/docs/METRICS-CONSISTENCY-AUDIT.md
+++ b/docs/METRICS-CONSISTENCY-AUDIT.md
@@ -1,0 +1,51 @@
+# Metrics Consistency Audit
+
+This audit documents the coding-agent contracts behind the base Trajectory
+metrics. It is meant to prevent metric names from drifting into
+adapter-specific meanings.
+
+## Metric Semantics
+
+`trajectory.turn.*` metrics are per completed-turn samples. A turn metric
+should not contain cumulative session-to-date values unless the metric name
+says so, for example `trajectory.session.*.elapsed` or `.accumulated`.
+
+`trajectory.turn.errors` means failed tool results in the completed turn,
+grouped by the `category` tag. It does not mean Trajectory capture, publish,
+or Datadog submission failures. The source precedence is:
+
+1. Use explicit `turn_end.tool_error_categories` when an adapter provides a
+   per-turn map.
+2. Otherwise derive one error category from each completed `tool_use` event
+   with `success:false`.
+
+The shared category taxonomy currently includes `command-failed`,
+`user-rejected`, `edit-failed`, `file-changed`, `file-too-large`,
+`file-not-found`, and `other`.
+
+## Agent Coverage
+
+| Agent | Failed-tool source for `trajectory.turn.errors` | Per-turn enrichment source |
+|---|---|---|
+| Claude Code | `PostToolUse`/`PostToolUseFailure` failed `tool_use` records, plus transcript-derived `turn_end.tool_error_categories` | Transcript enrichment is applied as the just-read turn delta, not the cumulative session state |
+| Codex | `PostToolUse` records with `tool_error` or `is_error:true` | Adapter emits failed `tool_use`; publish derives categories when no explicit turn map exists |
+| Cursor | `PostToolUse` records with `tool_error` or `is_error:true` | Adapter emits failed `tool_use`; publish derives categories when no explicit turn map exists |
+| Gemini | `AfterTool` records with `tool_error` | Adapter emits failed `tool_use`; publish derives categories when no explicit turn map exists |
+| Pi | Explicit `turn_end.tool_error_categories` when supplied; otherwise `PostToolUse` records with `is_error:true` | Adapter forwards per-turn turn-end fields from the Pi payload |
+| OpenCode | `tool.execute.after` payloads with `is_error` or `tool_error`, normalized to failed `tool_use` records | Adapter emits failed `tool_use`; publish derives categories when no explicit turn map exists |
+| Copilot CLI | Reuses the Claude-compatible capture contract | Supports `PostToolUseFailure`; no historical transcript backfill |
+| Factory Droid | Reuses the Claude-compatible capture contract for documented hooks | Current documented plugin hook set lacks `PostToolUseFailure`; ordinary `PostToolUse` failures are still captured when the payload carries `tool_error` or `is_error:true` |
+
+## Findings
+
+Claude Code transcript enrichment now stores cumulative state only for
+incremental transcript reads and writes only the new delta onto the current
+turn. This keeps turn-level error, language, line, file, interruption, and
+denial fields scoped to the completed turn.
+
+Publish now derives the same error categories from failed completed
+`tool_use` records when no explicit turn-end category map exists, so
+`trajectory.turn.errors` has the same meaning across adapters.
+
+OpenCode capture now preserves failed tool outcomes, error text, and output
+summaries, matching the other adapters' normalized `tool_use` shape.

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -4,6 +4,8 @@ This page catalogs the metric surface emitted by the current Trajectory binary. 
 
 For marker syntax and dashboard examples, see [MARKERS.md](MARKERS.md). For
 configuration and destination trust, see [USER-GUIDE.md](USER-GUIDE.md).
+For cross-agent source contracts, see
+[METRICS-CONSISTENCY-AUDIT.md](METRICS-CONSISTENCY-AUDIT.md).
 For the built-in metric guide, run:
 
 ```bash
@@ -60,7 +62,13 @@ markers:
 If a destination sets `markers.metrics: false`, marker-derived metrics are
 suppressed for that destination. Project `publish.trajectory.yaml` files can add
 metrics-only destinations only when `level: off`, marker metrics are enabled,
-and marker logs are disabled.
+marker logs are disabled, and LLM Observability marker evaluations are
+disabled.
+
+LLM Observability marker evaluations are a separate experimental output path.
+They are not enabled by `markers.enabled` or `markers.metrics`; a Datadog
+destination must set `markers.evaluations: true` explicitly before Trajectory
+submits marker results to the LLM Observability evaluation intake.
 
 Serve-side operational counters such as incognito and sensitivity health are
 best-effort Datadog Metrics API submissions. They are not tied to trace export.
@@ -130,7 +138,7 @@ Per-turn metrics are emitted on completed turn events.
 | `trajectory.turn.files_read` | gauge | file | Read tool activity in the turn |
 | `trajectory.turn.subagent_invocations` | gauge | invocation | Subagent starts observed in the turn |
 | `trajectory.turn.compactions` | gauge | compaction | Compactions observed in the turn |
-| `trajectory.turn.lines_of_code.count` | count | line | Tagged with `type:added` or `type:removed` |
+| `trajectory.turn.lines_of_code.count` | count | line | Per-turn added/removed line deltas; tagged with `type:added` or `type:removed` |
 
 Grouped per-turn metrics emit one data point per dimension value:
 
@@ -141,10 +149,14 @@ Grouped per-turn metrics emit one data point per dimension value:
 | `trajectory.turn.permission_prompts` | gauge | `decision` |
 | `trajectory.turn.tool_decision` | count | `tool_name`, `decision`, `source` |
 | `trajectory.turn.code_edit_tool.decision` | count | `tool_name`, `decision`, `source`, `language` |
-| `trajectory.turn.errors` | gauge | `category` |
+| `trajectory.turn.errors` | gauge | `category`; per-turn failed tool results. Uses explicit `turn_end.tool_error_categories` when an adapter supplies it, otherwise derives categories from completed `tool_use` events with `success:false`. This is not a Trajectory publish/tool-call transport failure metric. |
 
 For dashboard percentile queries, prefer the `.total` distributions. For
 per-tool breakdowns, use `trajectory.turn.tool_uses` grouped by `tool_name`.
+Turn-scoped gauges are completed-turn samples. Do not sum long-window gauge
+rollups as literal event counts unless the dashboard explicitly chooses a
+single point per turn; use `.total` distributions, `.count` metrics, or
+`.completed_count` mirrors where those exist.
 
 ## Per-Session Metrics
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -124,6 +124,9 @@ rerun setup with `DD_API_KEY` present.
 Standard Datadog credential resolution uses `auto`: env var for the
 `api_key_ref`, `DD_API_KEY`, `DATADOG_API_KEY`, the configured credential-provider
 command from `auth.key_command`, keychain, then destination `api_key_command`.
+For standard Datadog API-key resolution, `dd-api-key` and `dd_api_key` are
+accepted aliases for the same default key. Managed keychain deployments use
+exact refs only and do not alias, read env vars, or run key commands.
 If an env var is a secret-manager ID rather than the Datadog key, `auto` reports
 it and real Datadog publish destinations continue to later sources. Pin the
 intended source when you want that source to fail closed:
@@ -288,7 +291,20 @@ query permission (`timeseries_query`). Managed destinations can set
 `required_destinations[].app_key_ref` so readback uses the same destination
 identity as publish. You can also pass it for one command with `DD_APP_KEY=...`
 or use `--readback-app-key-ref <secret-name>` for a custom Trajectory keychain
-secret.
+secret. Application-key lookup is shared by readback and sync: explicit
+command ref, destination `app_key_ref`, then `dd-app-key`, `dd_app_key`, or
+`DD_APP_KEY`. Managed keychain mode uses the same order but reads each ref
+exactly from the keychain.
+
+`trajectory publish sync` creates log-based metric definitions through the
+Datadog Logs configuration API. That path needs the Datadog API key used for
+publish plus a Datadog application key. `publish validate` can accept the API
+key while sync still fails if `DD_APP_KEY` / `dd-app-key` / `dd_app_key` is
+missing or lacks log configuration write permission. Store the app key with:
+
+```bash
+trajectory config set-secret dd-app-key --stdin
+```
 
 For full built-in publish fidelity across spoofed coding-agent sources, use the
 synthetic canary:
@@ -411,7 +427,7 @@ trajectory logs -f --grep error      # Follow errors only
 
 ## Markers
 
-Markers are YAML-defined behavioral signals that Trajectory evaluates against captured sessions. They produce points, multi-turn ranges, and measures that can be exported to Datadog as `trajectory.<scope>.<concept>` metrics (where `<scope>` is one of `turn`, `session`, `task`, `commit`, `pr`).
+Markers are YAML-defined behavioral signals that Trajectory evaluates against captured sessions. They produce points, multi-turn ranges, and measures that can be exported to Datadog as `trajectory.<scope>.<concept>` metrics (where `<scope>` is one of `turn`, `session`, `task`, `commit`, or `pr`). LLM Observability marker evaluations are separate and stay off unless a destination explicitly sets `markers.evaluations: true`.
 
 Read the full guide in [MARKERS.md](MARKERS.md), or from the binary:
 


### PR DESCRIPTION
## Summary
- promote public stable and beta release metadata to v0.5.13
- refresh public marker and metrics docs for v0.5.13
- add the public metrics consistency audit

Docs and release metadata update.