### PR TITLE
Release v0.5.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 - [docs/LLM-CAPACITY.md](docs/LLM-CAPACITY.md): which features use additional LLM capacity and how to control them
 - [docs/METRICS-REFERENCE.md](docs/METRICS-REFERENCE.md): emitted metric names, types, tags, and query guidance
 - [docs/MARKERS.md](docs/MARKERS.md): marker authoring and marker-derived metrics
+- [docs/DATA-FORMATS.md](docs/DATA-FORMATS.md): materialized session fields and LLM Observability export fields
+- [docs/SUBAGENT-TRACE-MODEL.md](docs/SUBAGENT-TRACE-MODEL.md): semantic subagent trace rendering and span-link behavior
 
 ## License
 

--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.15",
-    "tag": "v0.5.15",
-    "released_at": "2026-06-22T06:24:32Z"
+    "version": "0.5.16",
+    "tag": "v0.5.16",
+    "released_at": "2026-06-24T07:36:08Z"
   },
   "beta": {
-    "version": "0.5.15",
-    "tag": "v0.5.15",
-    "released_at": "2026-06-22T06:24:32Z"
+    "version": "0.5.16",
+    "tag": "v0.5.16",
+    "released_at": "2026-06-24T07:36:08Z"
   }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,6 +50,7 @@ trajectory config set export.site datadoghq.com
 trajectory config set export.traces standard       # off | minimal | standard | full
 trajectory config set export.metrics true
 trajectory config set export.placeholder_llm_span false
+trajectory config set export.subagent_span_mode links_only  # semantic | links_only
 trajectory config set local_ui.auto_start false
 trajectory config set capture.retention_days 30
 trajectory config set-secret dd-api-key            # prompts securely
@@ -116,6 +117,7 @@ export:
   traces: standard
   metrics: true
   placeholder_llm_span: true
+  subagent_span_mode: semantic
 
 local_ui:
   auto_start: true
@@ -318,6 +320,7 @@ Environment variables are best for temporary overrides, CI jobs, or one launched
 | `export.traces` | `off` | LLM Observability trace export level: `off`, `minimal`, `standard`, or `full` |
 | `export.metrics` | `true` | Cost, token, marker, and operations metric export |
 | `export.placeholder_llm_span` | `true` | Synthetic LLM child span for turn-level token and cost enrichment |
+| `export.subagent_span_mode` | `semantic` | Parent-side subagent rendering mode: `semantic` adds readable parent-side task spans, `links_only` keeps only child-trace links and metadata |
 | `export.sensitivity.scanning_mode` | `balanced` | Sensitivity classification mode: `balanced`, `near_realtime`, or `off` |
 | `segmentation.enabled` | `true` | Async task segmentation |
 | `segmentation.interval` | `10` | Number of turns between segmentation passes |

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1,0 +1,42 @@
+# Data Formats
+
+## Materialized Session JSON
+
+Materialized session documents use `format_version: 1`.
+
+### Session Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `parent_session_id` | string, optional | Parent session ID copied from `session_start.parent_session_id`, `session_start.forked_from_session_id`, or `session_start.forked_from_id` when present. Used to preserve canonical child-session linkage without requiring transcript paths. |
+
+### Turn Viewer Fields
+
+The local viewer may add compact, read-optimized fields to each materialized
+turn. These fields are derived from the turn's own tool calls and from marker
+annotations or the local DB marker table; they do not replace the raw
+`tool_calls`, `permissions`, `sub_agents`, or top-level `annotations.markers`
+records.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `tool_summary` | object, optional | Per-turn tool counts. Contains `total`, `by_tool[]` entries with `tool` and `count`, plus `failures` and `denied` counts. Sub-agent tool calls already nested under `sub_agents[]` are excluded from the parent turn summary. |
+| `file_touches` | array of objects, optional | Structured file touch summaries derived from file-oriented tools. Each entry contains `path`, `operation`, `tool`, `count`, and optional `bytes` and `lines` estimates for write/edit content. `operation` is one of `read`, `write`, or `edit`. |
+| `markers` | array of marker objects, optional | Markers directly attached to this turn for viewer rendering. The viewer attaches markers from materialized `annotations.markers` and, when reading an existing materialized trace, merges marker records from the local DB at read time. |
+| `marker_ids` | array of strings, optional | Stable IDs for the markers attached to this turn. IDs are deduplicated and correspond to the objects in `markers` and/or top-level `annotations.markers`. |
+
+### Turn Sub-Agent Fields
+
+Each turn can include `sub_agents[]` records for delegated child sessions.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `trace` | object, optional | Materialized child session loaded from a sibling canonical `session-{child_session_id}.jsonl` file when the parent sub-agent record has no interleaved nested content. The parent session's aggregate tool counts do not include tools from this nested trace. The local viewer may populate this field at read time for older materialized parent traces. |
+
+## LLM Observability Turn Cost Fields
+
+Turn spans keep token and cost aggregates on the span itself. When turn metrics include an estimated total cost, the span includes `metrics.estimated_total_cost` in nanodollars, `meta.metadata.estimated_total_cost_nanodollars`, `meta.metadata.estimated_total_cost_usd`, and the low-cardinality tag `trajectory.cost_source:turn_metrics`.
+
+The user config setting `export.placeholder_llm_span: false`, or publish destination setting `placeholder_llm_span: false`, disables Trajectory's synthetic LLM child span for turn-cost enrichment. It does not remove real LLM spans, and it does not remove the turn-level cost metric or fallback metadata above.
+
+Subagent spans default to `export.subagent_span_mode: semantic`: synchronous subagents attach under the launching Agent/Task tool span, while async background subagents attach under the task-notification join turn. The child session trace is still preserved through span links and child trace metadata. Set `export.subagent_span_mode: links_only`, or destination `subagent_span_mode: links_only`, to suppress the extra parent-side subagent task span and keep only links on the nearest existing parent span. See [Subagent Trace Model](SUBAGENT-TRACE-MODEL.md) for the client-by-client validation matrix.

--- a/docs/LLM-CAPACITY.md
+++ b/docs/LLM-CAPACITY.md
@@ -196,6 +196,8 @@ session:
 - `export.metrics`: controls metrics publish.
 - `export.placeholder_llm_span`: controls a synthetic Datadog LLM span for cost
   enrichment; it does not call an LLM.
+- `export.subagent_span_mode`: controls how captured subagent lifecycle events
+  are rendered in trace exports; it does not call an LLM.
 - Marker evaluation: built-in and YAML markers are rule-based over local SQLite
   data.
 - `segmentation.publish_metrics` and `segmentation.publish_traces`: control

--- a/docs/SUBAGENT-TRACE-MODEL.md
+++ b/docs/SUBAGENT-TRACE-MODEL.md
@@ -1,0 +1,53 @@
+# Subagent Trace Model
+
+Trajectory renders subagents with two separate relationships:
+
+- Parent-side semantic spans make the trace tree readable at the workflow point
+  where the parent agent launched or joined the child work.
+- Span links preserve cross-trace navigation to the child session trace without
+  collapsing the child trace under the parent turn.
+
+The default mode is `export.subagent_span_mode: semantic`. Set
+`export.subagent_span_mode: links_only`, or destination
+`subagent_span_mode: links_only`, to suppress the extra parent-side subagent
+task span while keeping child trace links and child metadata on the nearest
+existing parent span.
+
+## Invariants
+
+| Shape | Parent-side rendering | Link rendering |
+| --- | --- | --- |
+| Sync launch with matching `tool_use_id` | A `subagent-*` task span is parented to the launching `Task` or `Agent` tool span and carries `subagent_attachment: launch`. | The launch tool span and subagent task span link to the child session root. |
+| Async launch with task notification join | The launch tool span is annotated with launch metadata; a `subagent-*` task span is parented to the task-notification join turn and carries `subagent_attachment: join`. | The launch tool span and join task span link to the child session root. |
+| Lifecycle without a matching launch tool | A standalone subagent agent span is parented to the active turn and carries `subagent_attachment: standalone`. | The standalone span links to the child session root. |
+| `links_only` mode | No extra parent-side `subagent-*` task span is emitted. | The launch tool, join turn, or active turn carries child metadata and span links. |
+
+The child session remains its own trace in every mode. The parent turn trace
+must not directly parent child-session turns, tools, or LLM spans.
+
+## Client Validation Matrix
+
+| Client | Current subagent source shape | Expected rendering |
+| --- | --- | --- |
+| Claude Code | Native `SubagentStart` and `SubagentStop` with a `Task` or `Agent` launch tool. Async background work returns through a `task_notification` user prompt. | Sync subagents attach under the launch tool. Async subagents attach under the join turn. |
+| Codex | Rollout `collab_agent_spawn_begin` and `collab_agent_spawn_end` events; parent linkage is preserved through `parent_session_id` and child thread id. | Codex collab lifecycle emits a standalone linked subagent span unless a future parent launch tool is present. |
+| Cursor Desktop | Command-hook `subagentStart` and `subagentStop` payloads. Current Desktop fixtures can be sync or task-notification-style async. | Sync lifecycle without a launch tool falls back to standalone active-turn attachment; async lifecycle attaches to the task-notification join turn when present. |
+| GitHub Copilot CLI | Command-hook lifecycle payloads plus transcript metadata that recovers the real child tool-call id and parent task tool id. | Subagent lifecycle attaches under the launching Agent/Task tool when the normalized hook carries the recovered `tool_use_id`. |
+| Gemini CLI | No native lifecycle hook; Trajectory synthesizes `subagent_start` and `subagent_stop` from `kind:"subagent"` chat artifacts during session end. | Synthetic subagent lifecycle attaches under the synthesized launch tool. |
+| Factory Droid | Current hook set includes `SubagentStop` but not `SubagentStart`. | Stop-only lifecycle falls back to a standalone active-turn subagent span. |
+| OpenCode | Current plugin SDK path records agent metadata on prompt, tool, and message events but does not expose child-session lifecycle ids. | No semantic subagent parentage is inferred from `agent_id` or `agent_type` alone. |
+| Pi | Current extension records normal session, prompt, tool, turn, compaction, model, and fork events but no dedicated child-session subagent lifecycle. | No semantic subagent parentage is inferred from fork or agent metadata alone. |
+
+## When Adding A Client Pattern
+
+Add or update coverage at the first layer that owns the new fact:
+
+- Capture normalization tests for raw hook or transcript fields.
+- Fixture replay tests when the client has a real or documented fixture shape.
+- Mapper tests for parent-side span placement and `links_only` behavior.
+- Client fixture matrix coverage when the fixture should pass through capture
+  replay, direct published mapping, and publish-exporter mapping.
+
+Do not infer subagent parentage from generic agent metadata alone. The mapper
+needs a child session id plus either a launch tool id, a task-notification join
+point, or an explicit standalone lifecycle event.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -164,6 +164,8 @@ env var, before the first publish attempt.
 
 Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml`, or `placeholder_llm_span: false` on a managed/trusted `publish.trajectory.yaml` destination, to stop publishing Trajectory's synthetic LLM child span for turn-level token/cost enrichment. The turn span still carries `metrics.estimated_total_cost` plus cost fallback metadata and the `trajectory.cost_source:turn_metrics` tag, so cost remains queryable without the placeholder child span. Project configs may disable this for a trusted destination, but cannot re-enable it if the trusted or managed destination disabled it.
 
+Subagent spans default to `export.subagent_span_mode: semantic`: synchronous subagents attach under the launching Agent or Task tool span, while async background subagents attach under the task-notification join turn. Set `export.subagent_span_mode: links_only`, or destination `subagent_span_mode: links_only`, to suppress the extra parent-side subagent task span and keep only child-trace links and metadata. See [SUBAGENT-TRACE-MODEL.md](SUBAGENT-TRACE-MODEL.md).
+
 For managed local-ui auto-start rollback, deploy `local_ui.auto_start: false` in `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` and `trajectory view` commands still work.
 
 ## Capture server

--- a/plugin/trajectory/hooks/hooks.json
+++ b/plugin/trajectory/hooks/hooks.json
@@ -15,6 +15,6 @@
     "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:19222/capture/PermissionRequest?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.5", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
     "SubagentStart": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:19222/capture/SubagentStart?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.5", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
     "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://localhost:19222/capture/SubagentStop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.5", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "\"${HOME}/.trajectory/bin/trajectory\" capture-hook SessionEnd &", "timeout": 2 }] }]
+    "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "\"${HOME}/.trajectory/bin/trajectory\" capture-hook --background-after-read --ensure-serve --ensure-serve-wait 2s --wait-notify 2s SessionEnd", "timeout": 2 }] }]
   }
 }


### PR DESCRIPTION
## Summary
- update release metadata to v0.5.16
- mirror the Claude SessionEnd hook update
- add public docs for data formats and subagent trace rendering

## Validation
- public scaffold validation
- JSON/schema checks
- Pi query-tool tests and typecheck