### PR TITLE
Release Trajectory 0.5.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 - [docs/LLM-CAPACITY.md](docs/LLM-CAPACITY.md): which features use additional LLM capacity and how to control them
 - [docs/METRICS-REFERENCE.md](docs/METRICS-REFERENCE.md): emitted metric names, types, tags, and query guidance
 - [docs/MARKERS.md](docs/MARKERS.md): marker authoring and marker-derived metrics
+- [docs/SKILL-OBSERVABILITY.md](docs/SKILL-OBSERVABILITY.md): skill usage, attribution, and dashboard guidance
 - [docs/DATA-FORMATS.md](docs/DATA-FORMATS.md): materialized session fields and LLM Observability export fields
 - [docs/SUBAGENT-TRACE-MODEL.md](docs/SUBAGENT-TRACE-MODEL.md): semantic subagent trace rendering and span-link behavior
 - [docs/LLM-OBS-SPAN-TAGS.md](docs/LLM-OBS-SPAN-TAGS.md): Datadog LLM Observability span tag contract

--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.20",
-    "tag": "v0.5.20",
-    "released_at": "2026-07-06T16:09:15Z"
+    "version": "0.5.21",
+    "tag": "v0.5.21",
+    "released_at": "2026-07-08T17:47:09Z"
   },
   "beta": {
-    "version": "0.5.20",
-    "tag": "v0.5.20",
-    "released_at": "2026-07-06T16:09:15Z"
+    "version": "0.5.21",
+    "tag": "v0.5.21",
+    "released_at": "2026-07-08T17:47:09Z"
   }
 }

--- a/docs/LLM-CAPACITY.md
+++ b/docs/LLM-CAPACITY.md
@@ -15,7 +15,7 @@ trajectory user-guide llm-capacity
 | Feature | Default | What it does | How often it can call an LLM | Primary controls |
 |---|---|---|---|---|
 | Task segmentation | On | Splits sessions into tasks and scores task dimensions such as outcome, autonomy, risk, and reversibility | About every `segmentation.interval` completed turns, default 10, plus one final pass at session end for sessions with at least 2 turns | `segmentation.enabled`, `segmentation.interval`, `segmentation.model`, `TRAJECTORY_SEGMENTATION_DISABLED=1` |
-| Sensitivity classification | On, `near_realtime` mode | Classifies session content for the publish gate as public, internal, confidential, or restricted | In `near_realtime` mode, active sessions are scanned only when new content exists, default every 240 minutes, plus a session-end scan on the non-incognito publish path. In `balanced` mode, about every 10 completed turns, plus the session-end scan. | `export.sensitivity.scanning_mode`, `export.sensitivity.near_realtime_interval_minutes` |
+| Sensitivity classification | Off in fresh single-user setup; managed configs may enable `near_realtime` | Classifies session content for the publish gate as public, internal, confidential, or restricted | In `near_realtime` mode, active sessions are scanned only when new content exists, default every 240 minutes, plus a session-end scan on the non-incognito publish path. In `balanced` mode, about every 10 completed turns, plus the session-end scan. | `export.sensitivity.scanning_mode`, `export.sensitivity.near_realtime_interval_minutes` |
 
 For zero Trajectory-owned LLM calls from the capture server, disable both:
 
@@ -89,16 +89,19 @@ LLM capacity use.
 
 ## Sensitivity classification
 
-Sensitivity classification is enabled by default in `near_realtime` mode. It is
-primarily used by trace publish privacy gates, but `export.traces=off` is not a
-guaranteed capacity control by itself. If you want no sensitivity-classifier LLM
-calls and no sensitivity publish gate, set `export.sensitivity.scanning_mode`
-to `off`.
+Fresh single-user `trajectory setup` writes
+`export.sensitivity.scanning_mode=off`, so initial minimal trace publishing is
+not held behind classification.
+Managed configs and explicit user config can enable sensitivity classification,
+usually in `near_realtime` mode. It is primarily used by trace publish privacy
+gates, but `export.traces=off` is not a guaranteed capacity control by itself.
+If you want no sensitivity-classifier LLM calls and no sensitivity publish gate,
+set `export.sensitivity.scanning_mode` to `off`.
 
 Scanning modes:
 
-- `near_realtime` is the default. It scans active sessions on a time window when
-  new content exists. The default interval is 240 minutes.
+- `near_realtime` scans active sessions on a time window when new content
+  exists. The default interval is 240 minutes.
 - `balanced` scans on the same default turn cadence as segmentation: about every
   10 completed turns, plus a final session-end scan on the non-incognito publish
   path.

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -1,13 +1,15 @@
 # Metrics Reference
 
-This page catalogs the metric surface emitted by the current Trajectory binary. Metric names, types, and tags are treated as part of the public distribution contract.
+This page catalogs the metric surface emitted by the current Trajectory binary.
+It is intended as the public reference for metric names, tags, and dashboard
+semantics.
 
 For marker syntax and dashboard examples, see [MARKERS.md](MARKERS.md). For
 configuration and destination trust, see [USER-GUIDE.md](USER-GUIDE.md).
 For cross-agent source contracts, see
 [METRICS-CONSISTENCY-AUDIT.md](METRICS-CONSISTENCY-AUDIT.md).
-For Datadog LLM Observability span tags, see [LLM-OBS-SPAN-TAGS.md](LLM-OBS-SPAN-TAGS.md).
-For cost-overlap dashboard guidance, see [COST-OVERLAP-CONSUMER-GUIDE.md](COST-OVERLAP-CONSUMER-GUIDE.md).
+For Claude Code/provider cost-overlap, dedupe tags, and dashboard consumption guidance, see
+[COST-OVERLAP-CONSUMER-GUIDE.md](COST-OVERLAP-CONSUMER-GUIDE.md).
 For the built-in metric guide, run:
 
 ```bash
@@ -45,12 +47,11 @@ Base telemetry is emitted when `export.metrics: true` is enabled for an active
 Datadog or OTLP destination. For normal `~/.trajectory/config.yaml` Datadog
 config, `export.site` plus `export.metrics: true` creates the built-in
 `_config_datadog` destination even when `export.traces: off`. In that mode
-metrics publish and LLM Observability trace spans do not.
+metrics publish and LLM Obs trace spans do not.
 
-Destination `type` is the backend or transport selector, not the metrics
-switch. For `type: datadog`, metrics use Datadog Metrics v2 when the metric
-gates are enabled. Legacy `type: dd_llmobs` is accepted as an alias for
-`datadog`.
+Destination `type` is the backend/transport selector, not the metrics switch.
+For `type: datadog`, metrics use Datadog Metrics v2 when the metric gates are
+enabled. Legacy `type: dd_llmobs` is accepted as an alias for `datadog`.
 
 Marker-derived metrics require both marker evaluation and destination marker
 metrics:
@@ -64,13 +65,12 @@ markers:
 If a destination sets `markers.metrics: false`, marker-derived metrics are
 suppressed for that destination. Project `publish.trajectory.yaml` files can add
 metrics-only destinations only when `level: off`, marker metrics are enabled,
-marker logs are disabled, and LLM Observability marker evaluations are
-disabled.
+marker logs are disabled, and LLM Obs marker evaluations are disabled.
 
-LLM Observability marker evaluations are a separate experimental output path.
-They are not enabled by `markers.enabled` or `markers.metrics`; a Datadog
-destination must set `markers.evaluations: true` explicitly before Trajectory
-submits marker results to the LLM Observability evaluation intake.
+LLM Obs marker evaluations are a separate experimental output path. They are not
+enabled by `markers.enabled` or `markers.metrics`; a Datadog destination must set
+`markers.evaluations: true` explicitly before Trajectory submits marker results
+to the LLM Obs evaluation intake.
 
 Serve-side operational counters such as incognito and sensitivity health are
 best-effort Datadog Metrics API submissions. They are not tied to trace export.
@@ -81,11 +81,14 @@ Publish-engine metrics receive the canonical tag set below when the source
 context is available. Identity tags use fallbacks so metrics are not silently
 unattributed.
 
+For the Datadog LLM Obs span tag contract, see
+[LLM-OBS-SPAN-TAGS.md](LLM-OBS-SPAN-TAGS.md).
+
 | Tag | Meaning | Fallback |
 |---|---|---|
 | `gen_ai.conversation.id` | Session ID | `unknown` |
 | `session_id` | Compatibility alias for session ID | `unknown` |
-| `trajectory.client_source` | Client source, such as `claude-code`, `cline`, `codex`, `gemini`, `agy`, `goose`, `aider`, `continue`, `mistral-vibe`, `codebuff`, `cursor`, `openhands`, `kiro`, `pi`, or `opencode` | `unknown` |
+| `trajectory.client_source` | Client source, such as `claude-code`, `codex`, `gemini`, `agy`, `goose`, `cursor`, `pi`, or `opencode` | `unknown` |
 | `trajectory.user` | Resolved user | `unknown` |
 | `trajectory.user_email` | Optional resolved user email from `TRAJECTORY_USER_EMAIL`, `identity.user_email`, `identity.user_email_command`, or `identity.user_email_suffix` | Omitted |
 | `git.email` | Optional resolved Git email from `TRAJECTORY_GITHUB_EMAIL`, `identity.github_email`, `identity.github_email_command`, repo-local Git config, or global Git config | Omitted |
@@ -98,14 +101,19 @@ unattributed.
 | `gen_ai.request.model` | Model name | Omitted |
 | `trajectory.client_version` | Client or harness version from capture or cache | Omitted when unavailable |
 | `trajectory.turn_id` | Stable turn ordinal on turn-scoped metrics; prevents same-second turn samples from collapsing into one Datadog point | Omitted when the turn cannot be resolved |
-| `repo` | Git repository name from the remote origin, or project directory basename when the origin is unavailable | `unknown` |
-| `owner` | Git repository owner from the remote origin | `unknown` |
-| `git_remote_host` | Git remote host from the remote origin | `unknown` |
 | `project_dir` | Project directory basename | Omitted |
+| `repo` | Git repository name from remote origin, or project directory basename when origin is unavailable | `unknown` when project directory is unavailable |
+| `owner` | Git repository owner from remote origin | `unknown` when remote origin is unavailable |
+| `git_remote_host` | Git remote host | `unknown` when remote origin is unavailable |
+| `trajectory.repo_source` | Provenance for `repo`, `owner`, and `git_remote_host`: `git_origin`, `git_origin_unparsed`, `project_dir`, `configured`, or `unknown` | `unknown` |
 | `trajectory.trace_type` | Metric grain: `turn`, `session`, `task`, `commit`, `pr`, or `serve` | Set by emitter |
+| `trajectory.metric_lifecycle` | Metric catalog lifecycle: `current`, `legacy`, `debug`, or `unknown` | Set by metric catalog classification |
+| `trajectory.metric_provenance` | Bounded data provenance for the metric, such as `captured_session`, `activity_classifier`, `context_budget_estimator`, `waste_evaluator`, `skill_attribution`, `marker_evaluation`, `serve_process`, or `instrumentation_health` | Set by metric catalog classification |
+| `trajectory.metric_signal` | Intended use tier, such as `authoritative_usage`, `derived_behavior`, `operational`, `diagnostic`, or `investigate` | Set by metric catalog classification |
+| `trajectory.metric_family` | Current catalog family for built-in metrics | Omitted for legacy/debug/unknown classifications |
 
 Top-level config `tags:` are included on Trajectory-published Datadog metric
-series for Datadog destinations, including base, marker, heartbeat, and task
+series for DD LLM Obs destinations, including base, marker, heartbeat, and task
 metrics. User and managed tag maps are additive; managed `config.defaults.yaml`
 values win on key conflicts. They are not written to local JSONL, and they are
 not added to OTLP exports, Claude native OTLP proxy metrics, or process-level
@@ -115,7 +123,7 @@ and non-sensitive.
 
 ### Cost Overlap Tags
 
-Trajectory cost metrics carry bounded tags that help dashboards avoid summing
+Trajectory cost metrics carry bounded tags that let dashboards avoid summing
 Trajectory attribution cost with provider, gateway, cloud billing, or native
 client telemetry cost. These tags are non-sensitive route classifications, not
 raw URLs, headers, credentials, helper commands, account IDs, or org IDs.
@@ -132,7 +140,15 @@ raw URLs, headers, credentials, helper commands, account IDs, or org IDs.
 | `trajectory.cost_dedupe_confidence` | `high`, `medium`, `low`, `mixed` |
 | `trajectory.cost_source` | Source of the cost stream when different metric families can overlap; native Claude telemetry proxied by Trajectory uses `claude_native_otlp` |
 
-The tags are applied to Trajectory-owned cost-bearing base metrics only.
+The tags are applied to Trajectory-owned cost-bearing base metrics only:
+`trajectory.turn.cost.usd`, `trajectory.turn.cost.usd.total`,
+`trajectory.turn.web_search.cost.usd`,
+`trajectory.turn.web_search.cost.usd.total`,
+`trajectory.session.cost.usd.accumulated`,
+`trajectory.session.web_search.cost.usd.accumulated`,
+`trajectory.session.cost.usd.total`, and
+`trajectory.session.web_search.cost.usd.total`.
+
 Claude Code native OTLP metrics proxied by Trajectory use
 `trajectory.cost_role:client_telemetry` and
 `trajectory.cost_source:claude_native_otlp` when that proxy path enriches the
@@ -173,9 +189,9 @@ Grouped per-turn metrics emit one data point per dimension value:
 |---|---|---|
 | `trajectory.turn.tool_uses` | gauge | `tool_name` |
 | `trajectory.turn.tool_uses.total` | distribution | No `tool_name`; total tools in the completed turn |
-| `trajectory.turn.permission_prompts` | gauge | `decision` |
-| `trajectory.turn.tool_decision` | count | `tool_name`, `decision`, `source` |
-| `trajectory.turn.code_edit_tool.decision` | count | `tool_name`, `decision`, `source`, `language` |
+| `trajectory.turn.permission_prompts` | gauge | `decision`, `permission_mode`, `approval_path` |
+| `trajectory.turn.tool_decision` | count | `tool_name`, `decision`, `source`, `permission_mode`, `approval_path`; legacy inferred accepts use `permission_mode:not_captured` instead of pretending a mode was observed |
+| `trajectory.turn.code_edit_tool.decision` | count | `tool_name`, `decision`, `source`, `permission_mode`, `approval_path`, `language`; legacy inferred accepts use `permission_mode:not_captured` instead of pretending a mode was observed |
 | `trajectory.turn.errors` | gauge | `category`; per-turn failed tool results. Uses explicit `turn_end.tool_error_categories` when an adapter supplies it, otherwise derives categories from completed `tool_use` events with `success:false`. This is not a Trajectory publish/tool-call transport failure metric. |
 
 For dashboard percentile queries, prefer the `.total` distributions. For
@@ -218,6 +234,30 @@ Session-end metrics:
 | `trajectory.session.yield_revert_count` | gauge | commit | Revert commits among yielded main-branch commits |
 | `trajectory.session.yield_revert_count.completed_count` | count | commit | Completed-session mirror for dashboard totals; prefer this for sums |
 
+Derived session behavior metrics:
+
+| Metric | Type | Unit | Provenance | Notes |
+|---|---|---|---|---|
+| `trajectory.session.one_shot_rate` | gauge | ratio | `activity_classifier` | Activity-classifier estimate of non-retried execution |
+| `trajectory.session.total_retries` | gauge | retry | `activity_classifier` | Retry count derived from activity classification |
+| `trajectory.session.plan_to_one_shot` | gauge | ratio | `activity_classifier` | Plan-to-execution one-shot score; `-1` means no plan phase was detected |
+| `trajectory.session.context_budget_pct` | gauge | percent | `context_budget_estimator` | Estimated context budget usage percentage |
+| `trajectory.session.context_budget_tokens` | gauge | token | `context_budget_estimator` | Estimated total context budget tokens |
+| `trajectory.session.context_budget_claude_md_tokens` | gauge | token | `context_budget_estimator` | Estimated CLAUDE.md contribution to context budget |
+| `trajectory.session.context_budget_mcp_tokens` | gauge | token | `context_budget_estimator` | Estimated MCP contribution to context budget |
+| `trajectory.session.context_budget_skills_tokens` | gauge | token | `context_budget_estimator` | Estimated skill-file contribution to context budget |
+| `trajectory.session.waste_score` | gauge | score | `waste_evaluator` | Waste evaluator score; higher is cleaner |
+| `trajectory.session.waste_junk_reads_count` | gauge | finding | `waste_evaluator` | Junk-read findings |
+| `trajectory.session.waste_duplicate_reads_count` | gauge | finding | `waste_evaluator` | Duplicate-read findings |
+| `trajectory.session.waste_low_read_edit_ratio_count` | gauge | finding | `waste_evaluator` | Low read/edit ratio findings |
+| `trajectory.session.waste_retry_loops_count` | gauge | finding | `waste_evaluator` | Retry-loop findings |
+| `trajectory.session.waste_unused_tools_count` | gauge | finding | `waste_evaluator` | Unused-tool findings |
+
+These metrics carry `trajectory.metric_signal:derived_behavior` and the
+corresponding `trajectory.metric_family` value (`activity`, `context_budget`,
+or `waste`). They should not be mixed with authoritative usage/cost totals
+without keeping the provenance dimension visible.
+
 ## Task Metrics
 
 Task metrics come from closed task segments. They are emitted with
@@ -239,47 +279,102 @@ publish outputs with `segmentation.enabled: false`.
 Marker metrics are resolved from the active marker catalog at publish time.
 Built-in and setup-default metrics include:
 
+For trusted skill usage reports, prefer `trajectory.turn.skill_invocations` with
+`sum by {skill_name,detected_from,source_scope,signal_confidence}`. When native
+or explicit source metadata is unavailable, `source_scope` may be recovered by
+matching a generic skill-tool invocation against local project/user skill files.
+These metric series also carry the normal Trajectory session tags, including
+`trajectory.client_source`, `trajectory.client_version`, `trajectory.user`, and
+repo tags when available. Use `trajectory.client_version` when checking whether
+Claude skill attribution coverage changed across Claude Code releases.
+`trajectory.session.skill_invocations` and its automatic `.completed_count`
+mirror remain available for completed-session rollups, but only
+high-confidence activation signals are counted there. Use
+`trajectory.turn.skill_observations` or `trajectory.session.skill_observations`
+for weaker breadcrumbs such as a client reading `SKILL.md` without an explicit
+activation signal.
+
+Claude Code skill activation can arrive from two high-confidence native
+surfaces:
+
+- native OTLP `skill_activated` logs accepted on the local `trajectory serve`
+  `/v1/logs` endpoint and converted into sanitized `Skill` tool activation
+  records tagged `detected_from:claude_native_otel`;
+- native transcript assistant messages with `attributionSkill`, stamped onto
+  the Trajectory `turn_end` event and converted into `skill-invoked` markers
+  tagged `detected_from:claude_native_transcript`.
+
+Setup enables Claude log detail locally so skill names are available when
+Claude exposes them.
+
+When a turn has a high-confidence skill invocation marker, Trajectory also emits
+skill complexity metrics. Claude native OTLP trace spans are preferred when
+available. Tool spans with native skill attributes publish as
+`skill_attribution:span_tool_attribute`; otherwise a single high-confidence
+skill signal can be correlated with same-turn Claude tool spans as
+`skill_attribution:span_temporal`. If no usable native trace window exists,
+Trajectory falls back to same-turn materialized tool rows tagged
+`skill_attribution:turn_assisted`. The fallback is useful for broad trends but
+does not imply exact active-skill parentage.
+
+All skill complexity series carry `skill_name`, `detected_from`,
+`source_scope`, `signal_confidence`, and `skill_attribution`.
+
+| Metric | Type | Scope | Source |
+|---|---|---|---|
+| `trajectory.turn.skill_tool_uses` | gauge | turn | Same-turn tool-use count tagged by `skill_name`, `tool_name`, `tool_type`, and signal dimensions |
+| `trajectory.turn.skill_tool_uses.total` | distribution | turn | Total non-skill tool calls in the skill-assisted turn |
+| `trajectory.turn.skill_distinct_tools.total` | distribution | turn | Distinct non-skill tool names in the skill-assisted turn |
+| `trajectory.turn.skill_duration_ms.total` | distribution | turn | Skill-assisted turn duration when turn timestamps are available |
+
+Count-like marker session gauges also have turn-level count samples for
+turn-native reporting. Permission reports should use
+`trajectory.turn.permissions_denied` grouped by `tool`, `category`, and `source`
+when turn visibility matters.
+
 | Metric | Type | Scope | Source |
 |---|---|---|---|
 | `trajectory.session.user_frustrations` | gauge | session | User frustration points |
+| `trajectory.turn.user_frustrations` | count | turn | Per-turn user frustration points |
 | `trajectory.session.commits` | gauge | session | Git commit points |
+| `trajectory.turn.commits` | count | turn | Per-turn git commit points |
 | `trajectory.session.prs` | gauge | session | PR/MR creation points |
+| `trajectory.turn.prs` | count | turn | PR/MR creation point for the originating turn, tagged by `change_host`, `owner`, `repo`, and `change_number` |
+| `trajectory.turn.pr_contexts` | count | turn | PR/MR context observation point for prompts or PR/MR CLI output, tagged by `change_host`, `owner`, `repo`, `change_number`, `context_source`, and `signal_confidence` when available |
 | `trajectory.session.pushes` | gauge | session | Git push points |
+| `trajectory.turn.pushes` | count | turn | Per-turn git push points |
 | `trajectory.session.test_fix_cycles` | gauge | session | Completed test-fix ranges |
+| `trajectory.turn.test_fix_cycles` | count | turn | Per-turn completed test-fix ranges |
 | `trajectory.session.user_interruptions` | gauge | session | User interruption points |
+| `trajectory.turn.user_interruptions` | count | turn | Per-turn user interruption points |
 | `trajectory.session.tool_errors` | gauge | session | Tool-error points, often grouped by `category` |
+| `trajectory.turn.tool_errors` | count | turn | Per-turn tool-error points tagged by `category` |
 | `trajectory.session.permissions_denied` | gauge | session | Permission denial points |
+| `trajectory.turn.permissions_denied` | count | turn | Per-turn permission denial points tagged by `tool`, `category`, and `source` |
 | `trajectory.session.language_activity` | gauge | session | Tool activity grouped by `language` |
-| `trajectory.session.skill_invocations` | gauge | session | Skill activity grouped by `skill_name` |
+| `trajectory.turn.language_activity` | count | turn | Per-turn language activity tagged by `language` |
+| `trajectory.session.skill_invocations` | gauge | session | High-confidence skill invocations grouped by `skill_name` |
+| `trajectory.turn.skill_invocations` | count | turn | High-confidence skill invocation events tagged by `skill_name`, `detected_from`, `source_scope`, and `signal_confidence` |
+| `trajectory.session.skill_observations` | gauge | session | Lower-confidence skill observations grouped by `skill_name` |
+| `trajectory.turn.skill_observations` | count | turn | Lower-confidence skill observations tagged by `skill_name`, `detected_from`, `source_scope`, and `signal_confidence` |
 | `trajectory.session.cli_tool_count` | gauge | session | Recognized shell command-line tool invocations grouped by normalized `tool`; use the `.completed_count` mirror for toplists |
-| `trajectory.session.subagents` | gauge | session | Setup-default subagent count |
-| `trajectory.session.tests_written` | gauge | session | Setup-default new-test count |
-| `trajectory.session.test_success_rate` | gauge | session | Setup-default test retry success ratio |
-| `trajectory.session.force_pushes` | gauge | session | Setup-default force-push count |
+| `trajectory.turn.cli_tool_count` | count | turn | Per-turn recognized shell command-line tool invocations tagged by normalized `tool` |
+| `trajectory.session.subagents` | gauge | session | Built-in subagent count |
+| `trajectory.turn.subagents` | count | turn | Per-turn subagent spawn points |
+| `trajectory.session.tests_written` | gauge | session | Built-in new-test count |
+| `trajectory.turn.tests_written` | count | turn | Per-turn new-test points |
+| `trajectory.session.force_pushes` | gauge | session | Built-in force-push count |
+| `trajectory.turn.force_pushes` | count | turn | Per-turn force-push points |
 | `trajectory.session.ci_iterations` | gauge | session | Setup-default CI feedback ranges |
+| `trajectory.turn.ci_iterations` | count | turn | Per-turn completed CI feedback ranges |
 | `trajectory.session.code_added` | gauge | session | Setup-default code-change count |
-| `trajectory.session.files_modified` | gauge | session | Setup-default files-touched count |
+| `trajectory.turn.lines_of_code.count` | count | turn | Base line-delta telemetry tagged with `type:added` or `type:removed`; use `type:added` for turn-level code-added reports |
+| `trajectory.session.files_modified` | gauge | session | Built-in files-touched count |
+| `trajectory.turn.files_touched` | count | turn | Per-turn files-touched marker points; `trajectory.turn.files_modified` remains the base edit-count gauge |
 | `trajectory.session.tasks` | gauge | session | Task segment count when `segmentation.publish_metrics` or `segmentation.publish_traces` is enabled and destination segmentation is enabled |
 | `trajectory.session.task_outcome_mean` | gauge | session | Mean task outcome score when task-segmentation publish is enabled for the destination |
 | `trajectory.session.task_autonomy_mean` | gauge | session | Mean task autonomy score when task-segmentation publish is enabled for the destination |
 | `trajectory.session.high_risk_tasks` | gauge | session | Tasks with high risk score when task-segmentation publish is enabled for the destination |
-
-For trusted skill usage reports, prefer `trajectory.turn.skill_invocations` with
-`sum by {skill_name,detected_from,source_scope,signal_confidence}`. When native
-or explicit source metadata is unavailable, `source_scope` may be recovered by
-matching a generic skill-tool invocation against local project or user skill
-files. These metric series also carry normal Trajectory session tags including
-`trajectory.client_source`, `trajectory.client_version`, `trajectory.user`, and
-repo tags when available.
-
-Claude Code skill activation can arrive from native OTLP `skill_activated` logs
-or native transcript assistant messages with `attributionSkill`. When a turn
-has a high-confidence skill invocation marker, Trajectory also emits skill
-complexity metrics. Tool spans with native skill attributes publish as
-`skill_attribution:span_tool_attribute`; otherwise Trajectory can correlate a
-single high-confidence skill signal with same-turn Claude tool spans as
-`skill_attribution:span_temporal`, or fall back to same-turn materialized tool
-rows tagged `skill_attribution:turn_assisted`.
 
 Count-like session gauges that represent one final value per completed session
 also publish a `.completed_count` mirror, for example
@@ -292,8 +387,8 @@ across dashboard buckets, so dashboards that ask "how many?" should sum the
 For command-line usage toplists, query
 `sum:trajectory.session.cli_tool_count.completed_count by {tool}`. The `tool`
 tag is normalized from an allowlist of command families such as `git`, `gh`,
-`go`, `pytest`, `npm`, `docker`, and `kubectl`; unknown command names are
-skipped instead of being emitted as raw tag values.
+`go`, `pytest`, `npm`, `docker`, and `kubectl`; unknown command names
+are skipped instead of being emitted as raw tag values.
 
 Commit and PR attribution metrics are distribution samples:
 
@@ -301,9 +396,17 @@ Commit and PR attribution metrics are distribution samples:
 |---|---|---|---|
 | `trajectory.commit.cost.usd.total` | distribution | commit | Cost attributed to turns since the previous commit; yield-derived samples carry `branch` and are preferred over transcript-derived commit markers |
 | `trajectory.commit.attributed_turns.total` | distribution | commit | Turns attributed to the commit; yield-derived samples carry `branch` and are preferred over transcript-derived commit markers |
-| `trajectory.pr.cost.usd.attributed.total` | distribution | pr | Cost attributed to the PR/MR creation tail |
-| `trajectory.pr.attributed_turns.total` | distribution | pr | Turns attributed to the PR/MR creation tail |
-| `trajectory.pr.containing_session.cost.usd.total` | distribution | pr | Containing-session cost sampled once per PR/MR; do not sum |
+| `trajectory.pr.cost.usd.attributed.total` | distribution | pr | Cost attributed to the PR/MR creation tail; carries `change_host`, `owner`, `repo`, and `change_number` when extracted |
+| `trajectory.pr.attributed_turns.total` | distribution | pr | Turns attributed to the PR/MR creation tail; carries `change_host`, `owner`, `repo`, and `change_number` when extracted |
+| `trajectory.pr.containing_session.cost.usd.total` | distribution | pr | Containing-session cost sampled once per PR/MR; carries `change_host`, `owner`, `repo`, and `change_number` when extracted; do not sum |
+| `trajectory.pr.contexts.total` | distribution | pr | One sample per detected PR/MR work context; carries PR/MR identity plus `context_source` and `signal_confidence` when extracted |
+| `trajectory.pr.work_turns.total` | distribution | pr | Turns covered by each detected PR/MR work context; carries PR/MR identity plus `context_source` and `signal_confidence` when extracted |
+| `trajectory.pr.work_duration_ms.total` | distribution | pr | Duration of each detected PR/MR work context; carries PR/MR identity plus `context_source` and `signal_confidence` when extracted |
+
+PR-specific marker point metrics carry the canonical `session_id` tag, and rows
+with a source turn also carry `trajectory.turn_id`. Use PR identity tags only on
+PR-specific metrics; broad token, duration, tool, permission, and skill metrics
+intentionally do not add PR numbers.
 
 Custom measures can publish under any valid `trajectory.*` or `gen_ai.*` metric
 name. If a measure omits `metric:`, Trajectory derives
@@ -316,19 +419,24 @@ privacy/publish diagnostics.
 
 | Metric | Type | Tags | Notes |
 |---|---|---|---|
-| `trajectory.ops.install.current_state` | gauge | Canonical serve tags plus `managed`, `role`, `outcome`, `reason`, `setup_binary_status`, `setup_binary_version` | Managed setup summary. Current state emits `1`; prior state series emit `0` when setup state changes so dashboards can filter on the latest active state. |
+| `trajectory.ops.install.current_state` | gauge | Canonical serve tags plus `managed`, `role`, `outcome`, `reason`, `setup_binary_status`, `setup_binary_version` | Managed setup summary. Current state emits `1`; prior state series are emitted as `0` when the setup state changes so dashboards can filter on the latest active state. |
 | `trajectory.ops.install.agent_state` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `agent_status`, `setup_outcome`, `setup_stage`, `setup_component`, `setup_capture_path`, `setup_next_step`, `reason`, `setup_binary_status`, `setup_binary_version` | Per-integration setup state for every selected client. Distinguishes registration failures from verification failures and degraded fallback paths such as MCP watcher fallback. |
 | `trajectory.ops.agent.present` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source` | Daily local inventory signal for each known coding-agent client. Emits `1` when the client is detected on the machine and `0` when absent. Client aliases such as `cc` are reported as canonical runtime sources such as `claude-code`. |
 | `trajectory.ops.agent.version` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `client_version`, `trajectory.client_version`, `version_source` | Daily installed-agent freshness signal. Emits `1` for detected clients with the best available CLI-probed version, or `client_version:unknown` when the client is present but the version probe is unavailable. |
 | `trajectory.ops.agent.active_sessions` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source` | Hourly count of fresh active sessions by canonical client source, deduped across concurrent `trajectory serve` processes using per-PID heartbeat sentinels. Emits `0` for known clients with no fresh active sessions. |
 | `trajectory.ops.agent.active_session_version` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `client_version`, `trajectory.client_version`, `version_source` | Hourly active-session count by client version, using captured session-start state from heartbeat sentinels. Missing versions are reported as `client_version:unknown`. |
-| `trajectory.publish.active_destinations` | gauge | Canonical tags plus top-level and destination tags on Datadog destinations | Number of active destinations seen for a session |
+| `trajectory.publish.active_destinations` | gauge | Canonical tags plus top-level and destination tags on DD destinations | Number of active destinations seen for a session |
 | `trajectory.publish.turns` | count | OTLP publish path tags | Internal publish turn counter |
 | `trajectory.serve.incognito.enabled` | count | `client_source` | User or tool enabled incognito; intentionally not tagged by session ID |
 | `trajectory.serve.process.start_total` | count | `start_source` | Capture server listener started; `start_source:rescue_hook` identifies hook-driven recovery after a dead listener |
 | `trajectory.serve.process.exit_total` | count | `exit_reason`, optional `signal` | Capture server observed a graceful or error exit path before publish shutdown; hard kills are inferred from later rescue starts |
 | `trajectory.serve.capture.request_error_total` | count | `client`, `event_type`, `error_kind`, `http_status_class` | Capture HTTP request returned 4xx/5xx or hit a handler error |
 | `trajectory.serve.goroutine.panic_recovered_total` | count | `goroutine`, `action` | Serve background goroutine panic was recovered; `action` is `restart` or `give_up` |
+| `trajectory.serve.local_state.live_session_files` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Count of non-lock live-session projection files found during the local-state health scan |
+| `trajectory.serve.local_state.heartbeat_files` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Count of active-session heartbeat sentinel files found during the local-state health scan |
+| `trajectory.serve.local_state.instrumentation_health_records` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Count of locally spooled instrumentation-health records found during the local-state health scan |
+| `trajectory.serve.local_state.serve_log_bytes` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Current `trajectory-serve.log` size in bytes at the local-state health scan |
+| `trajectory.serve.local_state.serve_diag_bytes` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Current `serve-diag.ndjson` size in bytes at the local-state health scan |
 | `trajectory.serve.publish.sensitivity_suppressed` | count | `client_source`, `destination`, `category`, `label` | Sensitive spans dropped for a destination |
 | `trajectory.serve.publish.sensitivity_held` | count | `client_source`, `destination`, `reason` | Spans held while classification is pending or unresolved |
 | `trajectory.serve.publish.spans_suppressed_total` | count | `client_source`, `destination`, `category`, `label` | Number of spans suppressed by sensitivity policy |
@@ -347,8 +455,8 @@ invoice reconciliation. Calls whose model is not visible or priced still emit
 the call count with `cost_source:pricing_unknown`.
 
 Managed setup state uses low-cardinality reason and remediation tags. Use
-`setup_stage:registration` when client setup failed before writing or
-registering assets, `setup_stage:verification` when setup completed but the
+`setup_stage:registration` when the client setup command failed before writing
+or registering assets, `setup_stage:verification` when setup completed but the
 installed config is not usable, `setup_stage:fallback` when capture is expected
 through a lower-fidelity fallback, and `setup_stage:configured` for a fully
 verified integration. `setup_component` identifies the failed surface, such as
@@ -356,13 +464,44 @@ verified integration. `setup_component` identifies the failed surface, such as
 `wrapper_metadata`, `client_runtime`, or `sdk_extension`. `setup_next_step`
 contains a bounded remediation code such as `rerun_setup_client`,
 `install_client_then_rerun_setup`, `fix_permissions_then_rerun_setup`,
-`install_node_or_reinstall_client`, or `ensure_trajectory_bin_first_on_path`.
+`install_node_or_reinstall_client`, or
+`ensure_trajectory_bin_first_on_path`.
 
-## Companion Metrics
+## Claude Native OTLP Metrics
 
-When the Claude Code companion metrics proxy is enabled, Trajectory forwards
-Claude Code's native OTLP usage metrics after adding session context. The
-companion also emits bounded diagnostic counters through its OTel meter.
+`trajectory serve` accepts Claude Code native OTLP metrics on `/v1/metrics`.
+When `server.otlp_proxy.endpoint` is configured, it decorates metric datapoints
+with canonical Trajectory identity tags plus
+`trajectory.cost_role:client_telemetry`,
+`trajectory.cost_source:claude_native_otlp`, and the bounded cost-overlap
+vocabulary above before forwarding to the upstream collector. It returns
+success to Claude even if enrichment or the upstream request fails; when
+enrichment fails, the original payload is forwarded unchanged.
+
+The serve-level forwarder does not correct native client cost values, drop
+invalid datapoints, or emit the companion diagnostic counters below. The legacy
+session-scoped companion metrics proxy still performs those sanitization and
+cost-correction steps when explicitly enabled.
+
+Datadog validation for Trajectory-owned metrics should use
+`trajectory publish metrics audit --readback` or `--readback-all`. Native
+client telemetry forwarded through `server.otlp_proxy` is not reconstructed
+from the local metric outbox; validate it in Datadog by filtering or grouping
+on `trajectory.cost_role:client_telemetry`,
+`trajectory.cost_source:claude_native_otlp`, and
+`trajectory.cost_dedupe_group`.
+For local pre-Datadog evidence, set `server.otlp_proxy.capture_enabled: true`
+or `TRAJECTORY_OTLP_PROXY_CAPTURE_ENABLED=1` and run:
+
+```bash
+trajectory otlp metrics compare --session <session-id>
+```
+
+That command reads normalized records from
+`~/.trajectory/state/otlp-proxy/metrics/` and reports whether inbound native
+OTLP datapoint values were preserved after Trajectory enrichment, which tags
+were added, and which cost stream should be displayed for attribution versus
+client-telemetry comparison.
 
 | Metric | Type | Notes |
 |---|---|---|
@@ -402,6 +541,13 @@ only by code paths that explicitly create health records.
 | `trajectory.instrumentation.backfill.lag_ms` | distribution |
 | `trajectory.instrumentation.health.spool_depth` | gauge |
 | `trajectory.instrumentation.health.emit_dropped` | count |
+
+`trajectory.instrumentation.health.spool_depth` is emitted as a remote-only
+gauge with bounded `component`, `signal`, and `reason` tags. It intentionally
+does not append to the local instrumentation-health spool. When a health record
+cannot be sanitized or written to the local spool,
+`trajectory.instrumentation.health.emit_dropped` emits a remote-only count with
+bounded `component`, `signal`, `error_class`, and `reason` tags.
 
 ## Heartbeat Metric Definitions
 
@@ -452,6 +598,22 @@ default `*` expands to a model-presence filter and drops otherwise valid
 non-token metrics when the model tag is absent. Prefer model as a grouping on
 `gen_ai.usage.*` token widgets, or apply a model filter only on widgets that
 intentionally require model-tagged data.
+
+Treat `repo` as a grouping label, not proof of Git identity. For repository
+dashboards that should only include parsed remotes, filter
+`trajectory.repo_source:git_origin`. Use `trajectory.repo_source:project_dir`
+to audit fallback coverage, `trajectory.repo_source:configured` for custom
+config tags, and `trajectory.repo_source:unknown` when no usable project
+directory or remote was available. `git_origin_unparsed` means Trajectory found
+a Git origin host and path, but could not split the path into both owner and
+repo.
+
+Dashboard templates should default `repo_source` filters to `*` while a fleet is
+rolling forward to a binary that emits `trajectory.repo_source`; otherwise the
+filter can hide valid recent data whose older series do not yet carry the tag.
+Use a dedicated provenance widget to watch `trajectory.repo_source` coverage,
+then apply `git_origin` filters only on widgets that explicitly need Git remote
+identity.
 
 Use max-style queries for `trajectory.publish.active_destinations` when asking
 "how many destinations were active?" It is a per-session gauge; averaging it

--- a/docs/SKILL-OBSERVABILITY.md
+++ b/docs/SKILL-OBSERVABILITY.md
@@ -1,0 +1,216 @@
+# Skill Observability
+
+Skill observability is the privacy-preserving view for teams that maintain
+coding-agent skills. It answers where a skill is used, how often it is invoked,
+how trustworthy the signal is, what tool mix appears around the skill, how long
+skill-assisted turns take, and which cost source applies to the same repo and
+client scope.
+
+It is intentionally derived telemetry. The dashboard and marker metrics do not
+publish prompts, assistant responses, tool input or output, shell commands,
+diffs, file contents, raw trace payloads, or local file paths.
+
+## Quick Setup
+
+For most teams, skill observability is a metrics dashboard. You do not need
+project skill mutation or read virtualization to start.
+
+1. Enable normal Trajectory capture and metrics:
+
+```bash
+trajectory setup --clients cc
+trajectory config set export.metrics true
+trajectory metrics verify
+```
+
+2. For Claude Code, launch sessions through Trajectory when you want the best
+   skill signal and native tool-window attribution:
+
+```bash
+trajectory claude
+trajectory claude -- "use the release skill to prepare the release checklist"
+```
+
+3. Export and import the skill observability dashboard:
+
+```bash
+trajectory dashboard export --type skill-observability --output trajectory-skill-observability.json
+```
+
+Import `trajectory-skill-observability.json` in Datadog, then set the dashboard
+variables for `repo`, `skill_name`, `trajectory.client_source`, and
+`signal_confidence:high`.
+
+4. Read the first panels this way:
+
+| Panel | What It Tells You |
+|---|---|
+| Skill invocations by repo | Whether the skill is being used and where |
+| Signal source and confidence | Whether the skill name came from Claude transcript, Claude native OTLP, or a weaker observation |
+| Tool totals and tool mix | How complex skill-assisted turns are |
+| Duration | How long skill-assisted turns typically take |
+| Cost-source context | Which cost stream applies to the same repo/client slice |
+
+This simple path is enough for the common skill-maintainer questions: which
+repos use the skill, how often it is invoked, whether attribution is reliable,
+which tools it tends to drive, and how slow skill-assisted turns are.
+
+## Optional Paths
+
+Use these only when you need the extra surface:
+
+| Need | Add |
+|---|---|
+| Tighter Claude tool windows | Run Claude with `trajectory claude` so native OTLP can flow through local `trajectory serve` |
+| Project `.claude/skills` fallback instrumentation | Opt in with `TRAJECTORY_CLAUDE_SKILLS_PROJECT=1 trajectory claude skills sync --project` |
+| Non-mutating skill-file experiments | Use `trajectory claude --skill-read-virtualization --skill-managed-binary -- <claude args>` |
+
+## Dashboard Import Details
+
+Export the standalone skill-maintainer dashboard:
+
+```bash
+trajectory dashboard export --type skill-observability --output trajectory-skill-observability.json
+```
+
+Import the JSON through the Datadog UI or Dashboard API. If an agent is creating
+the dashboard through Datadog MCP, export the MCP-shaped payload instead:
+
+```bash
+trajectory dashboard export --type skill-observability --format mcp --output trajectory-skill-observability-mcp.json
+```
+
+The dashboard uses variables for `trajectory.user`,
+`trajectory.client_source`, `trajectory.client_version`, `repo`, `skill_name`,
+`source_scope`, `signal_confidence`, and `skill_attribution`. Start with
+`signal_confidence:high`, then broaden only when investigating missing or
+weaker signals.
+
+## What You Can Answer
+
+Use these fields and metrics directly in Datadog Metrics Explorer or dashboard
+panels:
+
+| Question | Use |
+|---|---|
+| Which skills are used, and where? | `sum:trajectory.turn.skill_invocations{...} by {repo,skill_name}` |
+| How often is a skill invoked? | `trajectory.turn.skill_invocations`; use `trajectory.session.skill_invocations.completed_count` for completed-session rollups |
+| Which signal produced the skill name? | group by `detected_from`, `source_scope`, and `signal_confidence` |
+| How many tools did skill-assisted turns use? | `trajectory.turn.skill_tool_uses.total` grouped by `skill_name` and `skill_attribution` |
+| Which tool types and names appear? | `trajectory.turn.skill_tool_uses` grouped by `skill_name`, `tool_type`, and `tool_name` |
+| How long do skill-assisted turns take? | `p95:trajectory.turn.skill_duration_ms.total{...} by {skill_name,skill_attribution}` |
+| What cost source is in scope? | cost panels or queries grouped by `trajectory.cost_source` and `trajectory.cost_role` for the same repo/client filters |
+
+Cost panels are context for the same filtered repo, client, model, and version
+scope. They are not proof that every token in a turn was caused by the skill.
+When comparing Claude native telemetry with Trajectory attribution cost, keep
+`trajectory.cost_role:client_telemetry` plus
+`trajectory.cost_source:claude_native_otlp` separate from
+`trajectory.cost_role:attribution`.
+
+## Signal Quality
+
+Skill invocation metrics are derived from the high-confidence
+`skill-invoked-turn-count` marker point. Prefer
+`trajectory.turn.skill_invocations` for trusted usage reports.
+
+Common `detected_from` values:
+
+| Value | Meaning |
+|---|---|
+| `claude_native_transcript` | Claude transcript `message.attributionSkill` identified the skill |
+| `claude_native_otel` | Claude native OTLP emitted a `skill_activated` log through Trajectory |
+| `provenance` or `skill_prompt` | Trajectory inferred the skill from local capture or explicit skill metadata |
+
+`source_scope` describes where the skill came from, such as `user`,
+`project`, or `global`. `signal_confidence:high` means the point is suitable
+for normal usage reporting. Lower-confidence breadcrumbs publish as
+`trajectory.turn.skill_observations` and
+`trajectory.session.skill_observations`; use them for troubleshooting, not for
+primary adoption reporting.
+
+## Tool and Duration Attribution
+
+Tool and duration metrics carry `skill_attribution` so you can tell whether the
+tool window came from native Claude trace structure or from Trajectory's
+same-turn fallback:
+
+| Value | Meaning |
+|---|---|
+| `span_tool_attribute` | A native Claude tool span carried the skill name |
+| `span_temporal` | A single high-confidence skill signal was matched to native tool spans in the same turn by time |
+| `turn_assisted` | No usable native trace window was available, so Trajectory used all non-skill tools in the same skill-assisted turn |
+
+Use `span_tool_attribute` and `span_temporal` when you need a tighter estimate
+of skill complexity. Use `turn_assisted` for broad trend analysis and for
+clients or sessions that do not expose native skill spans.
+
+## Setup Details
+
+The baseline path is normal Trajectory capture plus metrics publishing:
+
+```bash
+trajectory setup --clients cc
+trajectory config set export.metrics true
+trajectory metrics verify
+```
+
+For Claude Code, normal setup can capture skill activation from Claude
+transcripts when the runtime writes `message.attributionSkill`. That is enough
+for repo-scoped invocation counts, signal-confidence breakdowns, and fallback
+same-turn tool metrics.
+
+Run Claude through `trajectory claude` when you want Trajectory to route Claude
+native OTLP and derive native trace-backed skill tool windows:
+
+```bash
+trajectory claude
+trajectory claude -- "work on the release checklist"
+```
+
+Project `.claude/skills` file instrumentation is opt-in because it can touch
+version-controlled files. Enable project skill sync only when you want that
+fallback path:
+
+```bash
+TRAJECTORY_CLAUDE_SKILLS_PROJECT=1 trajectory claude skills sync --project
+trajectory claude skills status
+trajectory claude skills restore --stale
+```
+
+On supported macOS launch chains, the non-mutating read-virtualization path can
+serve virtualized `SKILL.md` bytes through a managed Claude launch copy:
+
+```bash
+trajectory claude --skill-read-virtualization --skill-managed-binary -- <claude args>
+```
+
+Read virtualization is useful for clean experiments and for avoiding durable
+project-file edits. It is not required for the main transcript attribution path.
+
+
+## Troubleshooting
+
+If the dashboard has no skill data, first confirm metrics are publishing:
+
+```bash
+trajectory metrics session --latest
+trajectory metrics verify
+trajectory publish status
+```
+
+If invocation counts are missing but observations exist, filter
+`trajectory.turn.skill_observations` by `repo`, `skill_name`, `source_scope`,
+and `trajectory.client_version`. This usually means the client exposed a weak
+skill breadcrumb but not a high-confidence activation signal.
+
+If Claude skill invocations dropped after a runtime update, group
+`trajectory.turn.skill_invocations` by `trajectory.client_version`,
+`detected_from`, and `signal_confidence`. A shift away from
+`detected_from:claude_native_transcript` can indicate Claude stopped writing
+`message.attributionSkill`.
+
+If tool counts are present only with `skill_attribution:turn_assisted`, run the
+session through `trajectory claude` and confirm Claude native OTLP is reaching
+local `trajectory serve`. Native trace-backed windows require the Claude native
+OTLP path; fallback same-turn metrics do not.

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -1,6 +1,8 @@
 # Supported Clients
 
-Trajectory instruments AI coding agents via hooks that capture session events to a local server. Each client has its own plugin/extension format and minimum version requirements.
+Trajectory instruments AI coding agents via hooks that capture session events
+to a local server. Each client has its own plugin/extension format, Trajectory
+release status, and upstream CLI version support.
 
 For the lower-level install artifacts, hook surfaces, watcher behavior, and
 backfill boundaries per client, see
@@ -14,92 +16,410 @@ trajectory user-guide clients
 trajectory user-guide clients/codex
 trajectory user-guide clients/agy
 trajectory user-guide clients/goose
+trajectory user-guide clients/amp
 trajectory user-guide clients/cline
+trajectory user-guide clients/qwen
+trajectory user-guide clients/openhands
 trajectory user-guide clients/aider
 trajectory user-guide clients/continue
 trajectory user-guide clients/mistral-vibe
 trajectory user-guide clients/codebuff
-trajectory user-guide clients/hermes
-trajectory user-guide clients/amp
-trajectory user-guide clients/qwen
-trajectory user-guide clients/openhands
 trajectory user-guide clients/kilo
 trajectory user-guide clients/kiro
 ```
 
 ## Quick Reference
 
-| Client | Install | Min Version | Capture |
-|--------|---------|-------------|---------|
-| Claude Code | `trajectory setup --clients cc` | 2.0+ | HTTP hooks + MCP |
-| Codex CLI | `trajectory setup --clients codex` | 0.128.0 | Command hooks (primary) + rollout watcher (fallback) |
-| GitHub Copilot CLI | `trajectory setup --clients copilot` | Beta | Copilot plugin command hooks + MCP |
-| Gemini CLI | `trajectory setup --clients gemini` | 0.30.0+ | Managed command hooks + MCP |
-| Antigravity CLI (`agy`) | `trajectory setup --clients agy` | 1.0.0+ | Antigravity plugin command hooks + MCP |
-| Goose | `trajectory setup --clients goose` | 1.39.0 tested | Open Plugins command hooks |
-| Cline CLI | `trajectory setup --clients cline` | 3.0.34 tested | File hooks + MCP |
-| Aider | `trajectory setup --clients aider --install-client-shims` | Current CLI tested | Opt-in command shim + analytics/history sidecars |
-| Continue CLI | `trajectory setup --clients continue --install-client-shims` | 1.5.47 tested | Opt-in `cn` command shim + session JSON readback |
-| Mistral Vibe | `trajectory setup --clients mistral-vibe --install-client-shims` | 2.18.3 inspected | Opt-in command shim + native tool hooks |
-| Codebuff | `trajectory setup --clients codebuff --install-client-shims` | 1.0.682 inspected | Opt-in command shims + chat-history import |
-| Cursor Desktop | `trajectory setup --clients cursor` | 1.0+ | Command hooks that POST to capture |
-| cursor-agent CLI | Automatic when `cursor-agent` is on PATH | Beta | Transcript watcher |
-| Factory Droid | `trajectory setup --clients droid` | Beta | Factory plugin command hooks + MCP |
-| Hermes Agent | `trajectory setup --clients hermes` | Beta | Observer plugin hooks + MCP |
-| Amp Code | `trajectory setup --clients amp` | Beta | System TypeScript plugin events + MCP |
-| Qwen Code | `trajectory setup --clients qwen` | 0.19.2 tested | Native HTTP hooks + MCP |
-| OpenHands | `trajectory setup --clients openhands` | V1 CLI tested | Command hooks + MCP |
-| Pi | `trajectory setup --clients pi` | Beta | TypeScript extension + MCP |
-| OpenCode | `trajectory setup --clients opencode` | Beta | Plugin SDK events + MCP |
-| Kilo Code | `trajectory setup --clients kilo` | Beta | Plugin SDK events + MCP |
-| Kiro CLI | `trajectory setup --clients kiro` | Beta | Agent command hooks + MCP |
+Trajectory status describes this repository's release posture for the
+integration. Supported CLI version describes the upstream client version or
+contract Trajectory currently targets; beta status is not a minimum version.
+
+| Client | Setup integration | Trajectory status | Supported CLI version | Hook mechanism | Relay or native telemetry |
+|--------|-------------------|-------------------|-----------------------|----------------|---------------------------|
+| Claude Code | `trajectory setup --clients cc` | Supported | 2.0+ | HTTP hooks + MCP | Claude native OTLP can be relayed through Trajectory |
+| Codex CLI | `trajectory setup --clients codex` | Supported | 0.128.0+ | Command hooks (primary) + rollout watcher (fallback) | Responses proxy spans and watcher backfill |
+| GitHub Copilot CLI | `trajectory setup --clients copilot` | Beta | Public plugin hook contract; no stable minimum pinned | Copilot plugin command hooks + MCP | Plugin command capture only |
+| Gemini CLI | `trajectory setup --clients gemini` | Supported | 0.30.0+ | Managed command hooks + MCP | Hook payload token/cost fields |
+| Antigravity CLI (`agy`) | `trajectory setup --clients agy` | Supported | 1.0.0+ | Antigravity plugin command hooks + MCP | Gemini-compatible hook payloads |
+| Goose | `trajectory setup --clients goose` | Beta | 1.39.0 tested | Open Plugins command hooks | Open Plugins capture; provider-call detail depends on client payloads |
+| Cline CLI | `trajectory setup --clients cline` | Beta | 3.0.34 tested | File hooks + MCP | File-hook capture; current hooks omit token/cost usage |
+| Cursor Desktop | `trajectory setup --clients cursor` | Supported | 1.0+ | Command hooks that POST to capture | Cursor DB and watcher readback |
+| cursor-agent CLI | Automatic when `cursor-agent` is on PATH | Beta | Current CLI tested; no stable minimum pinned | Transcript watcher | Transcript watcher only |
+| Factory Droid | `trajectory setup --clients droid` | Beta | Public plugin hook contract; no stable minimum pinned | Factory plugin command hooks + MCP | Plugin command capture only |
+| Hermes Agent | `trajectory setup --clients hermes` | Beta | Public observer-hook contract; no stable minimum pinned | Observer plugin hooks + MCP | Observer usage payloads when present |
+| Amp Code | `trajectory setup --clients amp` | Beta | Current plugin API inspected; no stable minimum pinned | System TypeScript plugin events + MCP | Plugin events; token/cost usage depends on Amp payloads |
+| Qwen Code | `trajectory setup --clients qwen` | Beta | 0.19.2 tested | Native HTTP hooks + MCP | Native hooks with usage metadata when present |
+| OpenHands | `trajectory setup --clients openhands` | Beta | V1 CLI tested | Command hooks + MCP | Command-hook capture; current hooks omit token/assistant payloads |
+| Aider | `trajectory setup --clients aider --install-client-shims` | Beta | Current CLI tested | Opt-in command shim + analytics/history sidecar | Usage/cost from Aider analytics logs |
+| Continue CLI | `trajectory setup --clients continue --install-client-shims` | Beta | 1.5.47 tested | Opt-in `cn` command shim + session JSON readback | Usage/cost from Continue session history when present |
+| Mistral Vibe | `trajectory setup --clients mistral-vibe --install-client-shims` | Beta | 2.18.3 inspected | Opt-in `vibe` command shim + native `before_tool`/`after_tool` hooks | Usage/cost from Vibe session metadata when present |
+| Codebuff | `trajectory setup --clients codebuff --install-client-shims` | Beta | 1.0.682 inspected | Opt-in command shims + chat-history importer | Usage from Codebuff `chat-messages.json` |
+| Pi | `trajectory setup --clients pi` | Supported | Current CLI tested | TypeScript extension + MCP | Extension events with provider-call usage |
+| OpenCode | `trajectory setup --clients opencode` | Supported | Current CLI tested | Plugin SDK events + MCP | Plugin SDK events plus SQLite backfill |
+| Kilo Code | `trajectory setup --clients kilo` | Beta | Current CLI tested | Plugin SDK events + MCP | Plugin SDK events; native OTLP traces/logs can be pointed at the Trajectory OTLP relay |
+| Kiro CLI | `trajectory setup --clients kiro` | Beta | Public command-hook contract; no stable minimum pinned | Agent command hooks + MCP | Fixture-tested command hooks; no usage metadata in current hook payloads |
 
 ## Feature Coverage Matrix
 
-| Client | Live capture | Tool/model events | Token/cost usage | Incognito or MCP | Backfill | Resume |
-|--------|--------------|-------------------|------------------|------------------|----------|--------|
-| Claude Code | Yes, HTTP hooks | Yes | Yes | Yes | Transcript backfill | Yes |
-| Codex CLI | Yes, command hooks plus rollout watcher fallback | Yes | Yes | Yes | Codex rollout backfill | Yes |
-| GitHub Copilot CLI | Yes, beta plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
-| Gemini CLI | Yes, managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
-| Antigravity CLI (`agy`) | Yes, plugin command hooks | Yes, via Gemini-compatible hook schema | Yes, via Gemini-compatible token fields | Yes | Not yet | No setup-managed resume |
-| Goose | Yes, Open Plugins command hooks | Session, prompt, tool, shell/file, and assistant-message hooks | Usage when hook payloads expose it | Not yet | Not yet | No setup-managed resume |
-| Cline CLI | Yes, file hooks | Lifecycle, prompt, tool, assistant-message, turn, and session-end events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
-| Aider | Yes, opt-in command shim | Prompt, assistant-message, and turn events | Yes, from Aider analytics rows when present | Command shim | Not yet | No setup-managed resume |
-| Continue CLI | Yes, opt-in `cn` command shim | Prompt, assistant-message, and turn events | Yes, from Continue session usage metadata when present | Command shim | Not yet | No setup-managed resume |
-| Mistral Vibe | Yes, opt-in command shim plus native tool hooks | Prompt, tool, assistant-message, and turn events | Yes, from Vibe session metadata when present | Command shim | Not yet | No setup-managed resume |
-| Codebuff | Yes, opt-in command shims and chat-history import | Prompt, assistant-message, turn, and chat-history-derived model events | Yes, from Codebuff chat metadata | Command shim | Codebuff chat history backfill | No setup-managed resume |
-| Cursor Desktop | Yes, command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
-| cursor-agent CLI | Yes, transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
-| Factory Droid | Yes, beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
-| Hermes Agent | Yes, observer plugin hooks | Yes | Usage payloads when present | Yes | Not yet | No setup-managed resume |
-| Amp Code | Yes, setup-managed system plugin | Yes | When Amp plugin events expose usage | MCP | Not yet | No setup-managed resume |
-| Qwen Code | Yes, native HTTP hooks | Yes | Yes, from usage metadata and transcript fallback | Yes | Not yet | No setup-managed resume |
-| OpenHands | Yes, command hooks | Lifecycle, prompt, and tool events | Not exposed by command hook payloads | Yes | Not yet | No setup-managed resume |
-| Pi | Yes, TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
-| OpenCode | Yes, plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
-| Kilo Code | Yes, plugin SDK events | Yes | Native OTLP traces/logs plus SDK payloads when exposed | Yes | Not yet | No setup-managed resume |
-| Kiro CLI | Yes, agent command hooks | Prompt, tool, and assistant-response events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
+This section separates capture fidelity from privacy and derived-feature
+coverage. Incognito is a server-side Trajectory gate for every captured session
+once the session is toggled; the privacy matrix calls out whether setup gives
+that client a first-class way to toggle it. Sensitivity classification and task
+segmentation are core Trajectory features for captured non-headless sessions;
+headless sessions are captured and published when configured, but always skip
+sensitivity classification and segmentation.
 
-For local cost readback and supported-agent fidelity checks, run `trajectory
-cost`, `trajectory cost inspect --session <id>`, and `trajectory cost
-validate`. The validation command reports recent cost coverage for supported
-clients, including token-positive turns that recorded zero cost.
+### Capture And Telemetry
+
+| Client | Live capture | Tool/model events | Token/cost usage | Backfill | Resume |
+|--------|--------------|-------------------|------------------|----------|--------|
+| Claude Code | Yes, HTTP hooks | Yes | Yes | Transcript backfill | Yes |
+| Codex CLI | Yes, command hooks plus rollout watcher fallback | Yes | Yes | Codex rollout backfill | Yes |
+| GitHub Copilot CLI | Beta, Copilot plugin command hooks | Command-level lifecycle, prompt, tool, and session events | Not exposed by current hook payloads | Not yet | Not yet |
+| Gemini CLI | Yes, managed command hooks | Yes | Yes | Gemini transcript backfill | Yes |
+| Antigravity CLI (`agy`) | Yes, plugin command hooks | Yes, via Gemini-compatible hook schema | Yes, via Gemini-compatible token fields | Not yet | No setup-managed resume |
+| Goose | Yes, Open Plugins command hooks | Session, prompt, tool, shell/file, and assistant-message hooks | Usage detail depends on provider payloads; SQLite usage readback is a future backfill path | Not yet | No setup-managed resume |
+| Cline CLI | Yes, file hooks | Lifecycle, prompt, tool, assistant-message, turn, and session-end events | Not exposed by current hook payloads; `turn_end.tokens_status=unavailable` | Not yet | No setup-managed resume |
+| Cursor Desktop | Yes, command hooks | Yes | Cursor DB dependent | Cursor chat backfill | Yes |
+| cursor-agent CLI | Yes, transcript watcher | Tool and turn events | Not exposed by current transcripts | Same transcript source | No setup-managed resume |
+| Factory Droid | Beta, Factory plugin command hooks | Documented lifecycle, prompt, tool, notification, compaction, stop, and subagent-stop events | Not exposed by current documented hook payloads | Not yet | Not yet |
+| Hermes Agent | Yes, observer plugin hooks | Yes | Yes, from observer `usage` payloads when present | State DB backfill reference only; not implemented in Trajectory yet | No setup-managed resume |
+| Amp Code | Yes, setup-managed system plugin | Yes | Yes when Amp plugin events or thread messages expose usage | Thread JSON backfill reference only; not implemented in Trajectory yet | No setup-managed resume |
+| Qwen Code | Yes, native HTTP hooks | Yes | Yes, from Qwen `usageMetadata` and transcript fallback | Chat JSONL backfill reference only; not implemented in Trajectory yet | No setup-managed resume |
+| OpenHands | Yes, command hooks | Lifecycle, prompt, and tool events | Not exposed by command hook payloads; `turn_end.tokens_status=unavailable` | Not yet | No setup-managed resume |
+| Aider | Yes, opt-in command shim | Lifecycle, prompt, assistant-message, and turn events | Yes, from Aider `--analytics-log`; assistant text from `--llm-history-file` | Not yet | No setup-managed resume |
+| Continue CLI | Yes, opt-in `cn` command shim | Lifecycle, prompt, assistant-message, and turn events | Yes, from Continue session JSON when usage metadata is present | Not yet | No setup-managed resume |
+| Mistral Vibe | Yes, opt-in `vibe` command shim plus native tool hooks | Lifecycle, prompt, tool, assistant-message, and turn events | Yes, from Vibe session metadata when session logging is enabled | Not yet | No setup-managed resume |
+| Codebuff | Yes, opt-in command shims and post-run chat-history import | Lifecycle, prompt, assistant-message, and turn events | Yes, from `~/.config/manicode*/projects/*/chats/*/chat-messages.json` usage metadata | Codebuff chat history backfill | No setup-managed resume |
+| Pi | Yes, TypeScript extension | Yes | Yes | Pi/OMP session backfill | Yes |
+| OpenCode | Yes, plugin SDK events | Yes | Yes | SQLite backfill | Yes |
+| Kilo Code | Yes, plugin SDK events | Yes | Native OTLP traces/logs plus SDK payloads when exposed | Not yet | No setup-managed resume |
+| Kiro CLI | Yes, agent command hooks | Prompt, tool, and assistant-response events | Not exposed by current documented hook payloads | Not yet | No setup-managed resume |
+
+### Privacy And Derived Features
+
+| Client | Incognito UX | MCP incognito tool | Sensitivity scanning | Segmentation | Coverage note |
+|--------|--------------|--------------------|----------------------|--------------|---------------|
+| Claude Code | `/trajectory:incognito` command and incognito skill | Yes | Non-headless eligible; headless skipped | Non-headless eligible; headless skipped | First-class incognito UX |
+| Codex CLI | Incognito skill with bundled script fallback | Yes | Non-headless eligible; headless skipped | Non-headless eligible; headless skipped | First-class incognito UX |
+| GitHub Copilot CLI | Incognito skill in the local marketplace plugin | Yes | Non-headless plugin sessions eligible; headless skipped | Non-headless plugin sessions eligible; headless skipped | Plugin sessions can toggle incognito |
+| Gemini CLI | `/incognito` command and incognito skill | Yes | Non-headless hook sessions eligible; headless skipped | Non-headless hook sessions eligible; headless skipped | First-class incognito UX |
+| Antigravity CLI (`agy`) | `/incognito` command and incognito skill | Yes | Non-headless hook sessions eligible; headless skipped | Non-headless hook sessions eligible; headless skipped | Incognito skill and command installed by setup |
+| Goose | Setup-managed `goose-incognito` command | No | Non-headless Open Plugins sessions eligible; headless skipped | Non-headless Open Plugins sessions eligible; headless skipped | Command-based incognito toggle |
+| Cline CLI | Setup-managed `cline-incognito` command plus MCP request path | Yes | Non-headless file-hook sessions eligible; headless skipped | Non-headless file-hook sessions eligible; headless skipped | Command and MCP incognito paths |
+| Cursor Desktop | Incognito skill, using Claude skill when available or native Cursor fallback; setup also installs `cursor-agent-incognito` | Yes | Non-headless GUI sessions eligible; headless skipped | Non-headless GUI sessions eligible; headless skipped | GUI sessions use skill-based incognito |
+| cursor-agent CLI | Setup-managed `cursor-agent-incognito` command when the Cursor integration is installed; watcher has no native slash surface | No | Transcript-watcher sessions are treated as headless and skipped | Transcript-watcher sessions are treated as headless and skipped | Headless transcript watcher path |
+| Factory Droid | Incognito skill in the local marketplace plugin | Yes | Non-headless plugin sessions eligible; headless skipped | Non-headless plugin sessions eligible; headless skipped | Plugin sessions can toggle incognito |
+| Hermes Agent | Incognito skill | Yes | Non-headless observer sessions eligible; headless skipped | Non-headless observer sessions eligible; headless skipped | Observer sessions can toggle incognito |
+| Amp Code | Setup-managed `amp-incognito` command plus MCP request path | Yes | Non-headless Amp plugin sessions eligible; headless skipped | Non-headless Amp plugin sessions eligible; headless skipped | Command and MCP incognito paths |
+| Qwen Code | `/incognito` command and incognito skill | Yes | Non-headless Qwen hook sessions eligible; headless skipped | Non-headless Qwen hook sessions eligible; headless skipped | Incognito skill and command installed by setup |
+| OpenHands | Setup-managed `openhands-incognito` command plus MCP request path | Yes | Non-headless command-hook sessions eligible; headless skipped | Non-headless command-hook sessions eligible; headless skipped | Command and MCP incognito paths |
+| Aider | Setup-managed `aider-incognito` command | No | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions can use command incognito |
+| Continue CLI | Setup-managed `continue-incognito` command | No | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions can use command incognito |
+| Mistral Vibe | Setup-managed `vibe-incognito` and `mistral-vibe-incognito` commands | No | Wrapper/native sessions eligible when non-headless; headless skipped | Wrapper/native sessions eligible when non-headless; headless skipped | Wrapper sessions can use command incognito |
+| Codebuff | Setup-managed `codebuff-incognito` and `cb-incognito` commands | No | Wrapper/imported sessions eligible when non-headless; headless skipped | Wrapper/imported sessions eligible when non-headless; headless skipped | Wrapper/imported sessions can use command incognito |
+| Pi | Native `trajectory_incognito` tool plus MCP | Yes | Non-headless extension sessions eligible; extension-supplied verdicts accepted; headless skipped | Non-headless extension sessions eligible; headless skipped | Native extension incognito tool |
+| OpenCode | Incognito skill | Yes | Non-headless plugin SDK sessions eligible; headless skipped | Non-headless plugin SDK sessions eligible; headless skipped | Plugin SDK sessions can toggle incognito |
+| Kilo Code | Incognito skill | Yes | Non-headless plugin SDK sessions eligible; headless skipped | Non-headless plugin SDK sessions eligible; headless skipped | Plugin SDK sessions can toggle incognito |
+| Kiro CLI | Setup-managed `kiro-incognito` command plus MCP request path | Yes | Prompt/tool hook capture eligible when non-headless; headless skipped | Segmentation depends on a terminal session-end signal | Command and MCP incognito paths |
+
+For local cost readback and supported-agent fidelity checks, run
+`trajectory cost`, `trajectory cost inspect --session <id>`, and
+`trajectory cost validate`. The validation command reports recent cost coverage
+for Claude Code, Codex, Gemini, Antigravity, Pi, OpenCode, Kilo Code, Cursor,
+Hermes Agent, Amp Code, Qwen Code, and Mistral Vibe, including token-positive
+turns that recorded zero cost.
+
+## Hermes Agent
+
+**Trajectory status: Beta. Supported contract: public Hermes observer-hook contract.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients hermes
+```
+
+Setup writes `~/.hermes/plugins/trajectory/plugin.yaml`,
+`~/.hermes/plugins/trajectory/__init__.py`, merges `plugins.enabled:
+[trajectory]` and `mcp_servers.trajectory` into `~/.hermes/config.yaml`, and
+installs an incognito skill under `~/.hermes/skills/incognito/SKILL.md`.
+
+Hermes exposes a read-only observer hook system through Python plugins. The
+Trajectory plugin maps `on_session_start`, `pre_llm_call`,
+`post_api_request`, `post_llm_call`, `pre_tool_call`, `post_tool_call`,
+approval hooks, subagent hooks, and `on_session_finalize` into canonical
+Trajectory events at `/capture/hermes/<event>`. The plugin is fail-open and
+does not return behavior-changing hook values.
+
+`post_api_request` carries Hermes `usage` fields, which Trajectory records on
+`agent_message` and normalizes into `llm_call` rows when a concrete model is
+available. Cost prefers native Hermes cost fields and falls back to
+Trajectory's model pricing table.
+
+Historical import is not implemented yet. `ccusage` proves the usable Hermes
+state surface is `~/.hermes/state.db`, including per-session token and cost
+columns, but this Trajectory onboarding is scoped to live observer capture,
+setup/verify/uninstall, inventory, and auto-instrument support.
+
+## Amp Code
+
+**Trajectory status: Beta. Supported contract: current Amp plugin API inspected.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients amp
+```
+
+Setup writes a system plugin to `~/.config/amp/plugins/trajectory.ts` (or
+`$AMP_CONFIG_DIR/plugins/trajectory.ts`) and merges a `trajectory` MCP server
+into `~/.config/amp/settings.json` under `amp.mcpServers`.
+
+Amp plugins expose `session.start`, `agent.start`, `tool.call`,
+`tool.result`, and `agent.end`. The Trajectory plugin starts or reuses
+`trajectory serve`, normalizes those events into `/capture/amp/<event>`, and
+records `client_source=amp`. The plugin is fail-open and does not return
+allow/reject/modify decisions from `tool.call`.
+
+Amp supports headless execution with `amp --execute` and `AMP_API_KEY`.
+Trajectory captures plugin events when they are emitted; token and cost usage
+depend on the fields Amp exposes in those plugin or thread payloads.
+
+Historical import is not implemented yet. `ccusage` proves the usable history
+surface is `~/.local/share/amp/threads/**/*.json`, with usage ledger events and
+assistant-message usage fields that can supply tokens and credits.
+
+## Qwen Code
+
+**Trajectory status: Beta. Supported CLI version: 0.19.2 tested.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients qwen
+```
+
+Setup merges Trajectory into `~/.qwen/settings.json` (or `$QWEN_HOME/settings.json`),
+registers a `trajectory` MCP server, whitelists
+`http://127.0.0.1:19222/capture/qwen/*` in
+`security.allowedHttpHookUrls`, and installs HTTP hook entries for Qwen Code
+lifecycle, prompt, tool, permission, subagent, compaction, notification, stop,
+and session-end events. Setup also writes an incognito skill and command under
+`~/.qwen/skills/incognito/SKILL.md` and `~/.qwen/commands/incognito.toml`.
+
+Qwen Code supports OpenAI-compatible providers. For headless validation, use
+`security.auth.selectedType=openai`, `modelProviders.openai`, and the provider
+API key expected by Qwen, then run `qwen -p` with the model you want to test.
+
+Capture uses Qwen's native HTTP hook transport rather than command/curl shims.
+The Go runtime records `client_source=qwen`, normalizes prompt, tool,
+permission, subagent, assistant-message, turn, session-start, and session-end
+records, and derives provider-call `llm_call` rows from Qwen `usageMetadata`.
+If the stop hook payload does not include token usage, Trajectory falls back to
+the Qwen chat JSONL transcript path.
+
+Historical import is not implemented yet. `ccusage` proves the usable Qwen
+history surface is `~/.qwen/projects/*/chats/*.jsonl` with Gemini-style
+`usageMetadata`, but this onboarding is scoped to live hook capture and setup
+support.
+
+## OpenHands
+
+**Trajectory status: Beta. Supported CLI version: V1 CLI tested.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients openhands
+```
+
+Setup writes command hooks to `~/.openhands/hooks.json` and a `trajectory` MCP
+server entry to `~/.openhands/mcp.json`. For isolated runs, set
+`OPENHANDS_PERSISTENCE_DIR`; setup writes both files under that directory. The
+hook command is `trajectory capture-hook --client openhands --ensure-serve`,
+not a curl bridge, because OpenHands command hooks send hook payload JSON on
+stdin. Current OpenHands headless conversations load hooks from the workspace
+`.openhands/hooks.json`; for isolated validation, copy the setup-generated hook
+config into the project directory before launching the live session.
+
+The OpenHands CLI hook surface supports `SessionStart`, `UserPromptSubmit`,
+`PreToolUse`, `PostToolUse`, `Stop`, and `SessionEnd`. Trajectory maps these
+into canonical session, prompt, tool, turn, and session-end records with
+`client_source=openhands`. Command hook payloads do not expose assistant
+messages or token usage, so OpenHands `turn_end` records set
+`tokens_status=unavailable`.
+
+Headless validation can run a real OpenHands session with the provider key and
+model expected by OpenHands. Command-hook payloads are enough for lifecycle,
+prompt, and tool coverage, but they do not currently include assistant text or
+token usage.
+
+OpenHands SDKs also expose OpenTelemetry/Laminar environment variables, but
+Trajectory does not install an OpenHands OTLP relay by default today. Add a
+client-specific OTLP relay only if OpenHands exposes stable request/model/token
+attributes through that path.
+
+**Source:** [OpenHands-CLI](https://github.com/OpenHands/OpenHands-CLI),
+[OpenHands SDK](https://github.com/OpenHands/software-agent-sdk)
+
+## Aider
+
+**Trajectory status: Beta. Supported CLI version: current CLI tested.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients aider --install-client-shims
+```
+
+Interactive setup asks before installing this shim; scripted setup must pass
+`--install-client-shims`. Setup writes a managed shim at
+`~/.trajectory/bin/aider`, links `aider` into an existing home bin directory on
+PATH when possible, and writes metadata at
+`~/.trajectory/state/aider/wrapper.json` pointing to the real Aider binary.
+The shim invokes `trajectory aider --real <path> -- ...`, starts or reuses
+`trajectory serve`, passes user arguments through, and adds sidecar flags when
+the user has not supplied them: `--analytics-log`, `--llm-history-file`,
+`--chat-history-file`, and `--no-analytics`.
+
+The shim posts `SessionStart`, `UserPromptSubmit`, `AgentMessage`,
+`TurnEnd`, and `SessionEnd` to `/capture/aider/<Event>` with
+`client_source=aider`. Token and cost fields come from Aider's
+`message_send` analytics rows. Assistant text comes from the LLM history file,
+and prompts come from `--message`, `--message-file`, or chat history.
+
+Aider does not expose a stable native hook, plugin, or OTLP surface for
+per-tool events today, so Trajectory does not synthesize file-edit/tool rows
+from transcripts. Non-interactive validation can run `aider --message` with the
+provider credentials configured for Aider.
+
+**Source:** [Aider](https://github.com/Aider-AI/aider), [Aider CLI options](https://aider.chat/docs/config/options.html)
+
+## Continue CLI
+
+**Trajectory status: Beta. Supported CLI version: 1.5.47 tested.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients continue --install-client-shims
+```
+
+Interactive setup asks before installing this shim; scripted setup must pass
+`--install-client-shims`. Setup writes a managed shim at
+`~/.trajectory/bin/cn`, links `cn` into an existing home bin directory on PATH
+when possible, and writes metadata at
+`~/.trajectory/state/continue/wrapper.json` pointing to the real Continue CLI
+binary from the `@continuedev/cli` package. The shim invokes
+`trajectory continue --real <path> -- ...`, starts or reuses `trajectory serve`,
+sets `CONTINUE_CLI_TEST_SESSION_ID` to the Trajectory session id for new
+sessions, and passes user arguments through unchanged.
+
+The shim posts `SessionStart`, `UserPromptSubmit`, `AgentMessage`,
+`TurnEnd`, and `SessionEnd` to `/capture/continue/<Event>` with
+`client_source=continue`. After the real `cn` exits, Trajectory reads the
+Continue session file from `$CONTINUE_GLOBAL_DIR/sessions` or
+`~/.continue/sessions` and derives prompt text, assistant text, model, tokens,
+and cost from the session history when those fields are present.
+
+Continue's source tree includes a Claude-compatible hook implementation that
+reads `.continue/settings.json` and `.claude/settings.json`, but the current
+1.5.47 CLI release does not call that hook dispatcher from the chat path.
+Trajectory therefore uses the shim/session-file path today and suppresses
+Claude-compatible hook subprocess capture while the shim is active to avoid
+future double-capture if Continue wires those hooks later.
+
+Non-interactive validation can run `cn -p` with the provider credentials
+configured for Continue. Setup, wrapper parsing, and session-file ingestion are
+the core Trajectory surfaces for this integration.
+
+**Source:** [Continue](https://github.com/continuedev/continue), [Continue CLI docs](https://docs.continue.dev/cli/overview)
+
+## Mistral Vibe
+
+**Trajectory status: Beta. Supported CLI version: 2.18.3 inspected.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients mistral-vibe --install-client-shims
+```
+
+Interactive setup asks before installing this shim; scripted setup must pass
+`--install-client-shims`. Setup writes a managed shim at
+`~/.trajectory/bin/vibe`, links `vibe` into an existing home bin directory on
+PATH when possible, writes metadata at
+`~/.trajectory/state/mistral-vibe/wrapper.json`, and writes a managed block in
+`$VIBE_HOME/hooks.toml` or `~/.vibe/hooks.toml`. The hook block uses Vibe's
+native experimental `before_tool` and `after_tool` hooks and calls
+`trajectory capture-hook --client mistral-vibe`.
+
+The shim invokes `trajectory vibe --real <path> -- ...`, starts or reuses
+`trajectory serve`, enables Vibe experimental hooks for the wrapped process,
+and passes user arguments through unchanged. Tool hooks use the shim's
+Trajectory session id, while post-run telemetry reads Vibe session logs from
+`$VIBE_HOME/logs/session` or `~/.vibe/logs/session`.
+
+Trajectory records `SessionStart`, `UserPromptSubmit`, `PreToolUse`,
+`PostToolUse`, `AgentMessage`, `TurnEnd`, and `SessionEnd` with
+`client_source=mistral-vibe`. Token and cost fields come from Vibe's
+`metadata.json` `stats` object when session logging is enabled.
+
+Non-interactive validation can run Mistral Vibe through its generic OpenAI
+provider with an isolated `$VIBE_HOME/config.toml`. Set `active_model` to the
+model you want to test and confirm Trajectory records provider-call
+`llm_call` facts.
+
+**Source:** [Mistral Vibe](https://github.com/mistralai/mistral-vibe)
+
+## Codebuff
+
+**Trajectory status: Beta. Supported CLI version: 1.0.682 inspected.**
+
+Install with setup:
+
+```bash
+trajectory setup --clients codebuff --install-client-shims
+```
+
+`trajectory setup --clients cb` and `codebuff-ai` are accepted as aliases.
+Interactive setup asks before installing these shims; scripted setup must pass
+`--install-client-shims`. Setup writes managed shims at
+`~/.trajectory/bin/codebuff` and `~/.trajectory/bin/cb`, links `codebuff` and
+`cb` into an existing home bin directory on PATH when possible, plus metadata at
+`~/.trajectory/state/codebuff/wrapper.json` pointing to the real Codebuff
+binary.
+
+The shim invokes real Codebuff unchanged, then imports any Codebuff
+`chat-messages.json` rows written for the current project. Trajectory reads the
+same stable/dev/staging roots used by Codebuff and ccusage:
+`~/.config/manicode`, `~/.config/manicode-dev`, and
+`~/.config/manicode-staging`; `CODEBUFF_DATA_DIR` can override that list.
+
+The shim and `trajectory backfill --from-codebuff-chats` emit
+`SessionStart`, `UserPromptSubmit`, `AgentMessage`, `TurnEnd`, and
+`SessionEnd` to `/capture/codebuff/<Event>` with `client_source=codebuff`.
+When Codebuff history contains `metadata.usage`, `metadata.codebuff.usage`, or
+ccusage-style nested `metadata.runState.sessionState.mainAgentState.messageHistory`
+provider usage, Trajectory normalizes token usage and emits provider-call
+`llm_call` records.
+
+Codebuff does not currently expose a stable native hook, plugin, or OTLP
+surface for per-tool events in the standard CLI, so Trajectory does not claim
+file-edit or shell-tool events for Codebuff. Live validation requires
+Codebuff-specific auth (`CODEBUFF_API_KEY` or local credentials).
+
+**Source:** [Codebuff](https://github.com/CodebuffAI/codebuff), [ccusage Codebuff adapter](https://github.com/ryoppippi/ccusage)
 
 ## Recommended vs Manual Installs
 
-`trajectory setup --clients ...` is the recommended path for normal installs
-and refreshes because it wires the plugin together with the companion config
-each client expects: hooks, MCP entries, skills, commands, local binaries, and
-local marketplace metadata. It skips Datadog site, service name, and API key
-prompts, so it is also the right path when you only want to add, repair, or
-update one client integration.
+`trajectory setup --clients ...` is the recommended path for normal installs because it wires the plugin together with the companion config each client expects: hooks, MCP entries, skills, commands, local binaries, and local marketplace metadata. It is a client-only add/update path: Datadog site, service name, and API key prompts are skipped, and existing export config is left unchanged. Run `trajectory setup` without `--clients` when you need to change Datadog export settings.
 
-Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, opt-in command shims, or the capture hooks needed for complete telemetry.
-
+Direct or local plugin installs remain supported for development and manual recovery. When using a manual path, copy or install the plugin from a stable local location and mirror the companion config that setup would have written. A plugin-only install may load the extension but miss MCP tools, incognito controls, command assets, or the capture hooks needed for complete telemetry.
 ## Codex CLI
 
-**Minimum version: 0.128.0** (latest stable recommended)
+**Trajectory status: Supported. Supported CLI version: 0.128.0+.**
 
 Codex 0.128.0 is the first version where plugin-bundled hooks work end-to-end:
 
@@ -114,9 +434,20 @@ Earlier versions may have partial support (marketplace without hook discovery, o
 
 Codex uses two capture mechanisms:
 
-1. **Command hooks (primary)** - the plugin's `hooks.json` registers 12 lifecycle hooks using Codex's documented PascalCase hook keys, and each hook invokes the installed `trajectory capture-hook --client codex --ensure-serve` binary path with the same event name. The hook command verifies or starts the matching local capture server before forwarding stdin. For Codex, it also ensures a watcher-capable rescue `serve` process is present, overrides Codex watcher-disable variables for that rescue process, and suppresses unrelated client watchers so the rollout watcher fallback stays available. `TRAJECTORY_DISABLED=1` remains the all-capture suppression switch. Codex accepts `type: "command"` hook entries; it does not accept Claude-style `type: "http"` hook entries.
+1. **Command hooks (primary)** - the plugin's `hooks.json` registers 12 lifecycle hooks using Codex's documented PascalCase hook keys, and each hook invokes the installed `trajectory capture-hook --client codex --ensure-serve` binary path with the same event name. Codex hooks stay in the foreground long enough to notify the local capture server so prompt, tool, stop, and session-end events cannot overtake each other. The hook verifies or starts a watcher-capable rescue `serve` process, overrides Codex watcher-disable variables for that rescue process, and suppresses unrelated client watchers so the rollout watcher fallback stays available. `TRAJECTORY_DISABLED=1` remains the all-capture suppression switch. Codex accepts `type: "command"` hook entries; it does not accept Claude-style `type: "http"` hook entries.
 
 2. **Rollout watcher (fallback)** - the trajectory binary tails `~/.codex/sessions/` for rollout JSONL files. This captures sessions that started before the plugin was installed, or if hooks aren't firing.
+
+The two mechanisms are not interchangeable duplicates. Hooks provide the
+low-latency lifecycle edges that Codex blocks on, while rollout JSONL provides
+checkpoint-only detail such as assistant messages, reasoning, non-shell tools,
+permissions, compaction, model metadata, and token snapshots. Trajectory's
+session JSONL is the merged output. During a hook request, `trajectory serve`
+reads the Codex rollout forward first, writes only watcher-only events, applies
+token/model enrichment, and then writes the hook event so the final Trajectory
+JSONL preserves both order and detail. This is why Codex uses
+`trajectory capture-hook --client codex --ensure-serve` rather than a direct
+bounded `curl` hook or raw direct append.
 
 A file-based sentinel system (`~/.trajectory/state/codex-hook-active/`) prevents the watcher from duplicating events that hooks are already capturing. Because Codex command hooks are one-shot processes, the sentinel stays fresh for the serve inactivity window (10 minutes by default, minimum 30 seconds) before the watcher is allowed to take over.
 
@@ -136,7 +467,7 @@ If setup reports that every `codex --version` candidate failed with `ENOENT` und
 
 ## GitHub Copilot CLI
 
-**Status: Beta, fixture-tested only**
+**Trajectory status: Beta. Supported contract: public Copilot CLI plugin-hook contract.**
 
 Install the Copilot CLI plugin with setup:
 
@@ -153,13 +484,19 @@ copilot plugin marketplace add /path/to/trajectory
 copilot plugin install trajectory@trajectory
 ```
 
-Capture is live local CLI capture only. There is no Copilot historical backfill, transcript watcher, cloud-agent capture path, or session import path. The implementation is based on GitHub's public Copilot CLI plugin, MCP, skills, and hooks documentation and is tested with local fixtures that match the documented hook payloads; it has not been validated against a live Copilot CLI install in CI.
+Capture is live local CLI capture only. There is no Copilot historical backfill,
+transcript watcher, cloud-agent capture path, or session import path. The
+implementation is based on GitHub's public Copilot CLI plugin, MCP, skills, and
+hooks documentation and is validated against payloads that match the documented
+hook shape. Live validation should confirm setup-generated plugin assets plus a
+real `copilot --plugin-dir ... -p` session that emits prompt, tool, turn,
+session, and `client_source=copilot` JSONL.
 
 Registered documented events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `permissionRequest`, `notification`, `Stop`, `subagentStart`, `SubagentStop`, `ErrorOccurred`, `PreCompact`, and `SessionEnd`. The plugin uses command hooks, not Copilot HTTP hooks, because Copilot requires HTTPS for HTTP hooks that can affect permissions.
 
 ## Claude Code
 
-**Minimum version: 2.0+** (plugin marketplace support)
+**Trajectory status: Supported. Supported CLI version: 2.0+** (plugin marketplace support)
 
 Install with setup:
 
@@ -167,7 +504,7 @@ Install with setup:
 trajectory setup --clients cc
 ```
 
-Setup writes a local Claude Code marketplace under `~/.trajectory/claude-marketplace`, registers that local path with Claude, refreshes the marketplace, then installs the plugin at user scope. If `trajectory@trajectory` is already installed, setup refreshes the marketplace and runs `claude plugin update trajectory@trajectory --scope user` so an existing install moves to the bundled plugin version without requiring GitHub SSH or HTTPS credentials. Claude Code caches installed plugins by version, so the setup-generated marketplace and plugin manifest use Trajectory's bundled Claude plugin version. `trajectory update` also checks installed Claude plugin metadata and refreshes the plugin when the cached version is stale.
+Setup writes a local Claude Code marketplace under `~/.trajectory/claude-marketplace`, registers that local path with Claude, refreshes the marketplace, then installs the plugin at user scope. If `trajectory@trajectory` is already installed, setup refreshes the marketplace and runs `claude plugin update trajectory@trajectory --scope user` so an existing install moves to the bundled plugin version without requiring GitHub SSH or HTTPS credentials. Claude Code caches installed plugins by version; the setup-generated marketplace and plugin manifest use Trajectory's bundled Claude plugin version. `trajectory update` also checks installed Claude plugin metadata and refreshes the plugin when the cached version is stale or still carries the duplicate standard-hook manifest entry.
 
 Manual fallback after setup has staged the local marketplace:
 
@@ -179,16 +516,115 @@ claude plugin install trajectory@trajectory --scope user
 
 From a source checkout, use the checkout root instead of `~/.trajectory/claude-marketplace`.
 
-The plugin ships the standard Claude `hooks/hooks.json` file with 12 lifecycle
-hooks, primarily HTTP, with command shims for startup, shutdown, and serve
-lifecycle handling. Claude Code loads that standard hook file automatically; the
-plugin manifest intentionally does not list `hooks/hooks.json`, because doing so
-would load the same file twice.
+### Skill Observability
+
+The Claude plugin also installs a bounded prompt-time sync hook for Trajectory
+skill observability. It keeps user/global Claude skills instrumented with
+skill-scoped hooks and records reversible state under
+`~/.trajectory/state/claude-skills/manifest.json`.
+
+Useful commands:
+
+```bash
+trajectory claude skills status
+trajectory claude skills sync --user
+trajectory claude skills sync --project
+trajectory claude skills restore --stale
+```
+
+Project `.claude/skills` fallback sync is opt-in because it mutates
+version-controlled files. Enable it with `TRAJECTORY_CLAUDE_SKILLS_PROJECT=1`
+or a `.trajectory/claude-skills-project-enabled` marker in the project.
+
+For a non-mutating project path on supported macOS launch chains, use the
+Claude wrapper read-virtualization mode:
+
+```bash
+trajectory claude --skill-read-virtualization --skill-managed-binary -- <claude args>
+```
+
+This mode serves virtualized `SKILL.md` bytes through a managed Claude launch
+copy and leaves real skill files clean. If the runtime or managed settings block
+the virtualized/hook path, Trajectory falls back to explicit sync/status/restore
+commands rather than silently claiming scoped skill attribution.
+
+For current Claude builds that write `message.attributionSkill` into the native
+transcript, Trajectory treats that transcript field as the primary
+non-mutating skill attribution signal. Deferred stop processing stamps the
+skill onto `agent_message` and `turn_end` events, and ingest turns it into a
+high-confidence `skill-invoked` marker tagged
+`detected_from:claude_native_transcript`. Read virtualization remains useful
+for proving clean `SKILL.md` transformation and for hook-based experiments, but
+successful virtualized reads do not by themselves guarantee that Claude will
+execute hook metadata injected into a skill file.
+
+The packaged `skill-observability` dashboard exposes both invocation and
+observation metrics with `repo`, `skill_name`, `detected_from`,
+`source_scope`, `signal_confidence`, and `trajectory.client_version`
+dimensions:
+
+```bash
+trajectory dashboard export --type skill-observability --output trajectory-skill-observability.json
+```
+
+Use those version slices to spot Claude runtime drift: if a newer Claude
+version stops emitting transcript `attributionSkill`, invocation metrics will
+drop or shift away from `detected_from:claude_native_transcript` while
+lower-confidence observations may continue.
+
+For the full skill-maintainer workflow, run
+`trajectory user-guide skill-observability`.
+
+The plugin ships the standard Claude `hooks/hooks.json` file with 13 lifecycle
+hooks, primarily HTTP, with helper command shims for startup, shutdown, and serve
+lifecycle handling. The registered permission hooks include `PermissionRequest`
+and `PermissionDenied`; `PermissionDenied` records auto-mode classifier denials
+without relying on latency inference. Claude Code loads that standard hook file
+automatically; the plugin manifest intentionally does not list
+`hooks/hooks.json`, because doing so would load the same file twice.
+
+Claude Code native OTLP logs, metrics, and traces can be relayed through local
+`trajectory serve` when `trajectory claude` launches Claude with local OTLP
+environment overrides, or when the effective Claude settings explicitly point
+those signals at the local OTLP endpoints. Setup does not write
+`~/.claude/settings.json`; it may only remove the exact legacy user-scope
+Trajectory OTLP env block written by older versions. When Claude managed
+settings own OTel configuration, an admin must make any durable
+managed-settings change. `trajectory claude` preserves the effective OTLP
+protocol shape from Claude settings, falling back from per-signal protocol to
+`OTEL_EXPORTER_OTLP_PROTOCOL` and then to an explicit `http/json` default.
+Trajectory keeps only
+`skill_activated` records from logs, stores them as bounded local `Skill` tool
+activations tagged with
+`detected_from:claude_native_otel`, and can forward the original OTLP
+logs, enriched OTLP metrics, and original OTLP traces to an upstream collector
+when `server.otlp_proxy.endpoint` is set. Trajectory also writes safe
+normalized local trace summaries under `~/.trajectory/state/otlp-proxy/traces/`
+so skill complexity metrics can prefer native Claude tool spans. Forwarded
+Claude native metrics carry
+`trajectory.cost_role:client_telemetry` and
+`trajectory.cost_source:claude_native_otlp` so Datadog totals can keep native
+client telemetry separate from Trajectory attribution metrics. Complexity
+metrics expose `skill_attribution:span_tool_attribute`,
+`skill_attribution:span_temporal`, or `skill_attribution:turn_assisted` to
+distinguish native trace-derived windows from same-turn fallback attribution.
+Set `server.otlp_proxy.capture_enabled: true` or
+`TRAJECTORY_OTLP_PROXY_CAPTURE_ENABLED=1` to write local normalized
+inbound-vs-forwarded metric comparison records, then inspect them with
+`trajectory otlp metrics compare --session <session-id>`.
+
+`SessionEnd` is a foreground `trajectory capture-hook --background-after-read
+--ensure-serve --ensure-serve-wait 2s --wait-notify 2s SessionEnd` command hook.
+The foreground phase only reads Claude's stdin and spools it to a private
+payload file. A detached worker then restarts/notifies the local capture server,
+so the terminal event that drives final session metrics can be delivered without
+blocking Claude's exit path on publish or server recovery.
 
 Claude `--print` sessions omit `transcript_path`, so Trajectory marks them as
 headless. Headless coding-agent sessions are collected and published by default
 when export is configured, while sensitivity/classification and segmentation
-always skip headless sessions. To opt out for headless agent sessions:
+always skip headless sessions. To opt out for all non-internal headless agent
+sessions:
 
 ```bash
 trajectory config set capture.include_headless_agents false
@@ -198,7 +634,7 @@ Trajectory-owned classifier and segmenter subprocesses remain suppressed.
 
 ## Gemini CLI
 
-**Minimum version: 0.30.0+** (settings, hooks, and commands support)
+**Trajectory status: Supported. Supported CLI version: 0.30.0+** (settings, hooks, and commands support)
 
 Install with setup:
 
@@ -212,9 +648,16 @@ The repository still includes `hooks/hooks.json` as a legacy extension command-h
 
 The Gemini skill uses `trajectory_incognito` when MCP is available, and falls back to the `/session/incognito` HTTP endpoint.
 
+Gemini CLI does not currently expose direct subagent lifecycle hooks. When
+Gemini writes a `kind:"subagent"` chat artifact, Trajectory synthesizes
+`subagent_start`, `subagent_stop`, and `subagent_cost` during `SessionEnd` and
+links those lifecycle events back to the parent `generalist`, `cli_help`, or
+`codebase_investigator` tool call when the parent JSONL contains the launch
+`tool_use_id`.
+
 ## Antigravity CLI (`agy`)
 
-**Minimum version: 1.0.0+** (Antigravity CLI plugin manager and migrated Gemini hook support)
+**Trajectory status: Supported. Supported CLI version: 1.0.0+** (Antigravity CLI plugin manager and migrated Gemini hook support)
 
 Install with setup:
 
@@ -224,7 +667,7 @@ trajectory setup --clients agy
 
 Setup writes `~/.gemini/antigravity-cli/settings.json` for the Trajectory MCP server and stages a Trajectory plugin under `~/.gemini/config/plugins/trajectory`. The plugin includes `hooks/hooks.json`, `skills/incognito/SKILL.md`, and `commands/incognito.toml`.
 
-The Antigravity hooks use Gemini-compatible event names (`SessionStart`, `BeforeAgent`, `AfterModel`, `BeforeTool`, `AfterTool`, `AfterAgent`, `PreCompress`, `Notification`, and `SessionEnd`) but post to `/capture/agy/<Event>`. The capture server reuses Gemini parsing and token/cost logic while emitting `client_source=agy`.
+The Antigravity hooks use the same Gemini-compatible event names (`SessionStart`, `BeforeAgent`, `AfterModel`, `BeforeTool`, `AfterTool`, `AfterAgent`, `PreCompress`, `Notification`, and `SessionEnd`) but post to `/capture/agy/<Event>`. The capture server reuses Gemini parsing and token/cost logic while emitting `client_source=agy`.
 
 Manual validation:
 
@@ -236,7 +679,7 @@ Current limitations: no historical Antigravity backfill or setup-managed resume 
 
 ## Goose
 
-**Minimum version: 1.39.0 tested** (Open Plugins support)
+**Trajectory status: Beta. Supported CLI version: 1.39.0 tested.**
 
 Install with setup:
 
@@ -244,93 +687,22 @@ Install with setup:
 trajectory setup --clients goose
 ```
 
-Setup writes a Goose Open Plugins package under `~/.agents/plugins/trajectory`
-and registers it with Goose. The plugin defines command hooks that post Open
-Plugins context JSON to `/capture/goose/<event>`.
+Setup writes a Goose Open Plugins package under
+`~/.agents/plugins/trajectory`. If `GOOSE_PATH_ROOT` is set, setup writes the
+same package under `$GOOSE_PATH_ROOT/.agents/plugins/trajectory`. The package
+contains a `plugin.json` manifest and `hooks/hooks.json`.
 
-Goose live capture covers session start/end, prompts, tool calls, shell and
-file events, and assistant-message checkpoints. Historical Goose backfill is
-not implemented yet.
+The Goose hooks use command actions that post hook context JSON to
+`/capture/goose/<Event>`. Setup registers `SessionStart`, `UserPromptSubmit`,
+`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `BeforeReadFile`,
+`AfterFileEdit`, `BeforeShellExecution`, `AfterShellExecution`, `Stop`, and
+`SessionEnd`. Trajectory maps those into canonical session, prompt, tool,
+assistant-message, turn, and session-end records with `client_source=goose`.
 
-## Cline CLI
-
-**Minimum version: 3.0.34 tested** (file hooks and MCP)
-
-Install with setup:
-
-```bash
-trajectory setup --clients cline
-```
-
-Setup writes Trajectory-owned file hooks under `~/.cline/hooks` or
-`$CLINE_DIR/hooks` and registers Trajectory MCP in Cline settings. Existing
-user hook files are preserved; setup chooses a supported alternate suffix when
-needed. Current Cline hooks expose lifecycle, prompt, tool, assistant summary,
-and shutdown payloads, but not stable token or cost usage.
-
-## Aider
-
-**Status: Beta**
-
-Install with setup:
-
-```bash
-trajectory setup --clients aider --install-client-shims
-```
-
-Aider capture uses an opt-in command shim. Setup writes a managed `aider` shim
-under `~/.trajectory/bin`, links it into an existing home bin directory when
-possible, and records wrapper metadata under `~/.trajectory/state/aider/`.
-The shim passes user arguments through, adds analytics and history sidecars when
-not already supplied, and records prompts, assistant messages, token usage, and
-cost from Aider's sidecar files when present.
-
-## Continue CLI
-
-**Minimum version: 1.5.47 tested**
-
-Install with setup:
-
-```bash
-trajectory setup --clients continue --install-client-shims
-```
-
-Continue capture uses an opt-in `cn` command shim. The shim starts or reuses
-`trajectory serve`, passes user arguments through, and reads Continue session
-JSON after the real CLI exits. Prompt text, assistant text, model, token, and
-cost fields are derived from Continue session history when those fields are
-present.
-
-## Mistral Vibe
-
-**Status: Beta**
-
-Install with setup:
-
-```bash
-trajectory setup --clients mistral-vibe --install-client-shims
-```
-
-Mistral Vibe capture uses an opt-in `vibe` command shim plus native
-`before_tool` and `after_tool` hook entries in Vibe's hook config. Tool events
-come from the native hooks; prompt, assistant-message, token, and cost fields
-come from Vibe session metadata when session logging is enabled.
-
-## Codebuff
-
-**Minimum version: 1.0.682 inspected**
-
-Install with setup:
-
-```bash
-trajectory setup --clients codebuff --install-client-shims
-```
-
-Codebuff capture uses opt-in `codebuff` and `cb` command shims. After the real
-CLI exits, Trajectory imports Codebuff `chat-messages.json` rows for the current
-project and records prompt, assistant-message, turn, and provider-call events
-when usage metadata is present. `trajectory backfill --from-codebuff-chats`
-uses the same history import path.
+Real Goose model calls need provider credentials. Validate Goose either with
+recorded Open Plugins payloads or with a live provider-backed run. Goose also
+stores session history in SQLite under the normal Goose data root; historical
+usage backfill is not setup-managed yet.
 
 ## Cursor
 
@@ -338,7 +710,7 @@ Cursor has two separate products with different capture paths:
 
 ### Cursor Desktop (IDE)
 
-**Minimum version: 1.0+** (hooks.json support)
+**Trajectory status: Supported. Supported CLI version: 1.0+** (hooks.json support)
 
 The trajectory setup wizard writes hooks and MCP config directly:
 
@@ -348,25 +720,36 @@ trajectory setup --clients cursor
 
 This creates `~/.cursor/hooks.json` and `~/.cursor/mcp.json`. Capture uses Cursor's supported command hooks to `curl` POST payloads to the Trajectory capture server. Cursor does not currently accept every Claude Code lifecycle hook name; setup registers the supported Cursor event names and omits unsupported lifecycle hooks. When Claude Code is installed, Cursor uses the Claude Code Trajectory skill path for `/incognito`; otherwise setup installs a native Cursor fallback at `~/.cursor/skills/incognito/SKILL.md`. The `incognito` skill uses the shared `trajectory_incognito` MCP tool to suppress publish to non-exempt Datadog destinations for the active Cursor session while local JSONL capture continues.
 
-CI validates this Desktop install surface on macOS by running setup in an isolated home, checking the Cursor MCP/hooks files and incognito skill routing, replaying Cursor Desktop hook payloads into `/capture/cursor`, and verifying the `/session/incognito` sentinel lifecycle. That coverage is separate from the Docker `cursor-agent` test below. Cursor Desktop metrics include tool, turn, session, duration, and per-request cost values; token usage metrics are emitted when Cursor's `state.vscdb` exposes non-zero real token counts.
+Validation for this Desktop install surface should run setup in an isolated
+home, check the Cursor MCP/hooks files and incognito skill routing, replay
+Cursor Desktop hook payloads into `/capture/cursor`, and verify the
+`/session/incognito` sentinel lifecycle. Cursor Desktop metrics include tool,
+turn, session, duration, and per-request cost values; token usage metrics are
+emitted when Cursor's `state.vscdb` exposes non-zero real token counts.
 
 ### cursor-agent (CLI)
 
 cursor-agent is a standalone CLI (`cursor-agent --print` for headless mode). It does NOT support hooks.json. Capture uses a **transcript file watcher** that tails nested transcript files under `~/.cursor/projects/*/agent-transcripts/<session>/*.jsonl`, similar to the Codex rollout watcher.
 
-The watcher starts automatically when `cursor-agent` is on PATH. No manual
-setup needed - the trajectory binary detects cursor-agent and watches for
-transcripts. The watcher preserves `transcript_path` and marks these sessions
-headless, so sensitivity scanning and segmentation are skipped for the
-supported `cursor-agent --print` path. Because the current headless transcript
-format does not expose token or cost fields, cursor-agent metrics are limited
-to tool, turn, and session counts until Cursor adds those fields.
+The watcher starts automatically when `cursor-agent` is on PATH. No manual setup
+needed - the trajectory binary detects cursor-agent and watches for transcripts.
+A live validation run can ask `cursor-agent --print` to read a nonce file and
+assert `user_prompt` capture, a tool request event, turn end with the nonce,
+agent loop end, session end, and `client_source=cursor`. Tool result events are captured when Cursor includes
+`tool_result` parts in the transcript, but current live CLI transcripts do not
+always include a separate result part. The watcher preserves `transcript_path`
+on `session_start` for traceability and also marks the session headless, so
+sensitivity scanning and segmentation are skipped for this headless path.
+Because the current headless transcript format does not
+expose token or cost fields, cursor-agent metrics are limited to tool, turn, and
+session counts until Cursor adds those fields. `CURSOR_AGENT_MODEL` is optional;
+leave it unset to use the configured Cursor account default.
 
 Install cursor-agent: `curl -fsSL https://cursor.com/install | bash`
 
 ## Pi
 
-**Status: Supported** (headless mode: `pi -p`)
+**Trajectory status: Supported. Supported CLI version: current CLI tested** (headless mode: `pi -p`)
 
 Install the trajectory extension with setup:
 
@@ -383,13 +766,18 @@ cp -R /path/to/trajectory/plugin/trajectory-pi ~/.pi/agent/extensions/trajectory
 
 Then point `~/.pi/agent/mcp.json` at `~/.pi/agent/extensions/trajectory/bin/trajectory mcp`.
 
-Setup writes `~/.pi/agent/extensions/trajectory/` and points `~/.pi/agent/mcp.json` at the extension-local `bin/trajectory mcp` command. Pi uses a TypeScript extension API (`pi.on("event", handler)`) that subscribes to lifecycle events (session_start, turn_end, tool_call, tool_result, etc.) and POSTs them to the capture server. Pi also writes key lifecycle events through `capture-hook` for robustness and emits `PostCompact`. The native extension registers `trajectory_status`, `trajectory_flush`, `trajectory_incognito`, `trajectory_schema`, and `trajectory_query`; MCP exposes the shared cross-client tool surface in environments where Pi routes MCP tools. Pi supports multiple LLM providers - use any provider API key for testing.
+Setup writes `~/.pi/agent/extensions/trajectory/` with a `package.json` that declares `pi.extensions: ["./src/index.ts"]`, plus a root `index.ts` shim that re-exports `./src/index.ts`, and points `~/.pi/agent/mcp.json` at the extension-local `bin/trajectory mcp` command. Setup does not add Trajectory's extension entrypoint to `~/.pi/agent/settings.json`; Pi discovers the extension from its standard extensions directory. Pi uses a TypeScript extension API (`pi.on("event", handler)`) that subscribes to lifecycle events (session_start, turn_end, tool_call, tool_result, etc.) and POSTs them to the capture server. Pi also writes key lifecycle events through `capture-hook` for robustness and emits `PostCompact`. The native extension registers `trajectory_status`, `trajectory_flush`, `trajectory_incognito`, `trajectory_schema`, and `trajectory_query`; MCP exposes the shared cross-client tool surface in environments where Pi routes MCP tools. Pi supports multiple LLM providers - use any provider API key for testing.
 
 Pi does not currently consume the Codex/Claude-style `skills/` plugin directory. The Trajectory Pi extension vends incognito through its native `trajectory_incognito` tool; environments that expose MCP can also use the shared `trajectory_incognito` MCP tool.
 
+Pi capture currently records normal session, prompt, tool, turn, compaction,
+model, and fork events. It does not expose a dedicated subagent lifecycle event
+with a child session id and launch tool id, so Trajectory does not render Pi
+forks or agent metadata as subagent trace parentage.
+
 ## Factory Droid
 
-**Status: Beta, fixture-tested only**
+**Trajectory status: Beta. Supported contract: public Factory plugin-hook contract.**
 
 Install the Factory Droid plugin with setup:
 
@@ -406,86 +794,16 @@ droid plugin marketplace add /path/to/trajectory
 droid plugin install trajectory@trajectory --scope user
 ```
 
-Capture is live only. There is no Factory/Droid historical backfill, transcript watcher, or session import path. The implementation is based on Factory's public plugin, hook, skills, and MCP documentation and is tested with local fixtures that match the documented hook payloads; it has not been validated against a live Droid install in CI.
+Capture is live only. There is no Factory/Droid historical backfill,
+transcript watcher, or session import path. The implementation is based on
+Factory's public plugin, hook, skills, and MCP documentation and is validated
+against payloads that match the documented hook shape.
 
 Registered documented events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, and `SessionEnd`. Factory's public docs do not currently document `PostToolUseFailure`, `PermissionRequest`, `SubagentStart`, or `PostCompact` for Droid; the server accepts those Claude-compatible names as best-effort future compatibility, but the packaged Droid plugin does not register them.
 
-## Hermes Agent
-
-**Status: Beta, fixture-tested against the public Hermes observer-hook contract**
-
-Install with setup:
-
-```bash
-trajectory setup --clients hermes
-```
-
-Setup writes a Hermes observer plugin, plugin config, and MCP server entry. The
-observer plugin captures lifecycle events such as session start, turn start,
-message send, post-model request, tool execution, and session end, then posts
-them to `/capture/hermes/<event>`.
-
-Hermes `post_api_request` payloads can include usage fields. Trajectory records
-those on the canonical turn events and uses them for tokens and cost when
-available. Historical Hermes backfill is not implemented yet.
-
-## Amp Code
-
-**Status: Beta, fixture-tested**
-
-Install with setup:
-
-```bash
-trajectory setup --clients amp
-```
-
-Setup writes a system TypeScript plugin and MCP entry. Amp plugin lifecycle
-events include session start, agent start, tool calls, tool results, and
-assistant messages. Trajectory posts them to `/capture/amp/<event>` and stamps
-`client_source=amp`.
-
-Amp does not expose a session-end plugin event today, so live sessions end on
-Trajectory's idle lifecycle handling. Historical Amp backfill is not
-implemented yet.
-
-## Qwen Code
-
-**Minimum version: 0.19.2 tested** (native HTTP hooks and MCP)
-
-Install with setup:
-
-```bash
-trajectory setup --clients qwen
-```
-
-Setup writes Qwen Code settings, registers Trajectory MCP, and installs native
-HTTP hooks. Capture uses Qwen's HTTP hook transport to post events to
-`/capture/qwen/<event>`.
-
-Qwen Code supports OpenAI-compatible providers. Trajectory records
-`usageMetadata` when Qwen exposes it and can use the current chat JSONL
-transcript as a fallback for stop payloads that omit usage. Historical Qwen
-backfill is not implemented yet.
-
-## OpenHands
-
-**Status: Beta**
-
-Install with setup:
-
-```bash
-trajectory setup --clients openhands
-```
-
-Setup writes command hooks to `~/.openhands/hooks.json` and a Trajectory MCP
-entry to `~/.openhands/mcp.json`. The hooks use `trajectory capture-hook --client
-openhands --ensure-serve` because OpenHands sends hook payload JSON on stdin.
-Current OpenHands command hooks cover session start, prompts, tools, stop, and
-session end. They do not expose assistant messages or token usage today.
-
 ## OpenCode
 
-**Status: Supported** (headless mode: `opencode run`)
+**Trajectory status: Supported. Supported CLI version: current CLI tested** (headless mode: `opencode run`)
 
 Install the trajectory plugin with setup:
 
@@ -497,40 +815,54 @@ OpenCode uses a plugin SDK (`@opencode-ai/plugin`) with a `server` entrypoint th
 
 OpenCode supports native agent skills from `.opencode/skills/<name>/SKILL.md`, the configured OpenCode user skills directory, `.agents/skills/<name>/SKILL.md`, and Claude-compatible skills paths. `trajectory setup --clients opencode` installs the Trajectory OpenCode plugin under the resolved OpenCode config directory (`OPENCODE_CONFIG_DIR`, then `XDG_CONFIG_HOME/opencode`, then `~/.config/opencode`), merges that plugin path plus a `trajectory` MCP entry into `opencode.json`, and writes the incognito skill into the global OpenCode skills directory. The skill uses `trajectory_incognito` when MCP is available, and falls back to the `/session/incognito` HTTP endpoint.
 
+OpenCode capture currently records native agent metadata on ordinary prompt,
+tool, and message events, but the plugin SDK path used here does not provide a
+dedicated child-agent lifecycle with `child_session_id`. Trajectory therefore
+does not infer subagent trace parentage from OpenCode `agent_id` or
+`agent_type` alone.
+
 Manual fallback: copy `plugin/trajectory-opencode` to `~/.config/opencode/plugins/trajectory` and add that local path to the `plugins` array plus a `trajectory` MCP entry in `~/.config/opencode/opencode.json`.
 
 **Source:** [github.com/anomalyco/opencode](https://github.com/anomalyco/opencode)
 
 ## Kilo Code
 
-**Status: Beta**
+**Trajectory status: Beta. Supported CLI version: current CLI tested** (headless mode: `kilo run --auto`)
 
-Install with setup:
+Install the Trajectory plugin with setup:
 
 ```bash
 trajectory setup --clients kilo
 ```
 
-Kilo Code is OpenCode-compatible at the plugin surface. Setup installs the
-Trajectory Kilo plugin under the resolved Kilo config directory
-(`KILO_CONFIG_DIR`, `XDG_CONFIG_HOME/kilo`, then `~/.config/kilo`), adds the
-plugin path plus a `trajectory` MCP entry to `opencode.json`, and writes the
-incognito skill into the global Kilo skills directory.
+Kilo Code is OpenCode-compatible at the plugin surface. Trajectory installs a
+plugin SDK package under the Kilo config directory (`KILO_CONFIG_DIR` when set
+for isolated runs, otherwise `XDG_CONFIG_HOME/kilo` then `~/.config/kilo`),
+merges that plugin path and a `trajectory` MCP entry into `opencode.json`, and
+writes the incognito skill into the global Kilo skills directory. The plugin posts SDK events to
+`/capture/kilo/<event>`, and the server reuses the OpenCode-compatible parser
+while forcing `client_source=kilo`.
 
-The plugin uses SDK events for chat messages, tool execution before/after
-events, and lifecycle events. Kilo can also export native OpenTelemetry traces
-and logs to Trajectory's local OTLP relay at `http://localhost:4318`.
+Kilo also supports native OpenTelemetry export. To relay native telemetry through
+Trajectory, set `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:19222` before
+starting `kilo`; Kilo will export OTLP traces/logs to the local Trajectory relay
+when its OpenTelemetry setting is enabled. This complements the plugin event
+stream; it does not replace setup-managed plugin capture.
+
+Headless validation can run Kilo with an OpenAI-compatible provider:
+`KILO_PROVIDER=openai`, provider credentials, the model you want to test, then
+`kilo run --auto`.
 
 Manual fallback: copy `plugin/trajectory-kilo` to
 `~/.config/kilo/plugins/trajectory` and add that local path to the `plugin`
-array plus a `trajectory` MCP entry.
+array plus a `trajectory` MCP entry in `~/.config/kilo/opencode.json`.
 
 **Source:** [github.com/Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode),
 [Kilo CLI docs](https://kilo.ai/docs/code-with-ai/platforms/cli)
 
 ## Kiro CLI
 
-**Status: Beta**
+**Trajectory status: Beta. Supported contract: public Kiro CLI command-hook docs.**
 
 Install with setup:
 
@@ -538,35 +870,56 @@ Install with setup:
 trajectory setup --clients kiro
 ```
 
-Setup writes Trajectory-owned Kiro agent configuration under `~/.kiro/agents/`
-and merges a Trajectory MCP server into Kiro settings. Kiro command hooks send
-payload JSON on stdin for agent spawn, user prompt, tool events, and stop.
-Stop payloads include assistant response text, but current documented hook
-payloads do not expose stable token or cost usage.
+Setup writes a Trajectory agent config to `~/.kiro/agents/trajectory.json`
+(or `$KIRO_HOME/agents/trajectory.json`) and merges a `trajectory` MCP server
+into `~/.kiro/settings/mcp.json`. The installed agent keeps Kiro's normal
+coding-agent behavior, enables `includeMcpJson`, and registers fail-open command
+hooks that invoke `trajectory capture-hook --client kiro --ensure-serve`.
+
+Kiro exposes command hooks from agent configuration. Trajectory captures
+`agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop`
+payloads from stdin and records `client_source=kiro`. The current documented
+stop hook includes `assistant_response`, so Trajectory records final assistant
+text and a turn end. The documented hook payloads do not expose stable token or
+cost usage yet, so Kiro turns are marked `tokens_status=unavailable` unless a
+future Kiro payload adds usage metadata.
+
+Kiro supports headless execution with `kiro-cli chat --no-interactive` and
+`KIRO_API_KEY`. Trajectory captures command hooks when Kiro auth is configured;
+token and cost usage depend on future Kiro hook payload fields.
+
+Historical import is not implemented yet.
+
+**Source:** [Kiro CLI hooks](https://kiro.dev/docs/cli/hooks/),
+[Kiro CLI MCP](https://kiro.dev/docs/cli/mcp/),
+[Kiro CLI custom-agent configuration](https://kiro.dev/docs/cli/custom-agents/configuration-reference/),
+and prior Amazon Q Developer CLI references in
+[amazon/amazon-q-developer-cli](https://github.com/aws/amazon-q-developer-cli).
+
 
 ## Version Check
 
-To verify your client version:
+To verify an installed client version when the upstream CLI exposes one:
 
 ```bash
 claude --version          # Claude Code
 codex --version           # Codex CLI
 copilot version           # GitHub Copilot CLI
 gemini --version          # Gemini CLI
-cursor --version          # Cursor (desktop) / cursor-agent --version (CLI)
+agy --version             # Antigravity CLI
 goose --version           # Goose
 cline --version           # Cline CLI
-aider --version           # Aider
-cn --version              # Continue CLI
-vibe --version            # Mistral Vibe
-codebuff --version        # Codebuff
+cursor --version          # Cursor (desktop) / cursor-agent --version (CLI)
+droid --version           # Factory Droid
 hermes --version          # Hermes Agent
 amp --version             # Amp Code
 qwen --version            # Qwen Code
-openhands --version       # OpenHands
-kiro --version            # Kiro CLI
-droid --version           # Factory Droid
+openhands --version       # OpenHands CLI
+aider --version           # Aider
+cn --version              # Continue CLI
+codebuff --version        # Codebuff
 pi --version              # Pi
-opencode --version        # OpenCode (note: takes cwd as argument)
+opencode version          # OpenCode
 kilo --version            # Kilo Code
+kiro-cli --version        # Kiro CLI
 ```

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -5,30 +5,41 @@ Trajectory captures sessions from AI coding agents and exports them to Datadog L
 ## Check status
 
 ```bash
+trajectory onboard                   # Local-first first-run readiness and next actions
 trajectory status                    # Terminal dashboard with session metrics
+trajectory metrics session --latest  # Local metrics preview for existing sessions
+trajectory metrics verify            # Current Datadog metrics visibility proof
+trajectory metrics last              # Reprint latest metrics proof
+trajectory metrics open              # Reopen latest submitted Metrics Explorer proof
 trajectory cost                      # Local cost summary and top sessions
-trajectory view                      # Open the local browser viewer
-trajectory doctor                    # Diagnose issues (binary, config, hooks, data)
+trajectory local-ui                  # Start local UI, preferring port 8888
+trajectory ps                        # Show live Trajectory processes
+trajectory doctor                    # Plain-language local health, span, and metric diagnosis
+trajectory doctor --verbose          # Full low-level doctor report
 trajectory inventory refresh --json  # Refresh local agent and capability inventory
 trajectory inventory show --json     # Read the latest local inventory artifact
 trajectory plugins list              # Show opt-in product activation profiles
 trajectory plugins show datadog-security # Show Datadog Security activation
 trajectory security status           # Shortcut for the Datadog Security plugin
+trajectory modules list              # Show compiled optional modules and status
+trajectory modules capabilities <id> # Show one module's declared capabilities
+trajectory modules install-plan <id> # Preview setup-managed module hooks
+trajectory modules records --limit 20 # Show recent local module decisions
 trajectory features list             # Show feature flags and effective sources
 trajectory diagnose publish          # Explain capture, local mapping, and publish expectations
 trajectory logs [-f] [--grep PAT]   # View capture server logs
 trajectory version                   # Print version
 ```
 
-`trajectory doctor` is the first thing to run if something isn't working. It checks the binary, config, capture server, local-ui/Lapdog contract, database, credentials, and hook registration.
+`trajectory onboard` is the first command to run after install. It refreshes
+local inventory, summarizes config and detected client readiness, and prints
+the exact next commands for setup, a first real agent session, local proof,
+local UI, Datadog validation, and the install outcomes dashboard. It does not
+mutate client hooks or Datadog configuration.
 
-`trajectory inventory --json` refreshes a local inventory artifact under
-`~/.trajectory/inventory/` and prints a structured snapshot of detected agents
-and Trajectory-managed capabilities such as hooks, MCP entries, skills,
-commands, plugins, and settings sources. `current.json` contains the latest
-refresh, while `snapshots/` stores hash-named inventory snapshots for support
-triage or product-pack drift checks. Trajectory does not publish these
-inventory artifacts to Datadog yet.
+`trajectory doctor` is the first thing to run if something isn't working. It starts with plain-language Datadog span-publish and metric-visibility answers: whether local config, capture state, credentials, retry queues, and metric destinations look ready, plus the next command to run. The full low-level report is still saved to `~/.trajectory/doctor-report.txt`; use `trajectory doctor --verbose` when you need the detailed subsystem checks in the terminal.
+
+`trajectory inventory refresh --json` refreshes a first-class local inventory artifact under `~/.trajectory/inventory/` and prints a structured snapshot of detected agents and Trajectory-managed capabilities such as hooks, MCP entries, skills, commands, plugins, and settings sources. `trajectory inventory show --json` reads `current.json` without rescanning, and `trajectory inventory list --json` lists the hash-named snapshots under `snapshots/` for support triage or product-pack drift checks. Trajectory does not publish these inventory artifacts to Datadog yet.
 
 `trajectory plugins list` shows opt-in product activation profiles layered over
 compiled modules. Baseline `trajectory setup` remains observability-only; use
@@ -38,11 +49,34 @@ block agent actions and requires `--yes`. Use `trajectory security disable
 --clients ... --remove-hooks` to disable config and remove stale
 Trajectory-managed dispatcher hooks while preserving baseline capture hooks.
 
-Use `trajectory view --session <id>` to inspect one captured session in the local browser viewer. If local-ui is not already running, `view` starts it and opens the session deep link. Use `trajectory user-guide local-ui` for cache repair and Lapdog-compatible local inspection.
+`trajectory modules list` shows compiled optional modules such as
+`agent-security` and `ccm`. Use `trajectory modules capabilities <id>` to see
+the module's declared hooks, install intents, evaluators, MCP entries, skills,
+commands, env fields, and keychain refs. Use `trajectory modules configure <id>
+--set KEY=VALUE` for module-wide settings, then enable a module with
+`trajectory modules enable <id> --mode observe` or `--mode enforce` and rerun
+`trajectory setup --clients ...` to install any setup-managed client assets.
+Use `trajectory modules install-plan <id> --clients codex,cursor --json` to
+preview the exact dispatcher hook commands setup will render for each client.
+Product evaluators such as `ai_guard` or `model_cost_governance` can stay
+default-disabled until their evaluator config sets `enabled: true`. Use
+`trajectory modules evaluators <id>` to inspect evaluator status and
+`trajectory modules evaluator enable|configure ...` to update evaluator config
+without hand-editing YAML. Ordinary capture hooks remain separate from module
+hook-dispatch commands, and setup installs one dispatcher per client event and
+lifecycle phase. Foreground module evaluator decisions are recorded
+locally in `~/.trajectory/modules/decisions.jsonl` and can be inspected with
+`trajectory modules records --module <id>`.
+
+Use `trajectory local-ui` to start the local inspection API and browser viewer on `http://127.0.0.1:8888`, or on the next available port if the default is occupied by another process. For hosted Lapdog backed by local Trajectory data, run `trajectory local-ui --lapdog` and use the printed Lapdog URL; its `portOverride` matches the active local-ui port.
 
 Use `trajectory diagnose publish --session <id>` when Datadog data is missing or surprising. It compares local capture and local JSONL-to-span mapping against the transcript, then adds a metric publish plan from the local SQLite cache: expected metric counts, durable outbox row counts, missing expected rows, and the exact readback follow-up command. It does not query Datadog readback.
 
-Use `trajectory doctor --support-bundle` to write a redacted JSON support bundle under `~/.trajectory/` with doctor output, publish diagnosis, recent publish-related serve logs, and pricing status.
+`trajectory doctor` also checks recent local session-end fidelity. The `Session-end local fidelity` row compares recent Trajectory JSONL against known native transcript, rollout, or hook-log evidence. It fails when a native source has strong terminal evidence such as `SessionEnd`, `shutdown_complete`, `away_summary`, or `stop_hook_summary` but the Trajectory JSONL has no terminal `session_end`. For that case, run `trajectory doctor --reconcile-session-end`; it auto-discovers recoverable sessions, prints the exact files and native evidence, and prompts before appending anything. To inspect one session directly, run `trajectory publish session-end reconcile --session <id> --dry-run`. Applying direct repair requires the interactive confirmation prompt or `--yes`; it refuses active sessions, appends a synthetic terminal `session_end` only when strong native terminal evidence is still present, then retries final publish. It warns on stale terminal anchors such as `Stop` or `task_complete` when no fresh session heartbeat remains; start those with `trajectory diagnose publish --session <id>`.
+
+Use `trajectory user-guide claude-cost` when Claude cost overlap or native-cost parity is unclear. It covers `trajectory verify claude-cost route` for read-only route classification, `trajectory verify claude-cost transcript --session <id>` for transcript-vs-capture fidelity checks, and `trajectory verify claude-cost artifacts --dir <artifact-dir>` for native OTel canary artifacts that can prove equality against `claude_code.cost.usage`.
+
+Use `trajectory flare` only as a debug/support action when you need to share a redacted ZIP under `~/.trajectory/` with doctor output, process state, metrics fast-path diagnostics, config files, managed `config.defaults.yaml`, cohort overlay files, log tails, and version/pricing metadata. It is not part of the normal onboarding path. `trajectory doctor --support-bundle` remains available for the older single-JSON support summary.
 
 For slow Codex launch or exit reports, the default doctor output includes recent Trajectory MCP lifecycle timing and any existing Codex startup traces. If attribution is unclear, run `trajectory doctor --codex-startup` to launch a bounded Codex startup probe. The probe records whether Codex is delayed before `thread_spawn`, before Trajectory MCP is launched, or inside Trajectory itself.
 
@@ -61,16 +95,12 @@ trajectory config set <key> <value>  # Set a config value
 trajectory config reload             # Dry-run live serve reload/restart plan
 trajectory config reload --yes       # Reload live serve config; restart only when required
 trajectory update reconcile          # Dry-run old-version serve process refresh
-trajectory update reconcile --yes    # Safely replace old-version standalone serve processes
+trajectory update reconcile --yes    # Start a replacement and retire safe old-version serve processes
 trajectory config set-secret <name>  # Store a secret in the OS keychain
 trajectory config get <key>          # Read a single value
 trajectory features enable <name>    # Persist a user feature-flag override
 trajectory features disable <name>   # Persist a user feature-flag kill switch
 ```
-
-Most users edit `~/.trajectory/config.yaml` through `trajectory config set`. Installers or administrators may provide `~/.trajectory/config.defaults.yaml` to seed managed defaults, and environment variables can override specific values for the current shell or launched process.
-
-See [CONFIGURATION.md](CONFIGURATION.md) for the full config file model, examples, `config.defaults.yaml` behavior, environment overrides, and common settings.
 
 Common settings:
 
@@ -79,6 +109,8 @@ trajectory config set export.site datadoghq.com
 trajectory config set export.traces standard       # off | minimal | standard | full
 trajectory config set export.metrics true
 trajectory config set export.placeholder_llm_span false  # omit synthetic cost-only LLM spans
+trajectory config set export.index_traces.session true    # optional standalone session index span
+trajectory config set export.subagent_span_mode links_only # optional: links only, no parent-side subagent task spans
 trajectory config set local_ui.auto_start false    # disable automatic local-ui startup
 trajectory features disable claude_native_otlp_interposer # keep trajectory claude from injecting native OTLP env
 trajectory config set-secret dd-api-key             # prompts for the key securely
@@ -104,7 +136,10 @@ compare per-PID serve health against the installed binary version. The default
 dry-run reports old-version standalone serve processes and blockers. With
 `--yes`, Trajectory starts a target-version replacement first, waits for fresh
 target-version health, then signals only old-version standalone `serve` PIDs
-that have no fresh session heartbeat or active publish outbox claim.
+that have no fresh session heartbeat or active publish outbox claim. Automatic
+post-update signaling is guarded off by default; set
+`TRAJECTORY_UPDATE_RECONCILE_PROCESSES=1` only when you want `trajectory update`
+to run that `--yes` path after a successful binary replacement.
 
 For metrics-only Datadog export, keep `export.traces` off and set
 `export.metrics` true:
@@ -119,8 +154,8 @@ export:
 
 ### Forward finished sessions to a local sink
 
-To stream finished sessions to a local HTTP endpoint instead of, or in addition
-to, Datadog, set a forward URL:
+To stream finished sessions to a local HTTP endpoint instead of (or in addition
+to) Datadog, set a forward URL:
 
 ```bash
 trajectory setup --clients cc --forward-url http://localhost:4997/api/v1/sessions/ingest
@@ -138,56 +173,96 @@ it empty to disable forwarding.
 
 Do not add `type` under `export:` in normal `~/.trajectory/config.yaml`.
 Trajectory creates the built-in `_config_datadog` destination from the
-`export.*` fields. Destination `type` is only used in explicit `destinations:`
-or managed `required_destinations:` lists.
+`export.*` fields. Destination `type` is only used in explicit
+`destinations:` or managed `required_destinations:` lists.
 
 These controls are separate: destination `type` chooses the backend/transport,
-`export.traces` or destination `level` controls LLM Observability trace spans,
-and `export.metrics` plus destination metric settings control metrics. Use
-`type: datadog` for direct Datadog destinations, `type: datadog_agent` for
+`export.traces` or destination `level` controls LLM Obs trace spans, and
+`export.metrics` plus destination metric settings control metrics.
+Use `type: datadog` for direct Datadog destinations, `type: datadog_agent` for
 Agent-managed publishing, or `type: otlp` for OpenTelemetry collectors in new
 explicit configs. OTLP destinations set a base collector `endpoint`; Trajectory
 derives `/v1/traces`, `/v1/metrics`, and `/v1/logs` from it. Legacy
 `type: dd_llmobs` still works.
 
-Managed Datadog destinations can opt in to a security event stream: one
-Datadog log per canonical Trajectory event with
-`ddsource: trajectory-event-stream`. This is configured under
-`required_destinations[].event_stream`, not in repo `publish.trajectory.yaml`
-or ordinary user `export:` config. The stream is off unless
-`event_stream.enabled: true` is set. The default
-`privacy_profile: security` mode keeps structural event metadata plus
-pre-tool arguments for detections while omitting prompts, assistant text,
-thinking text, post-tool outputs/results, diffs, file contents, raw payloads,
-error text, summaries, and user email fields. See
-[SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md) and
-`trajectory user-guide security-event-stream`.
+Managed or trusted destinations can also opt in to module custom spans with
+`module_spans.enabled: true`. This is for module-owned APM-style spans such as
+AI Guard hook evaluations, not for ordinary LLM Obs turn traces. The local
+source is `~/.trajectory/modules/spans.jsonl`; publishing is off by default,
+scoped to named modules, deduped through the publish ledger, and blocked from
+repo `publish.trajectory.yaml` project config. Datadog destinations send these
+as agentless OTLP traces, and `type: otlp` destinations send them directly to
+the configured collector. Use `otlp_traces_url` only for test or special
+Datadog trace-intake routing.
 
-Managed Datadog destinations can also opt in to derived AI Usage events for
-skill observability:
+`server.otlp_proxy` is separate from publish destinations. It controls the
+local `trajectory serve` OTLP listener for client-native logs, metrics, and
+traces, such as Claude Code's OTel stream:
 
 ```yaml
-required_destinations:
-  - name: aiusage
-    type: datadog
-    site: datadoghq.com
-    ml_app: coding-agents
-    api_key_ref: dd-aiusage-api-key
-    level: off
-    ai_usage:
-      enabled: true
-      endpoint: https://event-platform-intake.datadoghq.com/api/v2/aiusage
-      track: aiusage
-      approved: true
+server:
+  otlp_proxy:
+    enabled: true
+    endpoint: https://otlp.datadoghq.com
+    api_key_ref: dd-api-key
+    capture_enabled: true # optional local inbound-vs-forwarded comparison records
 ```
 
-This publisher emits one `trajectory.ai_usage.skill.v1` JSON event per
-skill-assisted turn, with skill name, invocation count, repo/user identity,
-coding-agent identity, detection source, tool count, distinct tool count,
-duration, tool names, and tool types. It does not include prompts, assistant
-responses, tool input/output, shell commands, diffs, file contents, raw trace
-payloads, or local file paths. Project `publish.trajectory.yaml` files cannot
-enable this path.
+The serve proxy forwards inbound `/v1/logs`, `/v1/metrics`, and `/v1/traces`
+payloads to the configured upstream. Metric payloads are decoded and re-encoded
+in the same OTLP protocol so Trajectory can add canonical identity tags plus
+`trajectory.proxy.source:serve-otlp`,
+`trajectory.cost_role:client_telemetry`, and
+`trajectory.cost_source:claude_native_otlp`. Trace payloads are forwarded
+unchanged so Claude Code's native span hierarchy, including `claude_code.tool`
+spans with `skill_name` when Claude is configured to emit tool details, can be
+collected without mutating the client binary. The proxy is best-effort and
+fail-open for the coding agent; local capture still succeeds when enrichment or
+the upstream is unavailable.
+
+When `capture_enabled` is true, Trajectory writes normalized metric comparison
+records under `~/.trajectory/state/otlp-proxy/metrics/`. Run
+`trajectory otlp metrics compare --session <session-id>` to confirm forwarded
+values match inbound Claude native OTLP values and to see the cost-source tags
+that should be used in Datadog. Local inbound-vs-forwarded comparison artifacts
+are metrics-only today; use the upstream trace backend to inspect native Claude
+tool and skill spans.
+Restart long-lived serve processes after changing this config so all concurrent
+listeners use the same disk-backed settings.
+
+### Skill Usage Insights
+
+Use the dedicated skill observability guide when skill maintainers want
+repo-scoped usage, tool mix, duration, and cost-source context without exposing
+raw coding-agent I/O. The same guidance is available in this repository at
+[docs/SKILL-OBSERVABILITY.md](SKILL-OBSERVABILITY.md):
+
+```bash
+trajectory user-guide skill-observability
+```
+
+The packaged Datadog dashboards include a standalone **Skill Observability**
+dashboard plus skill groups in the enterprise and developer dashboards:
+
+```bash
+trajectory dashboard export --type skill-observability --output trajectory-skill-observability.json
+trajectory dashboard export --type skill-observability --format mcp --output trajectory-skill-observability-mcp.json
+```
+
+Baseline skill usage metrics come from Trajectory's normal capture and
+materialized marker path. Exact native Claude tool-span windows require Claude
+native OTLP traffic to flow through Trajectory, which is the explicit
+`trajectory claude` path for Claude sessions.
+
+Managed Datadog security destinations can opt in to a security event stream:
+one Datadog log per canonical Trajectory event with
+`ddsource: trajectory-event-stream`. This is configured under
+`required_destinations[].event_stream`, not in repo `publish.trajectory.yaml`.
+The stream is off unless `event_stream.enabled: true` is set. When enabled, the
+default `privacy_profile: security` mode keeps structural event metadata plus
+pre-tool arguments for detections while omitting prompts, assistant text,
+thinking text, post-tool output/results, raw payloads, error text, summaries,
+and user email fields. See `trajectory user-guide security-event-stream`.
 
 Trace export is off by default. Set `export.traces` explicitly when you want
 sessions published to LLM Observability. Rerunning `trajectory setup` preserves
@@ -198,25 +273,27 @@ it warns loudly when it preserves `full`.
 
 Secret writes are defensive: `trajectory setup` and `trajectory config
 set-secret` snapshot an existing keychain value before updating it and attempt
-to restore the old value if the write fails. Recover a missing Datadog key with
-`trajectory config set-secret dd-api-key` or a temporary `DD_API_KEY` /
+to restore the old value if the write fails. Rescue a missing Datadog key with
+`trajectory config set-secret dd_api_key` or a temporary `DD_API_KEY` /
 `DATADOG_API_KEY`.
 
 Environment variables are process-local. If a long-running `trajectory serve`
 process was started before `DD_API_KEY` was exported, that process cannot see
 the later shell variable. Setup-managed Codex hooks invoke the installed
 `trajectory capture-hook --client codex --ensure-serve` binary path so they can
-verify or start a matching local capture server, but stored credentials are
-still the durable option for agent sessions. Store the key once with
-`trajectory config set-secret dd-api-key`, configure `auth.key_command`, or
+verify or start a matching local capture server while preserving lifecycle event
+order, but stored credentials are still the durable option for agent sessions.
+Store the key once with
+`trajectory config set-secret dd_api_key`, configure `auth.key_command`, or
 rerun setup with `DD_API_KEY` present.
 
 Standard Datadog credential resolution uses `auto`: env var for the
 `api_key_ref`, `DD_API_KEY`, `DATADOG_API_KEY`, the configured credential-provider
 command from `auth.key_command`, keychain, then destination `api_key_command`.
-For standard Datadog API-key resolution, `dd-api-key` and `dd_api_key` are
-accepted aliases for the same default key. Managed keychain deployments use
-exact refs only and do not alias, read env vars, or run key commands.
+For standard Datadog API-key resolution, `dd-api-key` and `dd_api_key` are the
+same default key: setup stores `dd_api_key`, while publish config often names
+`dd-api-key`. Managed keychain deployments are the exception; they use exact
+refs only and do not alias, read env vars, or run key commands.
 If an env var is a secret-manager ID rather than the Datadog key, `auto` reports
 it and real Datadog publish destinations continue to later sources. Pin the
 intended source when you want that source to fail closed:
@@ -226,15 +303,17 @@ trajectory config set auth.credential_source keychain  # auto | env | key_provid
 trajectory doctor
 ```
 
-Managed `auth.mode: managed_keychain` policy uses exact keychain refs only.
-`trajectory serve` logs an early warning when `auto` sees a malformed Datadog
-env var, before the first publish attempt.
+Managed `auth.mode: managed_keychain` from MDM still wins and uses exact
+keychain refs only. `trajectory serve` logs an early warning when `auto` would
+select a malformed Datadog env var, before the first publish attempt.
 
 Set `export.placeholder_llm_span: false` in `~/.trajectory/config.yaml`, or `placeholder_llm_span: false` on a managed/trusted `publish.trajectory.yaml` destination, to stop publishing Trajectory's synthetic LLM child span for turn-level token/cost enrichment. The turn span still carries `metrics.estimated_total_cost` plus cost fallback metadata and the `trajectory.cost_source:turn_metrics` tag, so cost remains queryable without the placeholder child span. Project configs may disable this for a trusted destination, but cannot re-enable it if the trusted or managed destination disabled it.
 
-Subagent spans default to `export.subagent_span_mode: semantic`: synchronous subagents attach under the launching Agent or Task tool span, while async background subagents attach under the task-notification join turn. Set `export.subagent_span_mode: links_only`, or destination `subagent_span_mode: links_only`, to suppress the extra parent-side subagent task span and keep only child-trace links and metadata. See [SUBAGENT-TRACE-MODEL.md](SUBAGENT-TRACE-MODEL.md).
+Set `export.index_traces.session: true`, or `index_traces.session: true` on a managed/trusted destination, only when you want a standalone link-only session index span at session end. It is off by default because the canonical topology is turn-rooted; project configs may disable a trusted destination's session index span, but cannot enable one the trusted destination did not allow.
 
-For managed local-ui auto-start rollback, deploy `local_ui.auto_start: false` in `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` and `trajectory view` commands still work.
+Subagent rendering defaults to `export.subagent_span_mode: semantic`: sync subagents attach under the launching Agent/Task tool span, and async background subagents attach under the task-notification join turn. Use `links_only` only when you want to preserve child trace links without publishing the extra parent-side subagent task span.
+
+For fleet-wide local-ui auto-start rollback, deploy `local_ui.auto_start: false` in managed `~/.trajectory/config.defaults.yaml`. A managed false value disables automatic local-ui startup and cannot be overridden from user `config.yaml`; explicit `trajectory local-ui` commands still work.
 
 ## Capture server
 
@@ -255,13 +334,14 @@ trajectory status --session <id> --json
 trajectory cost inspect --session <id>
 trajectory cost observations --session <id>
 trajectory cost validate
-trajectory view --session <id>
+trajectory local-ui                  # Open local-ui, preferring http://127.0.0.1:8888
+trajectory local-ui --lapdog         # Hosted Lapdog with local port override
 trajectory user-guide query          # Local data and safe MCP query workflow
 trajectory user-guide costs          # Cost tracking commands and fidelity checks
 ```
 
 The current OSS binary does not expose a general-purpose `trajectory query`
-CLI. Use `trajectory status`, `trajectory view`, `get_session_trajectory`, and
+CLI. Use `trajectory status`, `trajectory local-ui`, `get_session_trajectory`, and
 the `trajectory_schema` / `trajectory_query` tools for local inspection. Pi
 registers those as native extension tools; setup-managed MCP clients get the
 same schema-first workflow through `trajectory mcp`. The embedded query guide
@@ -270,7 +350,8 @@ documents schema-first inspection and `TRAJECTORY_CACHE_DB` handling.
 Use `trajectory cost` for local cost tracking. It reads the local SQLite cache
 in read-only mode, shows recent cost totals, inspects turn-level cost evidence,
 reports objective cost observations without causal claims, and validates recent
-cost fidelity for supported clients. See [COSTS.md](COSTS.md).
+cost fidelity for Claude Code, Codex, Gemini, Antigravity, Aider, Pi, OpenCode, Kilo
+Code, and Cursor.
 
 ## MCP tools
 
@@ -286,12 +367,6 @@ read-only SQLite access.
 
 For SQLite queries, call `trajectory_schema` first so the agent uses the live
 database path and schema before calling `trajectory_query`.
-
-`trajectory_incognito` can be called with only `enable` when the MCP server can
-resolve the active session from environment variables or the active-session
-registry. Responses include `resolved_session_id` and `resolution_source`. If
-resolution fails, call `list_active_sessions` and retry with an explicit
-`session_id`.
 
 ```bash
 trajectory user-guide mcp
@@ -310,18 +385,14 @@ trajectory setup --clients aider --install-client-shims     # Add or refresh Aid
 trajectory setup --clients continue --install-client-shims  # Add or refresh Continue CLI shim capture
 trajectory setup --clients mistral-vibe --install-client-shims # Add or refresh Mistral Vibe shim capture
 trajectory setup --clients codebuff --install-client-shims  # Add or refresh Codebuff shim capture
-trajectory setup --clients droid     # Add or refresh Factory Droid beta live capture
-trajectory setup --clients hermes    # Add or refresh Hermes Agent capture
-trajectory setup --clients amp       # Add or refresh Amp Code capture
-trajectory setup --clients qwen      # Add or refresh Qwen Code capture
-trajectory setup --clients openhands # Add or refresh OpenHands capture
 trajectory setup --clients kilo      # Add or refresh Kilo Code capture
 trajectory setup --clients kiro      # Add or refresh Kiro CLI capture
+trajectory setup --clients droid     # Add or refresh Factory Droid beta live capture
 trajectory setup --clients all       # Add or refresh all setup-managed clients
+trajectory setup --clients cc --forward-url URL  # Also forward finished sessions to a local sink
 trajectory setup auto-instrument --json  # Dry-run managed auto-instrument plan
 trajectory setup auto-instrument apply --yes --json  # Apply when managed mutation is enabled
 trajectory setup auto-instrument status --json  # Last auto-instrument status
-trajectory setup --clients cc --forward-url URL  # Also forward finished sessions to a local sink
 trajectory setup --uninstall codex   # Remove one client integration
 ```
 
@@ -331,39 +402,110 @@ unchanged. If no config file exists yet, it creates a capture-only config so
 local session capture can start; run `trajectory setup` later to configure
 Datadog export.
 
-Managed deployments can preview automatic client instrumentation with `trajectory setup auto-instrument`. The dry-run planner only becomes ready when managed defaults explicitly enable `setup.auto_instrument.enabled` with an `allow_clients` list. Mutation requires a second opt-in, `setup.auto_instrument.apply_enabled: true`; without it, auto-instrument reports status only.
+Managed fleets can preview automatic client instrumentation with `trajectory
+setup auto-instrument`. The dry-run planner only becomes ready when both
+conditions are true: `selfupdate.conf` stamps a managed owner such as `jamf` or
+`mdm`, and managed `config.defaults.yaml` explicitly enables
+`setup.auto_instrument.enabled` with an `allow_clients` list. Unmanaged users
+and self-installs remain disabled by default, and a user config can opt out by
+setting `setup.auto_instrument.enabled: false`. Managed defaults are the policy
+ceiling: local user config can narrow `allow_clients`, add `deny_clients`, or
+choose a less frequent interval, but it cannot expand automatic client
+instrumentation beyond the managed allow-list.
+
+Mutation requires a second managed opt-in:
+`setup.auto_instrument.apply_enabled: true`. Without that key, auto-instrument
+continues to plan and report status only. With it enabled, an MDM/Jamf job can
+run `trajectory setup auto-instrument apply --yes`; the command reuses the same
+client-only setup path as `trajectory setup --clients ... --non-interactive`,
+then records the apply result in `state/auto-instrument/status.json`.
+
+When `trajectory serve` starts, it records the same plan in
+`state/auto-instrument/status.json` under the Trajectory home. Read it with
+`trajectory setup auto-instrument status`. Startup remains dry-run unless the
+managed policy also sets `setup.auto_instrument.apply_enabled: true`; when that
+second gate is enabled and the plan has actionable detected clients, startup
+runs the same client-only setup path in the background and records the apply
+result with source `serve_startup_apply`.
+
+Example managed defaults:
+
+```yaml
+setup:
+  auto_instrument:
+    enabled: true
+    apply_enabled: false
+    mode: detected
+    interval: 6h
+    allow_clients: [cc, codex, cursor, gemini, agy, goose, cline, aider, continue, codebuff, kilo, kiro]
+```
 
 `--forward-url <url>` records `export.local_forward_url`, making `trajectory
 serve` POST each finished session as NDJSON to that local endpoint at session
-end with no Datadog credentials required. See "Forward finished sessions to a
-local sink" above.
+end (no Datadog credentials required). See "Forward finished sessions to a local
+sink" above.
 
 ### Feature coverage matrix
 
-| Client | Live capture | Tool/model events | Token/cost usage | Incognito or MCP | Backfill | Resume |
-|--------|--------------|-------------------|------------------|------------------|----------|--------|
-| Claude Code | HTTP hooks | Yes | Yes | Yes | Transcript backfill | Yes |
-| Codex CLI | Command hooks plus rollout watcher fallback | Yes | Yes | Yes | Codex rollout backfill | Yes |
-| GitHub Copilot CLI | Beta Copilot plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
-| Gemini CLI | Managed command hooks | Yes | Yes | Yes | Gemini transcript backfill | Yes |
-| Antigravity CLI (`agy`) | Antigravity plugin command hooks | Yes | Yes | Yes | Not yet | No setup-managed resume |
-| Goose | Open Plugins command hooks | Session, prompt, tool, shell/file, and assistant-message hooks | Usage when hook payloads expose it | Not yet | Not yet | No setup-managed resume |
-| Cline CLI | File hooks | Lifecycle, prompt, tool, assistant-message, turn, and session-end events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
-| Aider | Opt-in command shim with analytics and history sidecars | Prompt, assistant-message, and turn events | Yes, from Aider analytics rows when present | Command shim | Not yet | No setup-managed resume |
-| Continue CLI | Opt-in `cn` command shim plus session JSON readback | Prompt, assistant-message, and turn events | Yes, from Continue session usage metadata when present | Command shim | Not yet | No setup-managed resume |
-| Mistral Vibe | Opt-in command shim plus native tool hooks | Prompt, tool, assistant-message, and turn events | Yes, from Vibe session metadata when present | Command shim | Not yet | No setup-managed resume |
-| Codebuff | Opt-in command shims plus chat-history import | Prompt, assistant-message, turn, and chat-history-derived model events | Yes, from Codebuff chat metadata | Command shim | Codebuff chat history backfill | No setup-managed resume |
-| Cursor Desktop | Command hooks | Yes | Cursor DB dependent | Yes | Cursor chat backfill | Yes |
-| cursor-agent CLI | Transcript watcher | Tool and turn events | Not exposed by current transcripts | No | Same transcript source | No setup-managed resume |
-| Factory Droid | Beta Factory plugin command hooks | Command-level events | Not yet | MCP config and incognito skill | Not yet | Not yet |
-| Hermes Agent | Observer plugin hooks | Yes | Usage payloads when present | Yes | Not yet | No setup-managed resume |
-| Amp Code | Setup-managed system plugin | Yes | When Amp plugin events expose usage | MCP | Not yet | No setup-managed resume |
-| Qwen Code | Native HTTP hooks | Yes | Yes, from usage metadata and transcript fallback | Yes | Not yet | No setup-managed resume |
-| OpenHands | Command hooks | Lifecycle, prompt, and tool events | Not exposed by command hook payloads | Yes | Not yet | No setup-managed resume |
-| Pi | TypeScript extension | Yes | Yes | Native tool plus MCP | Pi/OMP session backfill | Yes |
-| OpenCode | Plugin SDK events | Yes | Yes | Yes | SQLite backfill | Yes |
-| Kilo Code | Plugin SDK events | Yes | Native OTLP traces/logs plus SDK payloads when exposed | Yes | Not yet | No setup-managed resume |
-| Kiro CLI | Agent command hooks | Prompt, tool, and assistant-response events | Not exposed by current hook payloads | Yes | Not yet | No setup-managed resume |
+Incognito is a server-side Trajectory gate for every captured session once the
+session is toggled. The privacy matrix calls out whether setup gives that
+client a first-class way to toggle it. Sensitivity classification and task
+segmentation are core Trajectory features for captured non-headless sessions;
+headless sessions always skip sensitivity classification and segmentation.
+
+#### Capture and telemetry
+
+| Client | Live capture | Tool/model events | Token/cost usage | Backfill | Resume |
+|--------|--------------|-------------------|------------------|----------|--------|
+| Claude Code | HTTP hooks | Yes | Yes | Transcript backfill | Yes |
+| Codex CLI | Command hooks plus rollout watcher fallback | Yes | Yes | Codex rollout backfill | Yes |
+| GitHub Copilot CLI | Beta Copilot plugin command hooks | Command-level lifecycle, prompt, tool, and session events | Not exposed by current hook payloads | Not yet | Not yet |
+| Gemini CLI | Managed command hooks | Yes | Yes | Gemini transcript backfill | Yes |
+| Antigravity CLI (`agy`) | Antigravity plugin command hooks | Yes | Yes | Not yet | No setup-managed resume |
+| Goose | Open Plugins command hooks | Session, prompt, tool, shell/file, and assistant-message events | Fixture-only from live hooks; historical SQLite usage readback can be added later | Not yet | No setup-managed resume |
+| Cline CLI | File hooks | Lifecycle, prompt, tool, assistant-message, turn, and session-end events | Not exposed by current hook payloads | Not yet | No setup-managed resume |
+| Aider | Opt-in command shim with analytics and history sidecars | Prompt, assistant-message, and turn events | Yes, from Aider analytics rows when present | Not yet | No setup-managed resume |
+| Continue CLI | Opt-in `cn` command shim plus session JSON readback | Prompt, assistant-message, and turn events | Yes, from Continue session usage metadata when present | Not yet | No setup-managed resume |
+| Mistral Vibe | Opt-in `vibe` command shim plus native tool hooks | Prompt, tool, assistant-message, and turn events | Yes, from Vibe session metadata when present | Not yet | No setup-managed resume |
+| Codebuff | Opt-in command shims plus chat-history import | Prompt, assistant-message, turn, and chat-history-derived model events | Yes, from Codebuff chat metadata and nested run-state usage | `backfill --from-codebuff-chats` | No setup-managed resume |
+| Cursor Desktop | Command hooks | Yes | Cursor DB dependent | Cursor chat backfill | Yes |
+| cursor-agent CLI | Transcript watcher | Tool and turn events | Not exposed by current transcripts | Same transcript source | No setup-managed resume |
+| Factory Droid | Beta Factory plugin command hooks | Documented lifecycle, prompt, tool, notification, compaction, stop, and subagent-stop events | Not exposed by current documented hook payloads | Not yet | Not yet |
+| Pi | TypeScript extension | Yes | Yes | Pi/OMP session backfill | Yes |
+| Hermes Agent | Observer plugin hooks | Yes | Yes, from observer usage payloads | Not yet | No setup-managed resume |
+| Amp Code | System TypeScript plugin events | Yes | Fixture-tested; live usage when Amp exposes usage fields | Not yet | No setup-managed resume |
+| Qwen Code | Native HTTP hooks | Yes | Yes, from Qwen usageMetadata and transcript fallback | Not yet | No setup-managed resume |
+| OpenHands | Command hooks | Lifecycle, prompt, and tool events | Not exposed by command hook payloads | Not yet | No setup-managed resume |
+| OpenCode | Plugin SDK events | Yes | Yes | SQLite backfill | Yes |
+| Kilo Code | Plugin SDK events | Yes | Native OTLP traces/logs plus SDK payloads when exposed | Not yet | No setup-managed resume |
+| Kiro CLI | Agent command hooks | Prompt, tool, and assistant-response events | Not exposed by current documented hook payloads | Not yet | No setup-managed resume |
+
+#### Privacy and derived features
+
+| Client | Incognito UX | MCP incognito tool | Sensitivity scanning | Segmentation | Coverage note |
+|--------|--------------|--------------------|----------------------|--------------|---------------|
+| Claude Code | `/trajectory:incognito` command and incognito skill | Yes | Non-headless eligible; headless skipped | Non-headless eligible; headless skipped | First-class incognito UX |
+| Codex CLI | Incognito skill with bundled script fallback | Yes | Non-headless eligible; headless skipped | Non-headless eligible; headless skipped | First-class incognito UX |
+| GitHub Copilot CLI | Incognito skill in the local marketplace plugin | Yes | Non-headless plugin sessions eligible; headless skipped | Non-headless plugin sessions eligible; headless skipped | Plugin sessions can toggle incognito |
+| Gemini CLI | `/incognito` command and incognito skill | Yes | Non-headless hook sessions eligible; headless skipped | Non-headless hook sessions eligible; headless skipped | First-class incognito UX |
+| Antigravity CLI (`agy`) | `/incognito` command and incognito skill | Yes | Non-headless hook sessions eligible; headless skipped | Non-headless hook sessions eligible; headless skipped | Incognito skill and command installed by setup |
+| Goose | Setup-managed `goose-incognito` command | No | Non-headless Open Plugins sessions eligible; headless skipped | Non-headless Open Plugins sessions eligible; headless skipped | Command-based incognito toggle |
+| Cline CLI | Setup-managed `cline-incognito` command plus MCP request path | Yes | Non-headless file-hook sessions eligible; headless skipped | Non-headless file-hook sessions eligible; headless skipped | Command and MCP incognito paths |
+| Aider | Setup-managed `aider-incognito` command | No | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions can use command incognito |
+| Continue CLI | Setup-managed `continue-incognito` command | No | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions eligible when non-headless; headless skipped | Wrapper sessions can use command incognito |
+| Mistral Vibe | Setup-managed `vibe-incognito` and `mistral-vibe-incognito` commands | No | Wrapper/native sessions eligible when non-headless; headless skipped | Wrapper/native sessions eligible when non-headless; headless skipped | Wrapper sessions can use command incognito |
+| Codebuff | Setup-managed `codebuff-incognito` and `cb-incognito` commands | No | Wrapper/imported sessions eligible when non-headless; headless skipped | Wrapper/imported sessions eligible when non-headless; headless skipped | Wrapper/imported sessions can use command incognito |
+| Cursor Desktop | Incognito skill, using Claude skill when available or native Cursor fallback; setup also installs `cursor-agent-incognito` | Yes | Non-headless GUI sessions eligible; headless skipped | Non-headless GUI sessions eligible; headless skipped | GUI sessions use skill-based incognito |
+| cursor-agent CLI | Setup-managed `cursor-agent-incognito` command when the Cursor integration is installed; watcher has no native slash surface | No | Transcript-watcher sessions are treated as headless and skipped | Transcript-watcher sessions are treated as headless and skipped | Headless transcript watcher path |
+| Factory Droid | Incognito skill in the local marketplace plugin | Yes | Non-headless plugin sessions eligible; headless skipped | Non-headless plugin sessions eligible; headless skipped | Plugin sessions can toggle incognito |
+| Pi | Native `trajectory_incognito` tool plus MCP | Yes | Non-headless extension sessions eligible; extension-supplied verdicts accepted; headless skipped | Non-headless extension sessions eligible; headless skipped | Native extension incognito tool |
+| Hermes Agent | Incognito skill | Yes | Non-headless observer sessions eligible; headless skipped | Non-headless observer sessions eligible; headless skipped | Observer sessions can toggle incognito |
+| Amp Code | Setup-managed `amp-incognito` command plus MCP request path | Yes | Non-headless Amp plugin sessions eligible; headless skipped | Non-headless Amp plugin sessions eligible; headless skipped | Command and MCP incognito paths |
+| Qwen Code | `/incognito` command and incognito skill | Yes | Non-headless Qwen hook sessions eligible; headless skipped | Non-headless Qwen hook sessions eligible; headless skipped | Incognito skill and command installed by setup |
+| OpenHands | Setup-managed `openhands-incognito` command plus MCP request path | Yes | Non-headless command-hook sessions eligible; headless skipped | Non-headless command-hook sessions eligible; headless skipped | Command and MCP incognito paths |
+| OpenCode | Incognito skill | Yes | Non-headless plugin SDK sessions eligible; headless skipped | Non-headless plugin SDK sessions eligible; headless skipped | Plugin SDK sessions can toggle incognito |
+| Kilo Code | Incognito skill | Yes | Non-headless plugin SDK sessions eligible; headless skipped | Non-headless plugin SDK sessions eligible; headless skipped | Plugin SDK sessions can toggle incognito |
+| Kiro CLI | Setup-managed `kiro-incognito` command plus MCP request path | Yes | Prompt/tool hook capture eligible when non-headless; headless skipped | Punted for final segmentation proof: current documented command hooks lack a terminal `SessionEnd` signal | Fixture-only capture plus command-behavior coverage; no positive privacy-feature proof yet |
 
 ## Publishing and export
 
@@ -372,11 +514,120 @@ trajectory publish validate          # Verify publish config and credentials
 trajectory publish status            # Show effective mode and active sessions
 trajectory publish preview           # Preview what would be published
 trajectory diagnose publish          # Explain whether traces/metrics should publish
-trajectory publish metrics audit --latest
-                                    # Audit expected metrics from local cache
+trajectory metrics session --latest  # Preview metrics from local session history
+trajectory metrics verify            # Submit current verification metrics proof
+trajectory metrics last              # Reprint latest metrics proof
+trajectory metrics open              # Reopen latest submitted Metrics Explorer proof
 ```
 
-`trajectory publish validate` checks configuration, trust policy, and credentials, including credential source and non-secret value-shape diagnostics. `trajectory publish status` shows the effective mode, including metrics-only and trace-off states. Neither command verifies Datadog intake or readback.
+`trajectory publish validate` checks configuration, trust policy, and credentials,
+including credential source and non-secret value-shape diagnostics. `trajectory
+publish status` shows the effective mode, including metrics-only and trace-off
+states. Neither command verifies Datadog intake or readback.
+
+Trace and final-session publish retries use a durable metadata outbox at
+`~/.trajectory/state/trace-publish-outbox.sqlite`. If one `trajectory serve`
+process captures an event without Datadog credentials, it records the LLMO
+artifact identity and returns a publish error instead of silently advancing. Any
+other credentialed serve process can later claim a small batch and rebuild the
+Datadog payload from the local JSONL. `trajectory doctor` reports pending,
+retryable, failed, stale, and dropped trace outbox rows.
+
+`trajectory diagnose publish --session <id>` includes a compact metric publish
+plan for that session. Use it first when one session is missing data: it shows
+whether the local cache expects metric points, whether the durable metric outbox
+has matching rows, and what readback command to run next.
+
+For onboarding, prefer the two metrics fast-path commands:
+
+```bash
+trajectory metrics session --latest
+trajectory metrics session --session <id>
+trajectory metrics verify
+trajectory metrics last
+trajectory metrics open
+```
+
+`metrics session` is a local preview for existing sessions. It reconstructs
+the metrics Trajectory derived from the local cache, prints the metric names,
+important session tag filters, and outbox status, and does not submit
+historical metrics to Datadog. Sessions older than 24 hours are intentionally
+treated as local-only previews because remote historical metric intake/readback
+is not a reliable onboarding path.
+
+`metrics verify` is the Datadog visibility proof. It submits a current
+timestamped verification metric set through the normal metrics publish path,
+tries Datadog Metrics readback when one destination and an application key are
+ready, and otherwise falls back to submit-only with a notice. Filter the
+verification points by the printed `trajectory.canary_run` tag. Pass
+`--readback` explicitly when exact readback must be a hard gate.
+
+`metrics last` reprints the latest saved verification proof. `metrics open`
+reopens the saved Metrics Explorer URL after a submitted verification. Local-only
+verification runs are saved for diagnostics, but `metrics open` refuses them
+because no remote Datadog points were submitted.
+
+If `metrics session` reports no eligible destinations, enable base metrics and
+refresh live capture before proving visibility:
+
+```bash
+trajectory config set export.metrics true
+trajectory config reload --yes
+trajectory metrics verify
+```
+
+For exact readback, store an application key with Metrics query permission and
+pin the destination:
+
+```bash
+trajectory config set-secret dd_app_key --stdin
+trajectory metrics verify --destination <name> --readback
+```
+
+Use `trajectory publish metrics audit --latest` when you need the deeper
+read-only audit. Add `--builtin-details` to account for every built-in metric
+and show whether each one is `observed`, `not_observed`, or `out_of_scope` for
+the selected local data. Audit reconstruction suppresses
+`content_length_estimate` token and cost rows from authoritative metric
+expectations and warns when selected sessions contain them, so lower estimated
+cost is explicit instead of silent. To query Datadog for stable dashboard
+mirrors outside the first-run flow, run:
+
+```bash
+trajectory config set-secret dd_app_key --stdin
+trajectory publish metrics audit --latest --readback
+```
+
+Use `--readback-all --strict-fidelity` for CI/canaries or incident follow-up
+where every sent outbox group, including volatile duration and last-seen
+metrics, must read back exactly from Datadog. Strict mode fails if expected
+source-tagged rows are missing, extra rows are present, rows are not `sent`,
+source labels are unknown, or readback is incomplete.
+
+`trajectory publish sync` creates log-based metric definitions through the
+Datadog Logs configuration API. That path needs the Datadog API key used for
+publish plus a Datadog application key. `publish validate` can accept the API
+key while sync still fails if `DD_APP_KEY` / `dd_app_key` is missing or lacks
+log configuration write permission. Store the app key with:
+
+```bash
+trajectory config set-secret dd_app_key --stdin
+```
+
+For full built-in publish fidelity across spoofed coding-agent sources, use the
+synthetic canary. Add `--include-diagnostics` when you also want process and
+instrumentation-health metric readback:
+
+```bash
+trajectory publish metrics canary --clients all --runs-per-client 2 --include-diagnostics --submit --readback
+```
+
+The canary generates one expected point for every session-auditable built-in
+metric, can optionally emit diagnostic built-ins once per destination, tags each
+run with `trajectory.canary_run`, submits through the same
+MetricRecord-to-Datadog path, and polls Datadog Metrics until every expected
+metric group reads back exactly. Use `--destination <name>` when multiple
+Datadog metric destinations are configured.
 
 For the publish operations runbook covering validate/status/preview, missing
 Datadog data, `publish sync`, and publish ledger repair:
@@ -385,64 +636,7 @@ Datadog data, `publish sync`, and publish ledger repair:
 trajectory user-guide publish
 ```
 
-`trajectory diagnose publish --session <id>` includes a compact metric publish
-plan for that session. Use it first when one session is missing data: it shows
-whether the local cache expects metric points, whether the durable metric
-outbox has matching rows, and what readback command to run next.
-
-`trajectory publish metrics audit --latest` is the deeper read-only metric
-audit. It reconstructs the Datadog metric points Trajectory should publish from
-the local SQLite cache and correlates those expected points with the durable
-metric outbox when session-end publish has run, showing recorded, pending,
-sent, failed, and dropped rows for the selected session and destination.
-Outbox matches use a semantic payload identity: transport, metric kind,
-normalized value, and stable tag hash. They intentionally do not compare point
-timestamps, and they ignore volatile diagnostic tags such as version,
-repository, owner, and user. Metric-specific dimensions such as source and
-language remain part of the semantic identity. Add `--builtin-details` to
-account for every built-in metric and show whether each one is `observed`,
-`not_observed`, or `out_of_scope` for the selected local data. To query Datadog
-for the stable dashboard mirrors, run:
-
-```bash
-trajectory config set-secret dd-app-key --stdin
-trajectory publish metrics audit --latest --readback
-```
-
-The app key must belong to the destination Datadog org and include Metrics
-query permission (`timeseries_query`). Managed destinations can set
-`required_destinations[].app_key_ref` so readback uses the same destination
-identity as publish. You can also pass it for one command with `DD_APP_KEY=...`
-or use `--readback-app-key-ref <secret-name>` for a custom Trajectory keychain
-secret. Application-key lookup is shared by readback and sync: explicit
-command ref, destination `app_key_ref`, then `dd-app-key`, `dd_app_key`, or
-`DD_APP_KEY`. Managed keychain mode uses the same order but reads each ref
-exactly from the keychain.
-
-`trajectory publish sync` creates log-based metric definitions through the
-Datadog Logs configuration API. That path needs the Datadog API key used for
-publish plus a Datadog application key. `publish validate` can accept the API
-key while sync still fails if `DD_APP_KEY` / `dd-app-key` / `dd_app_key` is
-missing or lacks log configuration write permission. Store the app key with:
-
-```bash
-trajectory config set-secret dd-app-key --stdin
-```
-
-For full built-in publish fidelity across spoofed coding-agent sources, use the
-synthetic canary:
-
-```bash
-trajectory publish metrics canary --clients all --runs-per-client 2 --submit --readback
-```
-
-The canary generates one expected point for every session-auditable built-in
-metric, tags each run with `trajectory.canary_run`, submits through the same
-MetricRecord-to-Datadog path, and polls Datadog Metrics until every expected
-metric group reads back exactly. Use `--destination <name>` when multiple
-Datadog metric destinations are configured.
-
-For marker-metric readback, use `trajectory markers canary --keep-home`. It runs an isolated synthetic session, validates local marker/cost/token/assistant-message invariants, and prints Datadog queries for metric destination verification.
+For marker-metric readback, use `trajectory markers canary --keep-home`. It runs an isolated synthetic session, validates local marker/cost/token/assistant-message invariants, and prints Datadog query shapes for the configured destination.
 
 `trajectory audit --deep` adds an interpretation block for local capture fidelity, config-driven trace-off states, missing model/cost attribution, and the 24-hour LLMO trace intake backfill limit.
 
@@ -458,18 +652,15 @@ For the full metric catalog, see [METRICS-REFERENCE.md](METRICS-REFERENCE.md).
 
 ## Local UI and resume
 
-Open the local viewer:
+Start local-ui on the preferred default port 8888:
 
 ```bash
-trajectory view
-trajectory view --session <id>
+trajectory local-ui
 ```
 
-Run local-ui manually when you need a stable port or Lapdog-compatible local
-inspection:
+Use Lapdog against local Trajectory data:
 
 ```bash
-trajectory local-ui --port 8890
 trajectory local-ui --lapdog
 ```
 
@@ -484,20 +675,60 @@ trajectory resume --session <id> --target codex
 Read the embedded guides for details:
 
 ```bash
+trajectory user-guide onboarding
 trajectory user-guide local-ui
+trajectory user-guide source-provenance
 trajectory user-guide resume
 ```
 
 ## Datadog dashboards
 
-Trajectory ships embedded Datadog dashboards for enterprise, developer, and operations views.
+Trajectory ships embedded Datadog dashboards for enterprise, developer,
+operations, skill observability, data fidelity, and install outcomes views.
 
 ```bash
+trajectory dashboard export --type enterprise --output trajectory-enterprise.json
+trajectory dashboard export --type developer --output developer-dashboard.json
 trajectory dashboard export --type operations --output trajectory-operations.json
+trajectory dashboard export --type skill-observability --output trajectory-skill-observability.json
+trajectory dashboard export --type data-fidelity --output trajectory-data-fidelity.json
+trajectory dashboard export --type install-outcomes --output trajectory-install-outcomes.json
 trajectory dashboard export --type operations --format mcp --output trajectory-operations-mcp.json
+trajectory dashboard export --type skill-observability --format mcp --output trajectory-skill-observability-mcp.json
+trajectory dashboard export --type data-fidelity --format mcp --output trajectory-data-fidelity-mcp.json
+trajectory dashboard export --type install-outcomes --format mcp --output trajectory-install-outcomes-mcp.json
 ```
 
-Use the default `raw` format for Datadog dashboard API workflows. Use `--format mcp` when importing through the Datadog MCP `upsert_datadog_dashboard` tool. The MCP format keeps the payload to the tool's expected fields (`title`, `description`, `tags`, `template_variables`, and `widgets`), converts template variable `default` values to `defaults`, and keeps only `team:` dashboard tags because the MCP dashboard tool accepts only team tags.
+Trajectory exports dashboard JSON; it does not create the Datadog dashboard
+directly. Import the default `raw` JSON through the Datadog dashboard API or
+Datadog UI JSON import flow. Use `--format mcp` when importing through the
+Datadog MCP `upsert_datadog_dashboard` tool. The MCP format keeps the payload
+to the tool's expected fields (`title`, `description`, `tags`,
+`template_variables`, and `widgets`), converts template variable `default`
+values to `defaults`, and keeps only `team:` dashboard tags because the MCP
+dashboard tool accepts only team tags.
+
+The `skill-observability` dashboard is the narrow skill-maintainer view. It
+answers which skills are used by repo, how often they are invoked, which source
+produced the signal, how many tools and tool types appear in skill-assisted
+turns, whether complexity came from native trace attribution or fallback, p95
+duration, and cost-source context. It intentionally visualizes
+metrics only, not raw prompts, tool outputs, or full coding-agent trace I/O.
+
+The `data-fidelity` dashboard is the instrumentation trust view. It shows
+metric provenance, model/user/client attribution, repo-source coverage, skill
+signal provenance, and instrumentation-health fallback/failure counters.
+
+The `install-outcomes` dashboard is the managed rollout and onboarding view. It
+uses Jamf attempt metrics for pre-binary and retry behavior, then uses
+`trajectory.ops.install.current_state` and `trajectory.ops.install.agent_state`
+as the durable setup and per-integration state once the binary runs.
+
+The `operations` dashboard includes the low-cardinality coding-agent usage view:
+installed agents, installed agent versions, active sessions by client, and
+active-session versions. Use it to answer which coding agents are present and
+which ones are actually being used without tagging by session ID or project
+path.
 
 ## Privacy Controls
 
@@ -521,14 +752,17 @@ trajectory user-guide privacy
 
 ## Backfill
 
-Use backfill when you need to import historical sessions, refresh the local UI
-cache, or repair historical dashboard metrics.
+Use backfill for maintenance: importing historical sessions, refreshing the
+local UI cache, or repairing historical dashboard metrics in orgs where
+Datadog Historical Metrics Ingestion is enabled. It is not required for
+first-run metric onboarding; use `trajectory metrics session --latest` and
+`trajectory metrics verify` first.
 
 ```bash
 trajectory backfill --from-claude-code --republish-local  # Claude Code transcripts + local UI
 trajectory backfill --republish-local                  # Refresh local UI from cached sessions
 trajectory backfill --from-codex-sessions --limit 100  # Codex rollout files, newest first
-trajectory backfill-my-metrics                         # Dry-run historical dashboard metrics
+trajectory backfill-my-metrics                         # Dry-run historical dashboard repair
 ```
 
 Read the full embedded guide for modes, local UI repair, historical metric
@@ -536,6 +770,7 @@ readback, and structured record backfill:
 
 ```bash
 trajectory user-guide backfill
+trajectory user-guide source-provenance
 ```
 
 ## Viewing logs
@@ -550,7 +785,7 @@ trajectory logs -f --grep error      # Follow errors only
 
 ## Markers
 
-Markers are YAML-defined behavioral signals that Trajectory evaluates against captured sessions. They produce points, multi-turn ranges, and measures that can be exported to Datadog as `trajectory.<scope>.<concept>` metrics (where `<scope>` is one of `turn`, `session`, `task`, `commit`, or `pr`). LLM Observability marker evaluations are separate and stay off unless a destination explicitly sets `markers.evaluations: true`.
+Markers are YAML-defined behavioral signals that Trajectory evaluates against captured sessions. They produce points, multi-turn ranges, and measures that can be exported to Datadog as `trajectory.<scope>.<concept>` metrics (where `<scope>` is one of `turn`, `session`, `task`, `commit`, or `pr`). LLM Obs marker evaluations are separate and stay off unless a destination explicitly sets `markers.evaluations: true`.
 
 Read the full guide in [MARKERS.md](MARKERS.md), or from the binary:
 
@@ -576,14 +811,15 @@ trajectory user-guide config         # Configuration deep-dive
 trajectory user-guide llm-capacity   # LLM capacity and expense controls
 trajectory user-guide backfill       # Historical import, local UI repair, and metric backfill
 trajectory user-guide local-ui       # Browser viewer, local-ui, and cache repair
+trajectory user-guide source-provenance # Local-ui source kind and mechanism inventory
 trajectory user-guide publish        # Per-repo publish config
 trajectory user-guide dashboards     # Datadog dashboard export and MCP import
+trajectory user-guide skill-observability # Skill usage and attribution
 trajectory user-guide markers        # Marker authoring and metrics
 trajectory user-guide metrics        # Metric gates, names, tags, and queries
 trajectory user-guide mcp            # MCP tools, resources, and SQL query workflow
 trajectory user-guide query          # Local cache data and guarded MCP SQL workflow
 trajectory user-guide privacy        # Incognito, sensitive tags, and sensitivity scanning
-trajectory user-guide security-event-stream # Managed security event logs
 trajectory user-guide diagnostics    # Doctor, diagnose, audit, validate-spans, support bundles
 trajectory user-guide resume         # Reconstruct captured sessions into other clients
 trajectory user-guide clients        # All supported clients
@@ -602,7 +838,6 @@ trajectory user-guide clients/continue # Continue CLI command shim and session J
 trajectory user-guide clients/mistral-vibe # Mistral Vibe command shim and hook details
 trajectory user-guide clients/codebuff # Codebuff command shim and chat-history import details
 trajectory user-guide clients/qwen   # Qwen Code native HTTP hook details
-trajectory user-guide clients/openhands # OpenHands command hook details
 trajectory user-guide clients/kilo   # Kilo Code plugin and OTLP relay details
 trajectory user-guide clients/kiro   # Kiro CLI agent command hook details
 trajectory user-guide clients/pi     # Pi-specific details
@@ -614,19 +849,29 @@ trajectory user-guide install        # Installation methods
 
 Every span and metric emitted by trajectory carries a `trajectory.user` tag set to your Unix username. Override it with the `TRAJECTORY_USER` environment variable.
 
-Trajectory can also emit `trajectory.user_email` when configured. Resolution uses the first successful value: `TRAJECTORY_USER_EMAIL`, then `identity.user_email`, then `identity.user_email_command`, then `identity.user_email_suffix` appended to `trajectory.user`. Config values follow normal layering first (`config.defaults.yaml`, then `config.yaml`). If both command and suffix are set, the command wins when it returns a valid email; otherwise Trajectory falls through to the suffix.
+Trajectory can also emit `trajectory.user_email` when configured. Resolution uses the first successful value: `TRAJECTORY_USER_EMAIL`, then `identity.user_email`, then `identity.user_email_command`, then `identity.user_email_suffix` appended to `trajectory.user`. Config values follow normal layering first (`config.defaults.yaml`, assigned `cohort.yaml` when present, then `config.yaml`). If both command and suffix are set, the command wins when it returns a valid email; otherwise Trajectory falls through to the suffix.
 
 ```bash
+trajectory setup --clients codex --user-email "$(git config --global user.email)"
+trajectory config set identity.user_email user@example.com
 trajectory config set identity.user_email_suffix datadoghq.com
+trajectory config set identity.user_email_command "git config --global user.email"
+trajectory config reload --yes
+export TRAJECTORY_USER_EMAIL=user@example.com
 ```
 
-GitHub identity tags are optional. `github.email` resolves from `TRAJECTORY_GITHUB_EMAIL`, then `identity.github_email`, then `identity.github_email_command`, then repo-local `git config user.email`, then global `git config user.email`. `github.username` resolves from `TRAJECTORY_GITHUB_USERNAME`, then `identity.github_username`, then `identity.github_username_command`, then repo-local `git config github.user` or `github.username`, then global Git config. Repo-local values win over global values, and commands win over Git config when they return valid values.
+Identity tags are optional. `git.email` resolves from `TRAJECTORY_GITHUB_EMAIL`, then `identity.github_email`, then `identity.github_email_command`, then repo-local `git config user.email`, then global `git config user.email`. `github.username` resolves from `TRAJECTORY_GITHUB_USERNAME`, then `identity.github_username`, then `identity.github_username_command`, then repo-local `git config github.user` or `github.username`, then global Git config. Repo-local values win over global values, and commands win over Git config when they return valid values.
+
+Run `trajectory config reload --yes` after persistent `identity.*` changes and
+confirm with `trajectory ps`; new spans and metrics use the updated tags after
+live serve reloads or safely restarts. Environment overrides apply only to
+processes launched with that environment.
 
 Use these tags to filter in LLM Obs and Metrics Explorer:
 
 - **LLM Obs**: filter traces by `@trajectory.user:<your-name>`
 - **Metrics Explorer**: scope dashboards with `trajectory.user:<your-name>`
-- **GitHub identity**: filter with `github.username:<your-gh-login>` or `github.email:<your-gh-email>` when configured or resolved from Git config
+- **Identity**: filter with `github.username:<your-gh-login>` or `git.email:<your-git-email>` when configured or resolved from Git config
 
 This is useful on shared machines or CI where multiple users generate sessions.
 
@@ -643,10 +888,10 @@ tags:
   workspace: cloud
 ```
 
-These tags are applied at publish time to Datadog LLM Observability spans and
-Trajectory Datadog metric series for base, marker, heartbeat, and task metrics.
-They are not written to local JSONL, and they are not added to OTLP exports,
-Claude native OTLP proxy metrics, or process-level health/privacy counters.
+These tags are applied at publish time to Datadog LLM Obs spans and Trajectory
+DD metric series for base, marker, heartbeat, and task metrics. They are not
+written to local JSONL, and they are not added to OTLP exports, Claude native
+OTLP proxy metrics, or process-level health/privacy counters.
 
 User and managed `tags:` maps are additive. When the same key appears in both,
 the managed `config.defaults.yaml` value wins. Destination-level `tags:` in
@@ -659,16 +904,22 @@ user/email/GitHub attribution instead of custom keys.
 
 ## Repo tags on metrics
 
-Trajectory automatically tags every DD metric with repository metadata extracted from the git remote:
+Trajectory enriches session-scoped DD metrics with bounded repository labels:
 
-- `repo` - repository name (e.g., `trajectory`)
-- `owner` - org or user (e.g., `DataDog`)
-- `git_remote_host` - host (e.g., `github.com`)
+- `repo` - Git repository name when Trajectory can parse the remote origin;
+  otherwise the project directory basename; `unknown` when neither is available.
+- `owner` - org or user from the parsed Git remote; `unknown` for fallback repo
+  labels.
+- `git_remote_host` - Git remote host from the parsed origin; `unknown` for
+  fallback repo labels.
+- `trajectory.repo_source` - provenance for the repo labels:
+  `git_origin`, `git_origin_unparsed`, `project_dir`, `configured`, or
+  `unknown`.
 
-These tags appear on all metric series, so you can filter and group by
-repository in Metrics Explorer without any configuration. When a remote origin
-is unavailable, Trajectory falls back to the project directory basename for
-`repo` when possible and uses `unknown` for unavailable owner or host values.
+For high-trust repository dashboards, filter `trajectory.repo_source:git_origin`
+before grouping by `repo` or `owner`. Use `trajectory.repo_source:project_dir`
+or `unknown` to audit fallback coverage instead of mixing fallback labels into
+repo rankings.
 
 ## Completed-sample distributions
 
@@ -680,9 +931,12 @@ Trajectory publishes distribution metrics for completed samples that are useful 
 - `trajectory.turn.duration_ms.total` - duration of a completed turn when the client provides or Trajectory can derive it.
 - `trajectory.turn.permission_wait_ms.total` - estimated human approval wait inside a completed turn, emitted when Trajectory can derive a permission wait interval.
 - `trajectory.turn.duration_ms.excluding_permission_wait.total` - completed-turn duration minus derivable permission wait, useful when you want agent elapsed time with approval waits removed.
+- `trajectory.turn.permission_prompts` - permission prompt counts split by `decision`, `permission_mode`, and `approval_path` (`manual_prompt`, `auto_mode_prompt`, `auto_classifier`, or bounded fallbacks). Legacy inferred tool accepts use `permission_mode:not_captured`; `unknown` is reserved for source data that is missing or malformed.
 - `trajectory.session.turns.total`, `trajectory.session.tool_uses.total`, `trajectory.session.cost.usd.total`, `trajectory.session.web_search.requests.total`, `trajectory.session.web_search.cost.usd.total`, and `trajectory.session.compactions.total` - completed-session samples.
 - `trajectory.session.web_search.requests` and `trajectory.session.web_search.cost.usd.accumulated` - running and final observed WebSearch request and cost gauges.
-- `trajectory.pr.cost.usd.attributed.total`, `trajectory.pr.attributed_turns.total`, and `trajectory.pr.containing_session.cost.usd.total` - completed-PR samples for PR cost attribution dashboards.
+- `trajectory.pr.cost.usd.attributed.total`, `trajectory.pr.attributed_turns.total`, and `trajectory.pr.containing_session.cost.usd.total` - completed-PR samples for PR cost attribution dashboards. When Trajectory extracts the PR/MR URL, these carry `change_host`, `owner`, `repo`, and `change_number`.
+- `trajectory.turn.prs` - one count sample for the turn that created a PR/MR, tagged with PR/MR identity, `session_id`, and `trajectory.turn_id`.
+- `trajectory.pr.contexts.total`, `trajectory.pr.work_turns.total`, `trajectory.pr.work_duration_ms.total`, and `trajectory.turn.pr_contexts` - existing-PR/MR work context metrics from prompt URLs, PR/MR creation output, common `gh pr ...` / `glab mr ...` output, and managed enrichment markers. These carry `change_host`, `owner`, `repo`, `change_number`, `context_source`, and `signal_confidence` when Trajectory has normalized identity.
 - `trajectory.session.last_seen.unix` - latest observed session event time as Unix seconds, useful for recency-sorted session tables. Enable Historical Metrics Ingestion for this gauge before replaying sessions older than one hour.
 
 For Claude Code comparisons, treat these as the qualified active-time breakout:
@@ -699,4 +953,4 @@ Marker compute blocks (`sum` and `count` over turn windows) enable per-commit co
 
 This powers the `trajectory.commit.cost.usd.total` and `trajectory.commit.attributed_turns.total` distribution metrics, letting you answer "how much did this commit cost?" and percentile questions such as p95 cost per commit in Metrics Explorer, optionally split by the `branch` tag.
 
-PR attribution metrics remain aggregate-only. Trajectory emits `trajectory.pr.cost.usd.attributed.total` for the cost attributed to turns that contributed to a PR, `trajectory.pr.attributed_turns.total` for the number of attributed turns, and `trajectory.pr.containing_session.cost.usd.total` for the total cost of sessions that contained PR activity. Managed installs may separately enable `pr_attribution` structured records for PR/MR drilldown; repo configs and security destinations cannot enable those records.
+PR attribution metrics support direct PR-to-session lookup when a GitHub-compatible `/pull/<number>` URL or GitLab-compatible `/-/merge_requests/<number>` URL is visible in the successful `gh pr create` or `glab mr create` output, including enterprise/self-hosted hosts. Trajectory emits `trajectory.pr.cost.usd.attributed.total` for the cost attributed to turns that contributed to new PR creation, `trajectory.pr.attributed_turns.total` for those creation-tail turns, `trajectory.pr.containing_session.cost.usd.total` for the total cost of sessions that contained PR creation activity, and `trajectory.turn.prs` for the exact PR/MR creation turn. Existing-PR work uses `trajectory.pr.contexts.total`, `trajectory.pr.work_turns.total`, `trajectory.pr.work_duration_ms.total`, and `trajectory.turn.pr_contexts`; these are driven by marker ranges that start from prompt URLs, PR/MR CLI output, or managed `pr-context-entered` structural markers. Filter by `change_host`, `owner`, `repo`, and `change_number`, then group by `session_id`, `trajectory.turn_id`, or `context_source` for drilldown. Managed installs may separately enable `pr_attribution` structured records for richer PR/MR drilldown; repo configs and security destinations cannot enable those records.


### PR DESCRIPTION
## Summary
- update public release metadata to v0.5.21
- refresh public docs for metrics, supported clients, user guide, and LLM capacity
- add a public skill observability guide

## Validation
- local public repo checks passed