### PR TITLE
Release v0.5.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Observe AI coding agents like production systems.
 
 See the whole run. Measure the behavior. Improve the workflow.
 
-Trajectory captures coding-agent sessions across Claude Code, Codex, Gemini,
-Antigravity, Goose, Hermes Agent, Amp Code, Qwen Code, Kilo Code, Cursor, Pi,
-OpenCode, GitHub Copilot CLI, and Factory Droid, then turns them into local
-timelines, Datadog LLM Observability traces, operational metrics, and Markers.
+Trajectory captures coding-agent sessions across Claude Code, Cline CLI,
+Codex, Gemini, Antigravity, Goose, Aider, Continue CLI, Mistral Vibe,
+Codebuff, Hermes Agent, Amp Code, Qwen Code, OpenHands, Kiro CLI, Kilo Code,
+Cursor, Pi, OpenCode, GitHub Copilot CLI, and Factory Droid, then turns them
+into local timelines, Datadog LLM Observability traces, operational metrics,
+and Markers.
 
 ## What It Answers
 
@@ -78,8 +80,9 @@ agent behavior becomes something you can graph, alert on, compare, and improve.
 
 ## Core Capabilities
 
-- **Multi-client instrumentation** for Claude Code, Codex CLI, Gemini CLI,
-  Antigravity CLI, Goose, Hermes Agent, Amp Code, Qwen Code, Kilo Code,
+- **Multi-client instrumentation** for Claude Code, Cline CLI, Codex CLI,
+  Gemini CLI, Antigravity CLI, Goose, Aider, Continue CLI, Mistral Vibe,
+  Codebuff, Hermes Agent, Amp Code, Qwen Code, OpenHands, Kiro CLI, Kilo Code,
   Cursor, Pi, OpenCode, GitHub Copilot CLI beta, and Factory Droid beta.
 - **Local-first timelines** for session lifecycle, turns, tool calls, model
   usage, cost signals, and repository context.
@@ -100,7 +103,7 @@ agent behavior becomes something you can graph, alert on, compare, and improve.
 bash <(curl -fsSL https://raw.githubusercontent.com/datadog-labs/trajectory/main/install.sh)
 ```
 
-The installer downloads the latest Trajectory release asset for your platform, installs it under `~/.trajectory/bin/trajectory`, stages the Claude wrapper intercept runtime, runs `trajectory setup`, and registers detected coding-agent plugins.
+The installer downloads the latest Trajectory release asset for your platform, installs it under `~/.trajectory/bin/trajectory`, stages the Claude wrapper intercept runtime, runs `trajectory setup`, and registers detected coding-agent integrations. Agent command shims are opt-in and can be installed with `--install-client-shims` where supported.
 
 To upgrade an install from this repository, rerun the installer.
 
@@ -120,14 +123,21 @@ trajectory-windows-amd64.exe
 Trajectory supports:
 
 - Claude Code
+- Cline CLI
 - Codex CLI
 - GitHub Copilot CLI beta
 - Gemini CLI
 - Antigravity CLI (`agy`)
+- Aider
+- Continue CLI
+- Mistral Vibe
+- Codebuff
 - Goose
 - Hermes Agent
 - Amp Code
 - Qwen Code
+- OpenHands
+- Kiro CLI
 - Kilo Code
 - Cursor Desktop and cursor-agent
 - Factory Droid beta

--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.18",
-    "tag": "v0.5.18",
-    "released_at": "2026-06-29T12:54:28Z"
+    "version": "0.5.19",
+    "tag": "v0.5.19",
+    "released_at": "2026-07-01T15:34:44Z"
   },
   "beta": {
-    "version": "0.5.18",
-    "tag": "v0.5.18",
-    "released_at": "2026-06-29T12:54:28Z"
+    "version": "0.5.19",
+    "tag": "v0.5.19",
+    "released_at": "2026-07-01T15:34:44Z"
   }
 }

--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -23,15 +23,22 @@ trajectory user-guide clients
 | Gemini CLI | `trajectory setup --clients gemini` | Managed command hooks plus MCP | Gemini transcript backfill |
 | Antigravity CLI (`agy`) | `trajectory setup --clients agy` | Antigravity plugin command hooks plus MCP | None |
 | Goose | `trajectory setup --clients goose` | Open Plugins command hooks | None |
+| Cline CLI | `trajectory setup --clients cline` | File hooks plus MCP | None |
+| Aider | `trajectory setup --clients aider --install-client-shims` | Opt-in command shim plus analytics/history sidecars | None |
+| Continue CLI | `trajectory setup --clients continue --install-client-shims` | Opt-in `cn` shim plus session JSON readback | None |
+| Mistral Vibe | `trajectory setup --clients mistral-vibe --install-client-shims` | Opt-in command shim plus native tool hooks | None |
+| Codebuff | `trajectory setup --clients codebuff --install-client-shims` | Opt-in command shims plus chat-history import | Codebuff chat history |
 | Cursor Desktop | `trajectory setup --clients cursor` | Cursor command hooks plus MCP | Cursor chat backfill |
 | cursor-agent CLI | Automatic when `cursor-agent` is on PATH | Transcript watcher | Same transcript source |
 | Factory Droid | `trajectory setup --clients droid` | Beta Factory command hooks plus MCP | None |
 | Hermes Agent | `trajectory setup --clients hermes` | Observer Python plugin plus MCP | None |
 | Amp Code | `trajectory setup --clients amp` | System TypeScript plugin plus MCP | None |
 | Qwen Code | `trajectory setup --clients qwen` | Native HTTP hooks plus MCP | None |
+| OpenHands | `trajectory setup --clients openhands` | Command hooks plus MCP | None |
 | Pi | `trajectory setup --clients pi` | TypeScript extension plus eager MCP | Pi/OMP session backfill |
 | OpenCode | `trajectory setup --clients opencode` | OpenCode plugin SDK events plus MCP | SQLite backfill |
 | Kilo Code | `trajectory setup --clients kilo` | Plugin SDK events plus MCP | None |
+| Kiro CLI | `trajectory setup --clients kiro` | Agent command hooks plus MCP | None |
 
 ## Shared Local Flow
 
@@ -52,15 +59,16 @@ for the client:
   introspection.
 - Agent skills or slash commands where the client supports them.
 - Local marketplace metadata for plugin-based clients.
+- Opt-in command shims for clients that do not expose native hooks.
 - An installed or extension-local `trajectory` binary path where the client
   expects one.
 
 Plugin-only manual installs can miss these companion pieces. Use
 `trajectory setup --clients <client>` for normal installs and refreshes. That
-client-only path updates hooks, MCP entries, skills, commands, local binaries,
-and local marketplace files without prompting for Datadog site, service name,
-or API key values. Run `trajectory setup` without `--clients` when you want to
-change export settings.
+client-only path updates hooks, MCP entries, skills, commands, opt-in command
+shims, local binaries, and local marketplace files without prompting for
+Datadog site, service name, or API key values. Run `trajectory setup` without
+`--clients` when you want to change export settings.
 
 The authoritative MCP catalog, including safe query examples, is embedded in
 the binary:
@@ -204,6 +212,61 @@ goose plugin list
 trajectory doctor
 ```
 
+## Cline CLI
+
+Setup writes Trajectory-owned file hooks under `~/.cline/hooks` or
+`$CLINE_DIR/hooks`, plus Trajectory MCP settings. Existing user hook files are
+preserved. The hook scripts invoke `trajectory capture-hook --client cline
+--ensure-serve` and send stdin payloads to `/capture/cline/<event>`.
+
+Captured rows use `client_source=cline`. Current Cline hooks expose lifecycle,
+prompt, tool, assistant summary, and shutdown payloads, but not stable token or
+cost usage.
+
+## Aider
+
+Aider capture uses an opt-in command shim. Setup writes a managed `aider` shim
+under `~/.trajectory/bin` and wrapper metadata under
+`~/.trajectory/state/aider/`. The shim invokes the real Aider binary, starts or
+reuses `trajectory serve`, and adds analytics and history sidecars when the
+user has not already supplied them.
+
+The shim posts session, prompt, assistant-message, turn, and session-end events.
+Token and cost fields come from Aider analytics rows when present.
+
+## Continue CLI
+
+Continue capture uses an opt-in `cn` command shim. Setup writes wrapper metadata
+under `~/.trajectory/state/continue/`. The shim invokes the real Continue CLI,
+sets a Trajectory session id for new sessions, and reads Continue session JSON
+after the real process exits.
+
+Prompt text, assistant text, model, tokens, and cost are derived from Continue
+session history when those fields are present.
+
+## Mistral Vibe
+
+Mistral Vibe capture uses an opt-in `vibe` command shim plus native
+`before_tool` and `after_tool` hook entries. The shim starts or reuses
+`trajectory serve`, enables Vibe experimental hooks for the wrapped process,
+and reads Vibe session logs after the run.
+
+Trajectory records prompt, tool, assistant-message, turn, and session-end events
+with `client_source=mistral-vibe`. Token and cost fields come from Vibe session
+metadata when session logging is enabled.
+
+## Codebuff
+
+Codebuff capture uses opt-in `codebuff` and `cb` command shims. The shim invokes
+the real Codebuff binary unchanged, then imports any Codebuff
+`chat-messages.json` rows written for the current project. `CODEBUFF_DATA_DIR`
+can override the default Codebuff history roots.
+
+The shim and `trajectory backfill --from-codebuff-chats` emit session, prompt,
+assistant-message, turn, and session-end events. When Codebuff history contains
+provider usage metadata, Trajectory normalizes token usage and emits
+provider-call rows.
+
 ## Cursor
 
 Cursor has two distinct capture paths.
@@ -264,6 +327,16 @@ Qwen Code supports OpenAI-compatible providers. Trajectory records Qwen
 a fallback for stop payloads that omit usage. Historical Qwen import is not
 implemented yet.
 
+## OpenHands
+
+Setup writes command hooks to `~/.openhands/hooks.json` and a Trajectory MCP
+server entry to `~/.openhands/mcp.json`. The hooks invoke `trajectory
+capture-hook --client openhands --ensure-serve` because OpenHands sends hook
+payload JSON on stdin.
+
+Current OpenHands command hooks cover session start, prompts, tools, stop, and
+session end. They do not expose assistant messages or token usage today.
+
 ## Pi
 
 Setup writes `~/.pi/agent/extensions/trajectory/` and points
@@ -306,6 +379,16 @@ through the local Trajectory OTLP relay.
 Manual fallback: copy `plugin/trajectory-kilo` to
 `~/.config/kilo/plugins/trajectory` and add that absolute path to Kilo's
 `plugin` array plus a `trajectory` MCP entry.
+
+## Kiro CLI
+
+Setup writes Trajectory-owned Kiro agent configuration under `~/.kiro/agents/`
+and merges a Trajectory MCP server into Kiro settings. Kiro command hooks pass
+payload JSON on stdin for agent spawn, user prompt, tool events, and stop.
+
+Captured rows use `client_source=kiro`. Stop payloads include assistant response
+text, but current documented hook payloads do not expose stable token or cost
+usage.
 
 ## Troubleshooting
 

--- a/docs/LLM-CAPACITY.md
+++ b/docs/LLM-CAPACITY.md
@@ -15,7 +15,7 @@ trajectory user-guide llm-capacity
 | Feature | Default | What it does | How often it can call an LLM | Primary controls |
 |---|---|---|---|---|
 | Task segmentation | On | Splits sessions into tasks and scores task dimensions such as outcome, autonomy, risk, and reversibility | About every `segmentation.interval` completed turns, default 10, plus one final pass at session end for sessions with at least 2 turns | `segmentation.enabled`, `segmentation.interval`, `segmentation.model`, `TRAJECTORY_SEGMENTATION_DISABLED=1` |
-| Sensitivity classification | On, `balanced` mode | Classifies session content for the publish gate as public, internal, confidential, or restricted | In `balanced` mode, about every 10 completed turns, plus a session-end scan on the non-incognito publish path. In `near_realtime` mode, active sessions are scanned only when new content exists, default every 30 minutes. | `export.sensitivity.scanning_mode`, `export.sensitivity.near_realtime_interval_minutes` |
+| Sensitivity classification | On, `near_realtime` mode | Classifies session content for the publish gate as public, internal, confidential, or restricted | In `near_realtime` mode, active sessions are scanned only when new content exists, default every 240 minutes, plus a session-end scan on the non-incognito publish path. In `balanced` mode, about every 10 completed turns, plus the session-end scan. | `export.sensitivity.scanning_mode`, `export.sensitivity.near_realtime_interval_minutes` |
 
 For zero Trajectory-owned LLM calls from the capture server, disable both:
 
@@ -50,7 +50,8 @@ For example, a 23-turn session normally means about 3 segmentation calls: turn
 
 Headless coding-agent sessions are included in capture and publish by default
 when export is configured. Sensitivity/classification and segmentation always
-skip headless sessions. To opt out of capture/publish for headless agent sessions:
+skip headless sessions. To opt out of capture/publish for all non-internal
+headless agent sessions:
 
 ```bash
 trajectory config set capture.include_headless_agents false
@@ -88,7 +89,7 @@ LLM capacity use.
 
 ## Sensitivity classification
 
-Sensitivity classification is enabled by default in `balanced` mode. It is
+Sensitivity classification is enabled by default in `near_realtime` mode. It is
 primarily used by trace publish privacy gates, but `export.traces=off` is not a
 guaranteed capacity control by itself. If you want no sensitivity-classifier LLM
 calls and no sensitivity publish gate, set `export.sensitivity.scanning_mode`
@@ -96,12 +97,11 @@ to `off`.
 
 Scanning modes:
 
-- `balanced` is the default. It scans on the same default turn cadence as
-  segmentation: about every 10 completed turns, plus a final session-end scan on
-  the non-incognito publish path.
-- `near_realtime` scans active sessions on a time window when new content
-  exists. The default interval is 30 minutes, and the durable per-session window
-  is enforced across concurrent serve processes.
+- `near_realtime` is the default. It scans active sessions on a time window when
+  new content exists. The default interval is 240 minutes.
+- `balanced` scans on the same default turn cadence as segmentation: about every
+  10 completed turns, plus a final session-end scan on the non-incognito publish
+  path.
 - `off` disables sensitivity classifier calls and disables the sensitivity
   publish gate.
 
@@ -141,7 +141,7 @@ classifier calls:
 
 ```bash
 trajectory config set export.sensitivity.scanning_mode near_realtime
-trajectory config set export.sensitivity.near_realtime_interval_minutes 30
+trajectory config set export.sensitivity.near_realtime_interval_minutes 240
 ```
 
 Lower `near_realtime_interval_minutes` values can release held spans sooner, but
@@ -156,10 +156,10 @@ near_realtime: active windows with new content / interval + at most 1 session-en
 off:           0 calls
 ```
 
-Incognito is a privacy control, not a global capacity control. It suppresses
-publish for ordinary destinations and skips active-session and final sensitivity
-scans for that session. Use `scanning_mode: off` when you want a
-configuration-wide guarantee of zero sensitivity-classifier calls.
+Incognito is a privacy control, not a capacity control. It suppresses publish
+for ordinary destinations and skips the final non-incognito publish-drain scan,
+but active-session sensitivity scanning can still run while the session is
+active. Use `scanning_mode: off` for a capacity guarantee.
 
 ## Cost reporting
 
@@ -175,10 +175,6 @@ The cost metric uses estimated token counts from prompt and output size, then
 prices those counts with Trajectory's existing model pricing table. It is not a
 provider invoice. Calls whose model is not visible or not priced still emit
 `trajectory.serve.llm_capacity.calls.total` with `cost_source:pricing_unknown`.
-Classifier backend errors can also represent attempted calls that consumed
-provider-side capacity before failing or returning unparseable output. Check
-`trajectory.serve.sensitivity.classifier_backend_error` alongside the capacity
-metrics when investigating unexpected spend.
 
 Useful queries:
 
@@ -196,8 +192,6 @@ session:
 - `export.metrics`: controls metrics publish.
 - `export.placeholder_llm_span`: controls a synthetic Datadog LLM span for cost
   enrichment; it does not call an LLM.
-- `export.subagent_span_mode`: controls how captured subagent lifecycle events
-  are rendered in trace exports; it does not call an LLM.
 - Marker evaluation: built-in and YAML markers are rule-based over local SQLite
   data.
 - `segmentation.publish_metrics` and `segmentation.publish_traces`: control

--- a/docs/MARKERS.md
+++ b/docs/MARKERS.md
@@ -687,6 +687,10 @@ gen_ai.usage.input_tokens: 4300
 gen_ai.usage.output_tokens: 1240
 ```
 
+When generic skill-tool invocations omit native skill source metadata,
+Trajectory can infer `source_scope` by matching `skill_name` to local project
+or user skill files.
+
 The expected metric tags include `environment:test`, `session_id:<id>`, `trajectory.client_source:pi`, `trajectory.client_version:marker-canary/dev`, `gen_ai.request.model:openai/gpt-5.1`, and `project_dir:trajectory-marker-canary-fixture`. Marker detail fields such as `detected_from` and `source_scope` are validated locally; they are not Datadog metric tags unless a measure explicitly maps them to bounded dimensions.
 
 ## End-to-end authoring workflow

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -85,7 +85,7 @@ unattributed.
 |---|---|---|
 | `gen_ai.conversation.id` | Session ID | `unknown` |
 | `session_id` | Compatibility alias for session ID | `unknown` |
-| `trajectory.client_source` | Client source, such as `claude-code`, `codex`, `gemini`, `agy`, `cursor`, `pi`, or `opencode` | `unknown` |
+| `trajectory.client_source` | Client source, such as `claude-code`, `cline`, `codex`, `gemini`, `agy`, `goose`, `aider`, `continue`, `mistral-vibe`, `codebuff`, `cursor`, `openhands`, `kiro`, `pi`, or `opencode` | `unknown` |
 | `trajectory.user` | Resolved user | `unknown` |
 | `trajectory.user_email` | Optional resolved user email from `TRAJECTORY_USER_EMAIL`, `identity.user_email`, `identity.user_email_command`, or `identity.user_email_suffix` | Omitted |
 | `git.email` | Optional resolved Git email from `TRAJECTORY_GITHUB_EMAIL`, `identity.github_email`, `identity.github_email_command`, repo-local Git config, or global Git config | Omitted |
@@ -264,6 +264,23 @@ Built-in and setup-default metrics include:
 | `trajectory.session.task_autonomy_mean` | gauge | session | Mean task autonomy score when task-segmentation publish is enabled for the destination |
 | `trajectory.session.high_risk_tasks` | gauge | session | Tasks with high risk score when task-segmentation publish is enabled for the destination |
 
+For trusted skill usage reports, prefer `trajectory.turn.skill_invocations` with
+`sum by {skill_name,detected_from,source_scope,signal_confidence}`. When native
+or explicit source metadata is unavailable, `source_scope` may be recovered by
+matching a generic skill-tool invocation against local project or user skill
+files. These metric series also carry normal Trajectory session tags including
+`trajectory.client_source`, `trajectory.client_version`, `trajectory.user`, and
+repo tags when available.
+
+Claude Code skill activation can arrive from native OTLP `skill_activated` logs
+or native transcript assistant messages with `attributionSkill`. When a turn
+has a high-confidence skill invocation marker, Trajectory also emits skill
+complexity metrics. Tool spans with native skill attributes publish as
+`skill_attribution:span_tool_attribute`; otherwise Trajectory can correlate a
+single high-confidence skill signal with same-turn Claude tool spans as
+`skill_attribution:span_temporal`, or fall back to same-turn materialized tool
+rows tagged `skill_attribution:turn_assisted`.
+
 Count-like session gauges that represent one final value per completed session
 also publish a `.completed_count` mirror, for example
 `trajectory.session.force_pushes.completed_count`,
@@ -299,6 +316,8 @@ privacy/publish diagnostics.
 
 | Metric | Type | Tags | Notes |
 |---|---|---|---|
+| `trajectory.ops.install.current_state` | gauge | Canonical serve tags plus `managed`, `role`, `outcome`, `reason`, `setup_binary_status`, `setup_binary_version` | Managed setup summary. Current state emits `1`; prior state series emit `0` when setup state changes so dashboards can filter on the latest active state. |
+| `trajectory.ops.install.agent_state` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `agent_status`, `setup_outcome`, `setup_stage`, `setup_component`, `setup_capture_path`, `setup_next_step`, `reason`, `setup_binary_status`, `setup_binary_version` | Per-integration setup state for every selected client. Distinguishes registration failures from verification failures and degraded fallback paths such as MCP watcher fallback. |
 | `trajectory.publish.active_destinations` | gauge | Canonical tags plus top-level and destination tags on Datadog destinations | Number of active destinations seen for a session |
 | `trajectory.publish.turns` | count | OTLP publish path tags | Internal publish turn counter |
 | `trajectory.serve.incognito.enabled` | count | `client_source` | User or tool enabled incognito; intentionally not tagged by session ID |
@@ -322,6 +341,18 @@ LLM-capacity cost is estimated from prompt/output size and the existing model
 pricing table. It is useful for directional spend dashboards, not provider
 invoice reconciliation. Calls whose model is not visible or priced still emit
 the call count with `cost_source:pricing_unknown`.
+
+Managed setup state uses low-cardinality reason and remediation tags. Use
+`setup_stage:registration` when client setup failed before writing or
+registering assets, `setup_stage:verification` when setup completed but the
+installed config is not usable, `setup_stage:fallback` when capture is expected
+through a lower-fidelity fallback, and `setup_stage:configured` for a fully
+verified integration. `setup_component` identifies the failed surface, such as
+`mcp_config`, `hooks_config`, `plugin_marketplace`, `plugin_install`,
+`wrapper_metadata`, `client_runtime`, or `sdk_extension`. `setup_next_step`
+contains a bounded remediation code such as `rerun_setup_client`,
+`install_client_then_rerun_setup`, `fix_permissions_then_rerun_setup`,
+`install_node_or_reinstall_client`, or `ensure_trajectory_bin_first_on_path`.
 
 ## Companion Metrics
 

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -14,10 +14,17 @@ trajectory user-guide clients
 trajectory user-guide clients/codex
 trajectory user-guide clients/agy
 trajectory user-guide clients/goose
+trajectory user-guide clients/cline
+trajectory user-guide clients/aider
+trajectory user-guide clients/continue
+trajectory user-guide clients/mistral-vibe
+trajectory user-guide clients/codebuff
 trajectory user-guide clients/hermes
 trajectory user-guide clients/amp
 trajectory user-guide clients/qwen
+trajectory user-guide clients/openhands
 trajectory user-guide clients/kilo
+trajectory user-guide clients/kiro
 ```
 
 ## Quick Reference
@@ -30,15 +37,22 @@ trajectory user-guide clients/kilo
 | Gemini CLI | `trajectory setup --clients gemini` | 0.30.0+ | Managed command hooks + MCP |
 | Antigravity CLI (`agy`) | `trajectory setup --clients agy` | 1.0.0+ | Antigravity plugin command hooks + MCP |
 | Goose | `trajectory setup --clients goose` | 1.39.0 tested | Open Plugins command hooks |
+| Cline CLI | `trajectory setup --clients cline` | 3.0.34 tested | File hooks + MCP |
+| Aider | `trajectory setup --clients aider --install-client-shims` | Current CLI tested | Opt-in command shim + analytics/history sidecars |
+| Continue CLI | `trajectory setup --clients continue --install-client-shims` | 1.5.47 tested | Opt-in `cn` command shim + session JSON readback |
+| Mistral Vibe | `trajectory setup --clients mistral-vibe --install-client-shims` | 2.18.3 inspected | Opt-in command shim + native tool hooks |
+| Codebuff | `trajectory setup --clients codebuff --install-client-shims` | 1.0.682 inspected | Opt-in command shims + chat-history import |
 | Cursor Desktop | `trajectory setup --clients cursor` | 1.0+ | Command hooks that POST to capture |
 | cursor-agent CLI | Automatic when `cursor-agent` is on PATH | Beta | Transcript watcher |
 | Factory Droid | `trajectory setup --clients droid` | Beta | Factory plugin command hooks + MCP |
 | Hermes Agent | `trajectory setup --clients hermes` | Beta | Observer plugin hooks + MCP |
 | Amp Code | `trajectory setup --clients amp` | Beta | System TypeScript plugin events + MCP |
 | Qwen Code | `trajectory setup --clients qwen` | 0.19.2 tested | Native HTTP hooks + MCP |
+| OpenHands | `trajectory setup --clients openhands` | V1 CLI tested | Command hooks + MCP |
 | Pi | `trajectory setup --clients pi` | Beta | TypeScript extension + MCP |
 | OpenCode | `trajectory setup --clients opencode` | Beta | Plugin SDK events + MCP |
 | Kilo Code | `trajectory setup --clients kilo` | Beta | Plugin SDK events + MCP |
+| Kiro CLI | `trajectory setup --clients kiro` | Beta | Agent command hooks + MCP |
 
 ## Feature Coverage Matrix
 
@@ -50,15 +64,22 @@ trajectory user-guide clients/kilo
 | Gemini CLI | Yes, managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
 | Antigravity CLI (`agy`) | Yes, plugin command hooks | Yes, via Gemini-compatible hook schema | Yes, via Gemini-compatible token fields | Yes | Not yet | No setup-managed resume |
 | Goose | Yes, Open Plugins command hooks | Session, prompt, tool, shell/file, and assistant-message hooks | Usage when hook payloads expose it | Not yet | Not yet | No setup-managed resume |
+| Cline CLI | Yes, file hooks | Lifecycle, prompt, tool, assistant-message, turn, and session-end events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
+| Aider | Yes, opt-in command shim | Prompt, assistant-message, and turn events | Yes, from Aider analytics rows when present | Command shim | Not yet | No setup-managed resume |
+| Continue CLI | Yes, opt-in `cn` command shim | Prompt, assistant-message, and turn events | Yes, from Continue session usage metadata when present | Command shim | Not yet | No setup-managed resume |
+| Mistral Vibe | Yes, opt-in command shim plus native tool hooks | Prompt, tool, assistant-message, and turn events | Yes, from Vibe session metadata when present | Command shim | Not yet | No setup-managed resume |
+| Codebuff | Yes, opt-in command shims and chat-history import | Prompt, assistant-message, turn, and chat-history-derived model events | Yes, from Codebuff chat metadata | Command shim | Codebuff chat history backfill | No setup-managed resume |
 | Cursor Desktop | Yes, command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
 | cursor-agent CLI | Yes, transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
 | Factory Droid | Yes, beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Hermes Agent | Yes, observer plugin hooks | Yes | Usage payloads when present | Yes | Not yet | No setup-managed resume |
 | Amp Code | Yes, setup-managed system plugin | Yes | When Amp plugin events expose usage | MCP | Not yet | No setup-managed resume |
 | Qwen Code | Yes, native HTTP hooks | Yes | Yes, from usage metadata and transcript fallback | Yes | Not yet | No setup-managed resume |
+| OpenHands | Yes, command hooks | Lifecycle, prompt, and tool events | Not exposed by command hook payloads | Yes | Not yet | No setup-managed resume |
 | Pi | Yes, TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Yes, plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
 | Kilo Code | Yes, plugin SDK events | Yes | Native OTLP traces/logs plus SDK payloads when exposed | Yes | Not yet | No setup-managed resume |
+| Kiro CLI | Yes, agent command hooks | Prompt, tool, and assistant-response events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
 
 For local cost readback and supported-agent fidelity checks, run `trajectory
 cost`, `trajectory cost inspect --session <id>`, and `trajectory cost
@@ -74,7 +95,7 @@ local marketplace metadata. It skips Datadog site, service name, and API key
 prompts, so it is also the right path when you only want to add, repair, or
 update one client integration.
 
-Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, or the capture hooks needed for complete telemetry.
+Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, opt-in command shims, or the capture hooks needed for complete telemetry.
 
 ## Codex CLI
 
@@ -231,6 +252,86 @@ Goose live capture covers session start/end, prompts, tool calls, shell and
 file events, and assistant-message checkpoints. Historical Goose backfill is
 not implemented yet.
 
+## Cline CLI
+
+**Minimum version: 3.0.34 tested** (file hooks and MCP)
+
+Install with setup:
+
+```bash
+trajectory setup --clients cline
+```
+
+Setup writes Trajectory-owned file hooks under `~/.cline/hooks` or
+`$CLINE_DIR/hooks` and registers Trajectory MCP in Cline settings. Existing
+user hook files are preserved; setup chooses a supported alternate suffix when
+needed. Current Cline hooks expose lifecycle, prompt, tool, assistant summary,
+and shutdown payloads, but not stable token or cost usage.
+
+## Aider
+
+**Status: Beta**
+
+Install with setup:
+
+```bash
+trajectory setup --clients aider --install-client-shims
+```
+
+Aider capture uses an opt-in command shim. Setup writes a managed `aider` shim
+under `~/.trajectory/bin`, links it into an existing home bin directory when
+possible, and records wrapper metadata under `~/.trajectory/state/aider/`.
+The shim passes user arguments through, adds analytics and history sidecars when
+not already supplied, and records prompts, assistant messages, token usage, and
+cost from Aider's sidecar files when present.
+
+## Continue CLI
+
+**Minimum version: 1.5.47 tested**
+
+Install with setup:
+
+```bash
+trajectory setup --clients continue --install-client-shims
+```
+
+Continue capture uses an opt-in `cn` command shim. The shim starts or reuses
+`trajectory serve`, passes user arguments through, and reads Continue session
+JSON after the real CLI exits. Prompt text, assistant text, model, token, and
+cost fields are derived from Continue session history when those fields are
+present.
+
+## Mistral Vibe
+
+**Status: Beta**
+
+Install with setup:
+
+```bash
+trajectory setup --clients mistral-vibe --install-client-shims
+```
+
+Mistral Vibe capture uses an opt-in `vibe` command shim plus native
+`before_tool` and `after_tool` hook entries in Vibe's hook config. Tool events
+come from the native hooks; prompt, assistant-message, token, and cost fields
+come from Vibe session metadata when session logging is enabled.
+
+## Codebuff
+
+**Minimum version: 1.0.682 inspected**
+
+Install with setup:
+
+```bash
+trajectory setup --clients codebuff --install-client-shims
+```
+
+Codebuff capture uses opt-in `codebuff` and `cb` command shims. After the real
+CLI exits, Trajectory imports Codebuff `chat-messages.json` rows for the current
+project and records prompt, assistant-message, turn, and provider-call events
+when usage metadata is present. `trajectory backfill --from-codebuff-chats`
+uses the same history import path.
+
 ## Cursor
 
 Cursor has two separate products with different capture paths:
@@ -360,6 +461,22 @@ Qwen Code supports OpenAI-compatible providers. Trajectory records
 transcript as a fallback for stop payloads that omit usage. Historical Qwen
 backfill is not implemented yet.
 
+## OpenHands
+
+**Status: Beta**
+
+Install with setup:
+
+```bash
+trajectory setup --clients openhands
+```
+
+Setup writes command hooks to `~/.openhands/hooks.json` and a Trajectory MCP
+entry to `~/.openhands/mcp.json`. The hooks use `trajectory capture-hook --client
+openhands --ensure-serve` because OpenHands sends hook payload JSON on stdin.
+Current OpenHands command hooks cover session start, prompts, tools, stop, and
+session end. They do not expose assistant messages or token usage today.
+
 ## OpenCode
 
 **Status: Supported** (headless mode: `opencode run`)
@@ -405,6 +522,22 @@ array plus a `trajectory` MCP entry.
 **Source:** [github.com/Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode),
 [Kilo CLI docs](https://kilo.ai/docs/code-with-ai/platforms/cli)
 
+## Kiro CLI
+
+**Status: Beta**
+
+Install with setup:
+
+```bash
+trajectory setup --clients kiro
+```
+
+Setup writes Trajectory-owned Kiro agent configuration under `~/.kiro/agents/`
+and merges a Trajectory MCP server into Kiro settings. Kiro command hooks send
+payload JSON on stdin for agent spawn, user prompt, tool events, and stop.
+Stop payloads include assistant response text, but current documented hook
+payloads do not expose stable token or cost usage.
+
 ## Version Check
 
 To verify your client version:
@@ -416,9 +549,16 @@ copilot version           # GitHub Copilot CLI
 gemini --version          # Gemini CLI
 cursor --version          # Cursor (desktop) / cursor-agent --version (CLI)
 goose --version           # Goose
+cline --version           # Cline CLI
+aider --version           # Aider
+cn --version              # Continue CLI
+vibe --version            # Mistral Vibe
+codebuff --version        # Codebuff
 hermes --version          # Hermes Agent
 amp --version             # Amp Code
 qwen --version            # Qwen Code
+openhands --version       # OpenHands
+kiro --version            # Kiro CLI
 droid --version           # Factory Droid
 pi --version              # Pi
 opencode --version        # OpenCode (note: takes cwd as argument)

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -237,11 +237,18 @@ trajectory setup --clients codex     # Add or refresh one client integration
 trajectory setup --clients copilot   # Add or refresh GitHub Copilot CLI beta live capture
 trajectory setup --clients agy       # Add or refresh Antigravity CLI capture
 trajectory setup --clients goose     # Add or refresh Goose capture
+trajectory setup --clients cline     # Add or refresh Cline CLI capture
+trajectory setup --clients aider --install-client-shims     # Add or refresh Aider shim capture
+trajectory setup --clients continue --install-client-shims  # Add or refresh Continue CLI shim capture
+trajectory setup --clients mistral-vibe --install-client-shims # Add or refresh Mistral Vibe shim capture
+trajectory setup --clients codebuff --install-client-shims  # Add or refresh Codebuff shim capture
 trajectory setup --clients droid     # Add or refresh Factory Droid beta live capture
 trajectory setup --clients hermes    # Add or refresh Hermes Agent capture
 trajectory setup --clients amp       # Add or refresh Amp Code capture
 trajectory setup --clients qwen      # Add or refresh Qwen Code capture
+trajectory setup --clients openhands # Add or refresh OpenHands capture
 trajectory setup --clients kilo      # Add or refresh Kilo Code capture
+trajectory setup --clients kiro      # Add or refresh Kiro CLI capture
 trajectory setup --clients all       # Add or refresh all setup-managed clients
 trajectory setup auto-instrument --json  # Dry-run managed auto-instrument plan
 trajectory setup auto-instrument apply --yes --json  # Apply when managed mutation is enabled
@@ -273,15 +280,22 @@ local sink" above.
 | Gemini CLI | Managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
 | Antigravity CLI (`agy`) | Antigravity plugin command hooks | Yes | Yes | Yes | Not yet | No setup-managed resume |
 | Goose | Open Plugins command hooks | Session, prompt, tool, shell/file, and assistant-message hooks | Usage when hook payloads expose it | Not yet | Not yet | No setup-managed resume |
+| Cline CLI | File hooks | Lifecycle, prompt, tool, assistant-message, turn, and session-end events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
+| Aider | Opt-in command shim with analytics and history sidecars | Prompt, assistant-message, and turn events | Yes, from Aider analytics rows when present | Command shim | Not yet | No setup-managed resume |
+| Continue CLI | Opt-in `cn` command shim plus session JSON readback | Prompt, assistant-message, and turn events | Yes, from Continue session usage metadata when present | Command shim | Not yet | No setup-managed resume |
+| Mistral Vibe | Opt-in command shim plus native tool hooks | Prompt, tool, assistant-message, and turn events | Yes, from Vibe session metadata when present | Command shim | Not yet | No setup-managed resume |
+| Codebuff | Opt-in command shims plus chat-history import | Prompt, assistant-message, turn, and chat-history-derived model events | Yes, from Codebuff chat metadata | Command shim | Codebuff chat history backfill | No setup-managed resume |
 | Cursor Desktop | Command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
 | cursor-agent CLI | Transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
 | Factory Droid | Beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
 | Hermes Agent | Observer plugin hooks | Yes | Usage payloads when present | Yes | Not yet | No setup-managed resume |
 | Amp Code | Setup-managed system plugin | Yes | When Amp plugin events expose usage | MCP | Not yet | No setup-managed resume |
 | Qwen Code | Native HTTP hooks | Yes | Yes, from usage metadata and transcript fallback | Yes | Not yet | No setup-managed resume |
+| OpenHands | Command hooks | Lifecycle, prompt, and tool events | Not exposed by command hook payloads | Yes | Not yet | No setup-managed resume |
 | Pi | TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
 | OpenCode | Plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
 | Kilo Code | Plugin SDK events | Yes | Native OTLP traces/logs plus SDK payloads when exposed | Yes | Not yet | No setup-managed resume |
+| Kiro CLI | Agent command hooks | Prompt, tool, and assistant-response events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
 
 ## Publishing and export
 
@@ -514,8 +528,15 @@ trajectory user-guide clients/gemini # Gemini-specific details
 trajectory user-guide clients/hermes # Hermes Agent observer plugin details
 trajectory user-guide clients/amp    # Amp Code system plugin details
 trajectory user-guide clients/goose  # Goose-specific details
+trajectory user-guide clients/cline  # Cline CLI file hook details
+trajectory user-guide clients/aider  # Aider command shim and sidecar details
+trajectory user-guide clients/continue # Continue CLI command shim and session JSON details
+trajectory user-guide clients/mistral-vibe # Mistral Vibe command shim and hook details
+trajectory user-guide clients/codebuff # Codebuff command shim and chat-history import details
 trajectory user-guide clients/qwen   # Qwen Code native HTTP hook details
+trajectory user-guide clients/openhands # OpenHands command hook details
 trajectory user-guide clients/kilo   # Kilo Code plugin and OTLP relay details
+trajectory user-guide clients/kiro   # Kiro CLI agent command hook details
 trajectory user-guide clients/pi     # Pi-specific details
 trajectory user-guide clients/opencode # OpenCode-specific details
 trajectory user-guide install        # Installation methods

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,8 @@ warn()  { echo "[trajectory]  WARNING: $1" >&2; }
 fail()  { echo "[trajectory]  ERROR: $1" >&2; exit 1; }
 
 # Collect args that pass through to `trajectory setup`. Recognized setup flags:
-# --site, --ml-app, --api-key, --clients (all take a value), --non-interactive.
+# --site, --ml-app, --api-key, --clients (all take a value),
+# --install-client-shims, --no-client-shims, and --non-interactive.
 # The legacy install-only --add-to-path flag is accepted as a no-op for older
 # scripts. install.sh and `trajectory setup` do not edit shell rc files.
 SETUP_ARGS=()
@@ -448,6 +449,51 @@ else
     info "      Goose CLI not detected - skipping Goose configuration guidance."
 fi
 
+# Cline CLI configuration (handled by setup wizard)
+if command -v cline >/dev/null 2>&1; then
+    info "      Cline CLI detected - configuration is handled by the setup wizard."
+    info "      To refresh Cline wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients cline"
+    PLUGIN_INSTALLED=1
+else
+    info "      Cline CLI not detected - skipping Cline configuration guidance."
+fi
+
+# Aider configuration (opt-in command shim handled by setup wizard)
+if command -v aider >/dev/null 2>&1; then
+    info "      Aider detected - opt-in command shim configuration is handled by the setup wizard."
+    info "      To refresh Aider shim wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients aider --install-client-shims"
+    PLUGIN_INSTALLED=1
+else
+    info "      Aider CLI not detected - skipping Aider configuration guidance."
+fi
+
+# Continue CLI configuration (opt-in command shim handled by setup wizard)
+if command -v cn >/dev/null 2>&1; then
+    info "      Continue CLI detected - opt-in command shim configuration is handled by the setup wizard."
+    info "      To refresh Continue CLI shim wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients continue --install-client-shims"
+    PLUGIN_INSTALLED=1
+else
+    info "      Continue CLI not detected - skipping Continue CLI configuration guidance."
+fi
+
+# Mistral Vibe configuration (opt-in command shim handled by setup wizard)
+if command -v vibe >/dev/null 2>&1; then
+    info "      Mistral Vibe detected - opt-in command shim and hooks configuration is handled by the setup wizard."
+    info "      To refresh Mistral Vibe shim wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients mistral-vibe --install-client-shims"
+    PLUGIN_INSTALLED=1
+else
+    info "      Mistral Vibe CLI not detected - skipping Mistral Vibe configuration guidance."
+fi
+
+# Codebuff configuration (opt-in command shim handled by setup wizard)
+if command -v codebuff >/dev/null 2>&1 || command -v cb >/dev/null 2>&1; then
+    info "      Codebuff detected - opt-in command shim configuration is handled by the setup wizard."
+    info "      To refresh Codebuff shim wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients codebuff --install-client-shims"
+    PLUGIN_INSTALLED=1
+else
+    info "      Codebuff CLI not detected - skipping Codebuff configuration guidance."
+fi
+
 # Cursor configuration (handled by setup wizard)
 if command -v cursor >/dev/null 2>&1 || command -v cursor-agent >/dev/null 2>&1; then
     info "      Cursor detected - configuration is handled by the setup wizard."
@@ -482,6 +528,24 @@ if command -v qwen >/dev/null 2>&1; then
     PLUGIN_INSTALLED=1
 else
     info "      Qwen Code CLI not detected - skipping Qwen Code configuration guidance."
+fi
+
+# OpenHands configuration (handled by setup wizard)
+if command -v openhands >/dev/null 2>&1; then
+    info "      OpenHands detected - configuration is handled by the setup wizard."
+    info "      To refresh OpenHands wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients openhands"
+    PLUGIN_INSTALLED=1
+else
+    info "      OpenHands CLI not detected - skipping OpenHands configuration guidance."
+fi
+
+# Kiro CLI configuration (handled by setup wizard)
+if command -v kiro-cli >/dev/null 2>&1 || command -v kiro >/dev/null 2>&1; then
+    info "      Kiro CLI detected - configuration is handled by the setup wizard."
+    info "      To refresh Kiro CLI wiring later without Datadog prompts: ~/.trajectory/bin/trajectory setup --clients kiro"
+    PLUGIN_INSTALLED=1
+else
+    info "      Kiro CLI not detected - skipping Kiro CLI configuration guidance."
 fi
 
 # OpenCode plugin
@@ -557,10 +621,17 @@ if [ "$PLUGIN_INSTALLED" = "0" ]; then
     info "    Gemini:      ~/.trajectory/bin/trajectory setup --clients gemini"
     info "    Antigravity: ~/.trajectory/bin/trajectory setup --clients agy"
     info "    Goose:       ~/.trajectory/bin/trajectory setup --clients goose"
+    info "    Cline CLI:   ~/.trajectory/bin/trajectory setup --clients cline"
+    info "    Aider:       ~/.trajectory/bin/trajectory setup --clients aider --install-client-shims"
+    info "    Continue CLI: ~/.trajectory/bin/trajectory setup --clients continue --install-client-shims"
+    info "    Mistral Vibe: ~/.trajectory/bin/trajectory setup --clients mistral-vibe --install-client-shims"
+    info "    Codebuff:    ~/.trajectory/bin/trajectory setup --clients codebuff --install-client-shims"
     info "    Cursor:      ~/.trajectory/bin/trajectory setup --clients cursor"
     info "    Hermes:      ~/.trajectory/bin/trajectory setup --clients hermes"
     info "    Amp Code:    ~/.trajectory/bin/trajectory setup --clients amp"
     info "    Qwen Code:   ~/.trajectory/bin/trajectory setup --clients qwen"
+    info "    OpenHands:   ~/.trajectory/bin/trajectory setup --clients openhands"
+    info "    Kiro CLI:    ~/.trajectory/bin/trajectory setup --clients kiro"
     info "    OpenCode:    ~/.trajectory/bin/trajectory setup --clients opencode"
     info "    Kilo Code:   ~/.trajectory/bin/trajectory setup --clients kilo"
     info "    Pi:          ~/.trajectory/bin/trajectory setup --clients pi"

--- a/plugin/trajectory-pi/README.md
+++ b/plugin/trajectory-pi/README.md
@@ -17,6 +17,21 @@ mkdir -p ~/.pi/agent/extensions
 cp -R /path/to/trajectory/plugin/trajectory-pi ~/.pi/agent/extensions/trajectory
 ```
 
+The package manifest declares the Pi extension entrypoint:
+
+```json
+{
+  "pi": {
+    "extensions": ["./src/index.ts"]
+  }
+}
+```
+
+Pi discovers the extension from `~/.pi/agent/extensions/trajectory/package.json`;
+you do not need to add `src/index.ts` to `~/.pi/agent/settings.json`. The root
+`index.ts` file is a shim that re-exports `./src/index.ts` for Pi versions or
+workflows that scan package-root extension entrypoints.
+
 Then point `~/.pi/agent/mcp.json` at `~/.pi/agent/extensions/trajectory/bin/trajectory mcp`.
 
 ## Tools

--- a/plugin/trajectory-pi/index.ts
+++ b/plugin/trajectory-pi/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./src/index.ts";

--- a/plugin/trajectory-pi/package.json
+++ b/plugin/trajectory-pi/package.json
@@ -12,5 +12,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/datadog-labs/trajectory"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
   }
 }

--- a/plugin/trajectory-pi/tsconfig.json
+++ b/plugin/trajectory-pi/tsconfig.json
@@ -8,10 +8,20 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@mariozechner/pi-coding-agent": ["/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/dist/index.d.ts"],
-      "@mariozechner/pi-ai": ["/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai/dist/index.d.ts"],
-      "@sinclair/typebox": ["/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/node_modules/typebox/build/index.d.mts"]
-    }
+      "@mariozechner/pi-coding-agent": [
+        "/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/dist/index.d.ts"
+      ],
+      "@mariozechner/pi-ai": [
+        "/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai/dist/index.d.ts"
+      ],
+      "@sinclair/typebox": [
+        "/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/node_modules/typebox/build/index.d.mts"
+      ]
+    },
+    "allowImportingTsExtensions": true
   },
-  "include": ["src"]
+  "include": [
+    "index.ts",
+    "src"
+  ]
 }

--- a/plugin/trajectory/hooks/ensure-serve.sh
+++ b/plugin/trajectory/hooks/ensure-serve.sh
@@ -77,7 +77,7 @@ if [ ! -x "$BINARY" ]; then
     WARN_STAMP="${STATE_DIR}/no-binary-warned.${PPID}"
     if [ ! -f "$WARN_STAMP" ]; then
         : | atomic_write_file "$WARN_STAMP" || true
-        echo '[trajectory] Binary not found. Reload your shell or run: export PATH="$HOME/.trajectory/bin:$PATH"' >&2
+        echo '[trajectory] Binary not found at ~/.trajectory/bin/trajectory. Run ~/.trajectory/bin/trajectory doctor after reinstalling.' >&2
     fi
     exit 0
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -124,7 +124,7 @@ uninstall_clients() {
         return
     fi
 
-    for client in cc codex copilot cursor droid gemini agy goose hermes amp qwen pi opencode kilo; do
+    for client in cc codex copilot cursor droid gemini agy goose cline aider hermes continue mistral-vibe amp qwen openhands kiro pi opencode kilo codebuff; do
         if [ "$DRY_RUN" = "1" ]; then
             info "Would run: $binary setup --uninstall $client --non-interactive"
             continue


### PR DESCRIPTION
## Summary
- update public release metadata to v0.5.19
- add public docs and installer guidance for newly setup-managed clients
- mirror Pi extension manifest packaging, Claude hook messaging, and metrics/capacity docs

## Validation
- scaffold validation
- JSON and shell syntax checks
- TypeScript checks
- release asset checksum verification