### PR TITLE
Release v0.5.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 - [docs/CLIENT-INSTRUMENTATION.md](docs/CLIENT-INSTRUMENTATION.md): per-client hook, watcher, MCP, and backfill surfaces
 - [docs/COSTS.md](docs/COSTS.md): local cost summaries, turn evidence, objective observations, and fidelity checks
 - [docs/PRIVACY.md](docs/PRIVACY.md): incognito, sensitive tags, and sensitivity scanning
+- [docs/SECURITY-EVENT-STREAM.md](docs/SECURITY-EVENT-STREAM.md): managed security event log projection
 - [docs/LLM-CAPACITY.md](docs/LLM-CAPACITY.md): which features use additional LLM capacity and how to control them
 - [docs/METRICS-REFERENCE.md](docs/METRICS-REFERENCE.md): emitted metric names, types, tags, and query guidance
 - [docs/MARKERS.md](docs/MARKERS.md): marker authoring and marker-derived metrics

--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.13",
-    "tag": "v0.5.13",
-    "released_at": "2026-06-18T15:02:49Z"
+    "version": "0.5.14",
+    "tag": "v0.5.14",
+    "released_at": "2026-06-18T21:06:28Z"
   },
   "beta": {
-    "version": "0.5.13",
-    "tag": "v0.5.13",
-    "released_at": "2026-06-18T15:02:49Z"
+    "version": "0.5.14",
+    "tag": "v0.5.14",
+    "released_at": "2026-06-18T21:06:28Z"
   }
 }

--- a/docs/SECURITY-EVENT-STREAM.md
+++ b/docs/SECURITY-EVENT-STREAM.md
@@ -1,0 +1,98 @@
+# Security Event Stream
+
+Security event streams are managed Datadog log projections for security
+destinations. They publish one structured log per canonical Trajectory event
+so detections can query the event stream directly without parsing LLM
+Observability traces.
+
+This is a managed-destination feature. Individual repositories cannot enable
+it from `publish.trajectory.yaml`, and ordinary user `export:` config does not
+expose it.
+
+## Managed Configuration
+
+Enable the stream only on managed `required_destinations`:
+
+```yaml
+required_destinations:
+  - name: security-audit
+    type: datadog
+    site: us5.datadoghq.com
+    ml_app: coding-agents-security
+    api_key_ref: dd-security-api-key
+    level: full
+    incognito_exempt: true
+    privacy:
+      sensitivity_exempt: true
+    event_stream:
+      enabled: true
+      include_private_fields: false
+```
+
+`event_stream.enabled` defaults to `false`. When enabled, the destination must
+be a managed Datadog destination with `incognito_exempt: true`. Project publish
+configs cannot add event-stream destinations, enable the stream, or raise its
+privacy level.
+
+## Privacy Shape
+
+`event_stream.include_private_fields` defaults to `false` and should stay false
+for the managed default. In that mode, logs keep structural fields such as
+`event_type`, `session_id`, `sequence_number`, `turn_id`, `tool_name`, `phase`,
+`success`, `duration_ms`, `client_source`, token and cost summaries,
+provenance, and MCP identity.
+
+Default-minimal logs omit prompt, assistant response, thinking text, tool input,
+tool output, command arguments, command output, diffs, file contents, raw
+payloads, error text, summaries, and user email fields. This roughly mirrors
+minimal trace privacy: security detections get the shape of the activity
+without raw conversation or tool payload content.
+
+Set `include_private_fields: true` only for an explicit managed investigation
+scope. In full mode, Trajectory includes the original event fields in the log
+body.
+
+## Log Shape
+
+Each event stream log uses:
+
+- `ddsource: trajectory-event-stream`
+- `service`: the destination service
+- `ddtags`: destination tags plus event tags such as `ml_app`, `session_id`,
+  `event_type`, `client_source`, `turn_id`, `tool_name`, `phase`, and
+  `sequence_number` when present
+- `message`: a short event summary such as `tool_use: Bash (pre)`
+
+The log body includes event-stream metadata such as
+`event_stream_schema_version`, `event_stream_privacy`,
+`private_fields_included`, `destination_name`, `destination_type`, `ml_app`,
+`trajectory_version`, and the canonical event fields allowed by the privacy
+profile.
+
+## Delivery Semantics
+
+Event-stream logs follow the same publish lifecycle as traces: incremental turn
+publish sends newly observed turn events, and final session publish considers
+the full session event list so late terminal events such as `session_end` can
+be sent.
+
+They are not bundled into the LLM Observability trace payload. Logs are
+submitted as a separate Logs API request for the destination during the same
+publish call. The publish ledger deduplicates per destination and event
+identity, preferring `sequence_number` when available.
+
+The ledger is a fail-closed dedupe and reconciliation guard, not a durable logs
+retry outbox. If submit status is ambiguous, Trajectory keeps the claimed row
+and suppresses duplicate attempts until an operator reconciles it with
+`trajectory publish ledger status` and `trajectory publish ledger repair`.
+
+## Relationship to Other Outputs
+
+Enabling `event_stream` does not enable marker logs, structured records,
+metrics, segmentation logs, or traces. Those outputs keep their existing gates.
+Security destinations with `incognito_exempt: true` still do not receive
+structured records or metrics.
+
+For destination configuration, see `trajectory user-guide publish` and
+`trajectory user-guide deploy`. For privacy controls, see
+`trajectory user-guide privacy`.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -9,12 +9,21 @@ trajectory status                    # Terminal dashboard with session metrics
 trajectory cost                      # Local cost summary and top sessions
 trajectory view                      # Open the local browser viewer
 trajectory doctor                    # Diagnose issues (binary, config, hooks, data)
+trajectory inventory --json          # Refresh local agent and capability inventory
 trajectory diagnose publish          # Explain capture, local mapping, and publish expectations
 trajectory logs [-f] [--grep PAT]   # View capture server logs
 trajectory version                   # Print version
 ```
 
 `trajectory doctor` is the first thing to run if something isn't working. It checks the binary, config, capture server, local-ui/Lapdog contract, database, credentials, and hook registration.
+
+`trajectory inventory --json` refreshes a local inventory artifact under
+`~/.trajectory/inventory/` and prints a structured snapshot of detected agents
+and Trajectory-managed capabilities such as hooks, MCP entries, skills,
+commands, plugins, and settings sources. `current.json` contains the latest
+refresh, while `snapshots/` stores hash-named inventory snapshots for support
+triage or product-pack drift checks. Trajectory does not publish these
+inventory artifacts to Datadog yet.
 
 Use `trajectory view --session <id>` to inspect one captured session in the local browser viewer. If local-ui is not already running, `view` starts it and opens the session deep link. Use `trajectory user-guide local-ui` for cache repair and Lapdog-compatible local inspection.
 
@@ -98,6 +107,17 @@ Agent-managed publishing, or `type: otlp` for OpenTelemetry collectors in new
 explicit configs. OTLP destinations set a base collector `endpoint`; Trajectory
 derives `/v1/traces`, `/v1/metrics`, and `/v1/logs` from it. Legacy
 `type: dd_llmobs` still works.
+
+Managed Datadog destinations can opt in to a security event stream: one
+Datadog log per canonical Trajectory event with
+`ddsource: trajectory-event-stream`. This is configured under
+`required_destinations[].event_stream`, not in repo `publish.trajectory.yaml`
+or ordinary user `export:` config. The default `include_private_fields: false`
+mode keeps structural event metadata for detections while omitting prompts,
+assistant text, thinking text, tool payloads, diffs, file contents, raw
+payloads, error text, summaries, and user email fields. See
+[SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md) and
+`trajectory user-guide security-event-stream`.
 
 Trace export is off by default. Set `export.traces` explicitly when you want
 sessions published to LLM Observability. Rerunning `trajectory setup` preserves
@@ -460,6 +480,7 @@ trajectory user-guide metrics        # Metric gates, names, tags, and queries
 trajectory user-guide mcp            # MCP tools, resources, and SQL query workflow
 trajectory user-guide query          # Local cache data and guarded MCP SQL workflow
 trajectory user-guide privacy        # Incognito, sensitive tags, and sensitivity scanning
+trajectory user-guide security-event-stream # Managed security event logs
 trajectory user-guide diagnostics    # Doctor, diagnose, audit, validate-spans, support bundles
 trajectory user-guide resume         # Reconstruct captured sessions into other clients
 trajectory user-guide clients        # All supported clients


### PR DESCRIPTION
## Summary
- promote public stable and beta release metadata to v0.5.14
- refresh public user guide docs for v0.5.14
- add the public security event stream guide

Docs and release metadata update.