### PR TITLE
Release v0.5.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 
 - [docs/USER-GUIDE.md](docs/USER-GUIDE.md): CLI workflows and day-to-day operation
 - [docs/CONFIGURATION.md](docs/CONFIGURATION.md): config files, managed defaults, environment overrides, and common settings
+- [docs/FEATURE-FLAGS.md](docs/FEATURE-FLAGS.md): feature-flag commands, runtime overrides, and registered flags
 - [docs/SUPPORTED-CLIENTS.md](docs/SUPPORTED-CLIENTS.md): supported coding-agent clients and version requirements
 - [docs/CLIENT-INSTRUMENTATION.md](docs/CLIENT-INSTRUMENTATION.md): per-client hook, watcher, MCP, and backfill surfaces
 - [docs/COSTS.md](docs/COSTS.md): local cost summaries, turn evidence, objective observations, and fidelity checks

--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.19",
-    "tag": "v0.5.19",
-    "released_at": "2026-07-01T15:34:44Z"
+    "version": "0.5.20",
+    "tag": "v0.5.20",
+    "released_at": "2026-07-06T16:09:15Z"
   },
   "beta": {
-    "version": "0.5.19",
-    "tag": "v0.5.19",
-    "released_at": "2026-07-01T15:34:44Z"
+    "version": "0.5.20",
+    "tag": "v0.5.20",
+    "released_at": "2026-07-06T16:09:15Z"
   }
 }

--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -70,6 +70,33 @@ shims, local binaries, and local marketplace files without prompting for
 Datadog site, service name, or API key values. Run `trajectory setup` without
 `--clients` when you want to change export settings.
 
+## Setup Instrumentation Policy
+
+Client setup uses the least invasive registration surface the upstream client
+supports:
+
+- Prefer native packages, plugins, hooks, MCP, extension manifests, or
+  transcript discovery before command shims or wrapper-style launch
+  interception.
+- Write only scoped client integration files needed for capture, MCP, skills,
+  commands, plugin discovery, or local extension runtimes.
+- Do not edit shell startup files, shell aliases, shell functions, or export
+  `PATH` from setup. When `trajectory` is not on `PATH`, setup and doctor
+  prefer an existing home bin directory and suggest a symlink such as
+  `ln -s ~/.trajectory/bin/trajectory ~/.local/bin/trajectory`.
+- Command shims named like upstream agent commands are allowed only for clients
+  that have no stable native capture surface, and they require explicit opt-in
+  through `--install-client-shims` or the interactive setup prompt.
+- Feature gates are required for behavior that mutates durable user state,
+  changes client startup, adds wrapper or OTLP interposer behavior, depends on
+  managed settings precedence, or changes outbound network shape.
+- Wrapper metadata records the real upstream binary, setup avoids self-wrapping
+  an existing Trajectory shim, and uninstall removes only Trajectory-managed
+  shim files and metadata.
+- Setup verification, inventory, and doctor report the actual registration
+  mechanism: package manifest, command shim and metadata, hook config, MCP
+  config, or transcript watcher.
+
 The authoritative MCP catalog, including safe query examples, is embedded in
 the binary:
 
@@ -126,6 +153,15 @@ Verify:
 claude plugin list
 trajectory doctor
 ```
+
+Use `trajectory claude` when you want Trajectory to route native Claude Code
+OTLP telemetry through local `trajectory serve` for one launched process
+without changing `~/.claude/settings.json`. This process-only interposer is
+controlled by the `claude_native_otlp_interposer` feature flag. It is on by
+default because running `trajectory claude` is the explicit opt-in boundary;
+disable it with `trajectory features disable claude_native_otlp_interposer` or
+`TRAJECTORY_DISABLE_FEATURES=claude_native_otlp_interposer` to keep the wrapper
+from injecting native OTLP environment variables.
 
 ## Codex CLI
 
@@ -279,9 +315,11 @@ writes `~/.cursor/skills/incognito/SKILL.md`.
 
 cursor-agent CLI does not support `hooks.json`. Trajectory watches nested
 transcript files under `~/.cursor/projects/*/agent-transcripts/` when
-`cursor-agent` is present on `PATH`. Current cursor-agent transcripts do not
-expose token or cost fields, so metrics are limited to activity that can be
-derived from transcript structure.
+`cursor-agent` is present on `PATH`. The watcher marks those sessions headless
+while preserving `transcript_path`, so sensitivity scanning and segmentation
+are skipped for the supported `cursor-agent --print` path. Current cursor-agent
+transcripts do not expose token or cost fields, so metrics are limited to
+activity that can be derived from transcript structure.
 
 ## Factory Droid
 

--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -1,0 +1,90 @@
+
+# Feature Flags
+
+Trajectory feature flags gate risky or rollout-sensitive behavior. Use them for
+new behavior that mutates durable user state, changes client startup, introduces
+wrapper/interposer behavior, depends on managed settings, or changes outbound
+network shape.
+
+## Decision Checklist
+
+For feature-oriented work, agents must tell the user the feature-flag decision
+before implementation starts:
+
+```text
+Feature flag decision: needed/not needed - <reason>.
+```
+
+Use a flag when the change mutates durable user or admin config, changes setup
+or client registration, changes wrapper/interposer behavior, changes environment
+injection or OTLP/network shape, changes publish/export behavior, depends on
+managed-settings precedence, introduces a new user-visible workflow, or needs a
+fast kill switch for narrow rollout.
+
+Do not use a flag for docs-only changes, tests-only changes, logging-only
+visibility, internal refactors with no behavior change, or bug fixes that restore
+documented behavior for everyone. Privacy and security fixes should not be made
+optional unless a temporary rollout-safety kill switch is required.
+
+## Commands
+
+Inspect effective flags:
+
+```bash
+trajectory features list
+trajectory features status claude_native_otlp_interposer
+```
+
+Persist a user override in `~/.trajectory/config.yaml`:
+
+```bash
+trajectory features enable claude_native_otlp_interposer
+trajectory features disable claude_native_otlp_interposer
+trajectory features clear claude_native_otlp_interposer
+```
+
+The same lists are visible through the config surface:
+
+```bash
+trajectory config get features.enabled
+trajectory config get features.disabled
+trajectory config set features.disabled claude_native_otlp_interposer
+```
+
+After changing a flag for long-running `trajectory serve` processes, run:
+
+```bash
+trajectory config reload --yes
+```
+
+## Runtime Overrides
+
+Use process-local environment overrides for tests, emergency kill switches, or
+one launched process:
+
+```bash
+TRAJECTORY_ENABLE_FEATURES=flag_a,flag_b trajectory ...
+TRAJECTORY_DISABLE_FEATURES=flag_a,flag_b trajectory ...
+```
+
+Disabled wins when a flag appears in both enabled and disabled lists. A managed
+`config.defaults.yaml` disable also wins over user config, so users cannot
+locally re-enable an admin-disabled feature.
+
+## Rollout Rules
+
+- Default risky features off unless the user action is already an explicit
+  opt-in boundary, such as running `trajectory claude`.
+- Put the feature check at the entrypoint and at the mutation or side-effect
+  boundary when practical.
+- Add tests for default behavior, enabled behavior, disabled behavior, managed
+  disabled behavior, and env-disabled kill switch behavior.
+- Do not use feature flags as permission to mutate broad user settings. Feature
+  flags gate behavior; setup still must use the least invasive supported client
+  integration surface.
+
+## Registered Flags
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `claude_native_otlp_interposer` | on | Allows `trajectory claude` to route Claude Code native OTLP through local `trajectory serve` for that launched process. Setup does not write Claude settings files. Disable this flag to keep `trajectory claude` from injecting native OTLP env vars. |

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -102,7 +102,7 @@ unattributed.
 | `owner` | Git repository owner from the remote origin | `unknown` |
 | `git_remote_host` | Git remote host from the remote origin | `unknown` |
 | `project_dir` | Project directory basename | Omitted |
-| `trajectory.trace_type` | Metric grain: `turn`, `session`, `task`, `commit`, or `pr` | Set by emitter |
+| `trajectory.trace_type` | Metric grain: `turn`, `session`, `task`, `commit`, `pr`, or `serve` | Set by emitter |
 
 Top-level config `tags:` are included on Trajectory-published Datadog metric
 series for Datadog destinations, including base, marker, heartbeat, and task
@@ -318,6 +318,10 @@ privacy/publish diagnostics.
 |---|---|---|---|
 | `trajectory.ops.install.current_state` | gauge | Canonical serve tags plus `managed`, `role`, `outcome`, `reason`, `setup_binary_status`, `setup_binary_version` | Managed setup summary. Current state emits `1`; prior state series emit `0` when setup state changes so dashboards can filter on the latest active state. |
 | `trajectory.ops.install.agent_state` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `agent_status`, `setup_outcome`, `setup_stage`, `setup_component`, `setup_capture_path`, `setup_next_step`, `reason`, `setup_binary_status`, `setup_binary_version` | Per-integration setup state for every selected client. Distinguishes registration failures from verification failures and degraded fallback paths such as MCP watcher fallback. |
+| `trajectory.ops.agent.present` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source` | Daily local inventory signal for each known coding-agent client. Emits `1` when the client is detected on the machine and `0` when absent. Client aliases such as `cc` are reported as canonical runtime sources such as `claude-code`. |
+| `trajectory.ops.agent.version` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `client_version`, `trajectory.client_version`, `version_source` | Daily installed-agent freshness signal. Emits `1` for detected clients with the best available CLI-probed version, or `client_version:unknown` when the client is present but the version probe is unavailable. |
+| `trajectory.ops.agent.active_sessions` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source` | Hourly count of fresh active sessions by canonical client source, deduped across concurrent `trajectory serve` processes using per-PID heartbeat sentinels. Emits `0` for known clients with no fresh active sessions. |
+| `trajectory.ops.agent.active_session_version` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `client_version`, `trajectory.client_version`, `version_source` | Hourly active-session count by client version, using captured session-start state from heartbeat sentinels. Missing versions are reported as `client_version:unknown`. |
 | `trajectory.publish.active_destinations` | gauge | Canonical tags plus top-level and destination tags on Datadog destinations | Number of active destinations seen for a session |
 | `trajectory.publish.turns` | count | OTLP publish path tags | Internal publish turn counter |
 | `trajectory.serve.incognito.enabled` | count | `client_source` | User or tool enabled incognito; intentionally not tagged by session ID |

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -354,7 +354,13 @@ CI validates this Desktop install surface on macOS by running setup in an isolat
 
 cursor-agent is a standalone CLI (`cursor-agent --print` for headless mode). It does NOT support hooks.json. Capture uses a **transcript file watcher** that tails nested transcript files under `~/.cursor/projects/*/agent-transcripts/<session>/*.jsonl`, similar to the Codex rollout watcher.
 
-The watcher starts automatically when `cursor-agent` is on PATH. No manual setup needed - the trajectory binary detects cursor-agent and watches for transcripts. Because the current headless transcript format does not expose token or cost fields, cursor-agent metrics are limited to tool, turn, and session counts until Cursor adds those fields.
+The watcher starts automatically when `cursor-agent` is on PATH. No manual
+setup needed - the trajectory binary detects cursor-agent and watches for
+transcripts. The watcher preserves `transcript_path` and marks these sessions
+headless, so sensitivity scanning and segmentation are skipped for the
+supported `cursor-agent --print` path. Because the current headless transcript
+format does not expose token or cost fields, cursor-agent metrics are limited
+to tool, turn, and session counts until Cursor adds those fields.
 
 Install cursor-agent: `curl -fsSL https://cursor.com/install | bash`
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -9,7 +9,12 @@ trajectory status                    # Terminal dashboard with session metrics
 trajectory cost                      # Local cost summary and top sessions
 trajectory view                      # Open the local browser viewer
 trajectory doctor                    # Diagnose issues (binary, config, hooks, data)
-trajectory inventory --json          # Refresh local agent and capability inventory
+trajectory inventory refresh --json  # Refresh local agent and capability inventory
+trajectory inventory show --json     # Read the latest local inventory artifact
+trajectory plugins list              # Show opt-in product activation profiles
+trajectory plugins show datadog-security # Show Datadog Security activation
+trajectory security status           # Shortcut for the Datadog Security plugin
+trajectory features list             # Show feature flags and effective sources
 trajectory diagnose publish          # Explain capture, local mapping, and publish expectations
 trajectory logs [-f] [--grep PAT]   # View capture server logs
 trajectory version                   # Print version
@@ -24,6 +29,14 @@ commands, plugins, and settings sources. `current.json` contains the latest
 refresh, while `snapshots/` stores hash-named inventory snapshots for support
 triage or product-pack drift checks. Trajectory does not publish these
 inventory artifacts to Datadog yet.
+
+`trajectory plugins list` shows opt-in product activation profiles layered over
+compiled modules. Baseline `trajectory setup` remains observability-only; use
+`trajectory security setup --mode observe --clients cc,codex,cursor` to enable
+the Datadog Security plugin for explicit supported clients. Enforce mode can
+block agent actions and requires `--yes`. Use `trajectory security disable
+--clients ... --remove-hooks` to disable config and remove stale
+Trajectory-managed dispatcher hooks while preserving baseline capture hooks.
 
 Use `trajectory view --session <id>` to inspect one captured session in the local browser viewer. If local-ui is not already running, `view` starts it and opens the session deep link. Use `trajectory user-guide local-ui` for cache repair and Lapdog-compatible local inspection.
 
@@ -45,8 +58,14 @@ For repeated Codex turns or malformed LLM Obs spans, check the capture and publi
 ```bash
 trajectory config show               # View merged runtime config
 trajectory config set <key> <value>  # Set a config value
+trajectory config reload             # Dry-run live serve reload/restart plan
+trajectory config reload --yes       # Reload live serve config; restart only when required
+trajectory update reconcile          # Dry-run old-version serve process refresh
+trajectory update reconcile --yes    # Safely replace old-version standalone serve processes
 trajectory config set-secret <name>  # Store a secret in the OS keychain
 trajectory config get <key>          # Read a single value
+trajectory features enable <name>    # Persist a user feature-flag override
+trajectory features disable <name>   # Persist a user feature-flag kill switch
 ```
 
 Most users edit `~/.trajectory/config.yaml` through `trajectory config set`. Installers or administrators may provide `~/.trajectory/config.defaults.yaml` to seed managed defaults, and environment variables can override specific values for the current shell or launched process.
@@ -61,8 +80,31 @@ trajectory config set export.traces standard       # off | minimal | standard | 
 trajectory config set export.metrics true
 trajectory config set export.placeholder_llm_span false  # omit synthetic cost-only LLM spans
 trajectory config set local_ui.auto_start false    # disable automatic local-ui startup
+trajectory features disable claude_native_otlp_interposer # keep trajectory claude from injecting native OTLP env
 trajectory config set-secret dd-api-key             # prompts for the key securely
 ```
+
+Feature flags can also be overridden for one process with
+`TRAJECTORY_ENABLE_FEATURES=name_a,name_b` and
+`TRAJECTORY_DISABLE_FEATURES=name_a,name_b`. Disabled wins, and managed
+`config.defaults.yaml` disables cannot be re-enabled by user config. See
+[`FEATURE-FLAGS.md`](FEATURE-FLAGS.md) for rollout rules and the registered
+flag catalog.
+
+After changing config or credentials, run `trajectory config reload` first; if
+it prints reload candidates, run `trajectory config reload --yes`, then confirm
+with `trajectory ps`. Publish/export and identity changes normally reload in
+place. Listener, capture, sensitivity, org-sync, module, and similar process
+shape changes report restart-required keys and use the safe replacement
+fallback.
+
+After a binary update, existing `trajectory serve` processes keep running the
+old executable image until replaced. Run `trajectory update reconcile` to
+compare per-PID serve health against the installed binary version. The default
+dry-run reports old-version standalone serve processes and blockers. With
+`--yes`, Trajectory starts a target-version replacement first, waits for fresh
+target-version health, then signals only old-version standalone `serve` PIDs
+that have no fresh session heartbeat or active publish outbox claim.
 
 For metrics-only Datadog export, keep `export.traces` off and set
 `export.metrics` true:
@@ -120,6 +162,32 @@ thinking text, post-tool outputs/results, diffs, file contents, raw payloads,
 error text, summaries, and user email fields. See
 [SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md) and
 `trajectory user-guide security-event-stream`.
+
+Managed Datadog destinations can also opt in to derived AI Usage events for
+skill observability:
+
+```yaml
+required_destinations:
+  - name: aiusage
+    type: datadog
+    site: datadoghq.com
+    ml_app: coding-agents
+    api_key_ref: dd-aiusage-api-key
+    level: off
+    ai_usage:
+      enabled: true
+      endpoint: https://event-platform-intake.datadoghq.com/api/v2/aiusage
+      track: aiusage
+      approved: true
+```
+
+This publisher emits one `trajectory.ai_usage.skill.v1` JSON event per
+skill-assisted turn, with skill name, invocation count, repo/user identity,
+coding-agent identity, detection source, tool count, distinct tool count,
+duration, tool names, and tool types. It does not include prompts, assistant
+responses, tool input/output, shell commands, diffs, file contents, raw trace
+payloads, or local file paths. Project `publish.trajectory.yaml` files cannot
+enable this path.
 
 Trace export is off by default. Set `export.traces` explicitly when you want
 sessions published to LLM Observability. Rerunning `trajectory setup` preserves


### PR DESCRIPTION
## Summary

- Update public release channels to v0.5.20.
- Add the public feature-flag guide and link it from the README.
- Refresh user docs for config reload, update reconcile, opt-in product activation commands, agent operational metrics, and cursor-agent headless handling.
