### PR TITLE
Release v0.5.15

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.14",
-    "tag": "v0.5.14",
-    "released_at": "2026-06-18T21:06:28Z"
+    "version": "0.5.15",
+    "tag": "v0.5.15",
+    "released_at": "2026-06-22T06:24:32Z"
   },
   "beta": {
-    "version": "0.5.14",
-    "tag": "v0.5.14",
-    "released_at": "2026-06-18T21:06:28Z"
+    "version": "0.5.15",
+    "tag": "v0.5.15",
+    "released_at": "2026-06-22T06:24:32Z"
   }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -81,6 +81,25 @@ that destination. Metrics export is controlled by `export.metrics` and
 destination metric settings. Legacy aliases `dd_llmobs` and
 `dd_llmobs_via_agent` are still accepted.
 
+Managed Datadog security destinations can opt in to a security event stream:
+
+```yaml
+required_destinations:
+  - name: security-audit
+    type: datadog
+    level: full
+    incognito_exempt: true
+    event_stream:
+      enabled: true
+      privacy_profile: security
+```
+
+The stream is off unless `event_stream.enabled: true` is set. The default
+`security` profile keeps structural event metadata plus pre-tool arguments for
+detections, while omitting prompts, assistant text, thinking text, post-tool
+outputs/results, diffs, file contents, raw payloads, error text, summaries, and
+user email fields. See [SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md).
+
 Trace export is off by default. Rerunning `trajectory setup` preserves an
 existing non-off trace setting and prints the effective level. If the existing
 setting is `full`, interactive setup asks before preserving it; the safe default

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -19,7 +19,16 @@ or a natural-language request such as:
 Go incognito for this session.
 ```
 
-Some managed destinations can be configured with `incognito_exempt: true`. Those destinations may still receive spans during incognito for approved security or audit use cases. Security destinations are managed-config only and cannot be changed by project `publish.trajectory.yaml`.
+Some managed destinations can be configured with `incognito_exempt: true`.
+Those destinations may still receive spans during incognito for approved
+security or audit use cases. Managed security destinations may also enable the
+security event stream, which publishes one Datadog log per canonical event. Its
+default `security` profile keeps structural metadata and pre-tool arguments
+such as commands and file paths, while omitting prompts, assistant responses,
+thinking text, post-tool outputs/results, raw payloads, error text, summaries,
+and user email fields. Security destinations are managed-config only and cannot
+be changed by project `publish.trajectory.yaml`. See
+[SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md).
 
 ## Sensitive Tags
 Use `<sensitive>...</sensitive>` blocks as an instruction to the agent and to human readers:

--- a/docs/SECURITY-EVENT-STREAM.md
+++ b/docs/SECURITY-EVENT-STREAM.md
@@ -26,7 +26,7 @@ required_destinations:
       sensitivity_exempt: true
     event_stream:
       enabled: true
-      include_private_fields: false
+      privacy_profile: security
 ```
 
 `event_stream.enabled` defaults to `false`. When enabled, the destination must
@@ -36,21 +36,31 @@ privacy level.
 
 ## Privacy Shape
 
-`event_stream.include_private_fields` defaults to `false` and should stay false
-for the managed default. In that mode, logs keep structural fields such as
-`event_type`, `session_id`, `sequence_number`, `turn_id`, `tool_name`, `phase`,
-`success`, `duration_ms`, `client_source`, token and cost summaries,
-provenance, and MCP identity.
+`event_stream.privacy_profile` controls field fidelity once the stream is
+enabled:
 
-Default-minimal logs omit prompt, assistant response, thinking text, tool input,
-tool output, command arguments, command output, diffs, file contents, raw
-payloads, error text, summaries, and user email fields. This roughly mirrors
-minimal trace privacy: security detections get the shape of the activity
-without raw conversation or tool payload content.
+| Profile | Behavior |
+|---|---|
+| `security` | Default detection-focused fidelity: structural metadata plus pre-tool input/argument fields; prompts and post-tool outputs are omitted. |
+| `minimal` | Structural metadata only. Pre-tool input, command, and argument fields are also omitted. |
+| `full` | Original event fields are included for explicit managed investigations. |
 
-Set `include_private_fields: true` only for an explicit managed investigation
-scope. In full mode, Trajectory includes the original event fields in the log
-body.
+The stream itself remains off unless `event_stream.enabled: true` is set.
+
+The default `security` profile keeps fields such as `event_type`, `session_id`,
+`sequence_number`, `turn_id`, `tool_name`, `phase`, `success`, `duration_ms`,
+`client_source`, token and cost summaries, provenance, MCP identity, and
+pre-tool input fields such as `input`, `tool_input`, `args`, `arguments`,
+`cmd`, and `command`. Those input fields are omitted outside pre-tool events.
+
+It omits prompt, assistant response, thinking text, post-tool output/result
+payloads, raw payloads, error text, summaries, and user email fields. This is
+the detection-focused middle ground: security detections can see what a tool
+was asked to do without receiving the user's prompt or the tool's returned
+content.
+
+`event_stream.include_private_fields: true` is a deprecated compatibility alias
+for `privacy_profile: full` when `privacy_profile` is omitted.
 
 ## Log Shape
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -112,10 +112,12 @@ Managed Datadog destinations can opt in to a security event stream: one
 Datadog log per canonical Trajectory event with
 `ddsource: trajectory-event-stream`. This is configured under
 `required_destinations[].event_stream`, not in repo `publish.trajectory.yaml`
-or ordinary user `export:` config. The default `include_private_fields: false`
-mode keeps structural event metadata for detections while omitting prompts,
-assistant text, thinking text, tool payloads, diffs, file contents, raw
-payloads, error text, summaries, and user email fields. See
+or ordinary user `export:` config. The stream is off unless
+`event_stream.enabled: true` is set. The default
+`privacy_profile: security` mode keeps structural event metadata plus
+pre-tool arguments for detections while omitting prompts, assistant text,
+thinking text, post-tool outputs/results, diffs, file contents, raw payloads,
+error text, summaries, and user email fields. See
 [SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md) and
 `trajectory user-guide security-event-stream`.
 


### PR DESCRIPTION
## Summary
- promote public stable and beta release metadata to v0.5.15
- refresh public documentation for the v0.5.15 security event stream privacy profile

Docs and release metadata update.