### PR TITLE
TRA-236: add protected public release publication

### DIFF
--- a/.github/chainguard/trajectory.public-release-publication.sts.yaml
+++ b/.github/chainguard/trajectory.public-release-publication.sts.yaml
@@ -1,0 +1,14 @@
+# Grants the protected source publication workflow a short-lived token to
+# dispatch the target publication gate. It cannot mutate repository contents.
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/trajectory:environment:public-release-publication
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  repository: DataDog/trajectory
+  job_workflow_ref: DataDog/trajectory/\.github/workflows/public-release-publication\.yml@refs/heads/main
+
+permissions:
+  actions: write

--- a/.github/scripts/public_release_mirror.py
+++ b/.github/scripts/public_release_mirror.py
@@ -1,0 +1,1066 @@
+#!/usr/bin/env python3
+"""Publish exact qualified assets into the public GitHub repository."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.client
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+REQUEST_KIND = "trajectory-public-release-mirror-request"
+MANIFEST_KIND = "trajectory-release-asset-manifest"
+PUBLICATION_RECEIPT_KIND = "trajectory-publication-receipt"
+TARGET_RECEIPT_KIND = "trajectory-public-release-receipt"
+VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+HOST_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$")
+PUBLIC_DOWNLOAD_SUFFIXES = (
+    ".actions.githubusercontent.com",
+    ".blob.core.windows.net",
+    ".githubusercontent.com",
+)
+CHUNK_SIZE = 1024 * 1024
+
+
+class MirrorError(RuntimeError):
+    """The source evidence or public release violates the publication contract."""
+
+
+class GitHubAPIError(MirrorError):
+    def __init__(self, method: str, path: str, status: int, detail: str) -> None:
+        super().__init__(f"GitHub API {method} {path} failed: HTTP {status}: {detail}")
+        self.status = status
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+class SafePublicRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        validate_public_download_url(newurl)
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is not None:
+            redirected.remove_header("Authorization")
+        return redirected
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise MirrorError(f"cannot read JSON from {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise MirrorError(f"{path} must contain a JSON object")
+    return value
+
+
+def exact_keys(value: Any, expected: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MirrorError(f"{label} must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise MirrorError(f"{label} keys do not match contract; missing={missing}, extra={extra}")
+    return value
+
+
+def require_string(value: Any, label: str, *, nonempty: bool = True) -> str:
+    if not isinstance(value, str) or (nonempty and not value):
+        raise MirrorError(f"{label} must be a non-empty string")
+    if "\x00" in value:
+        raise MirrorError(f"{label} must not contain NUL")
+    return value
+
+
+def require_positive_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise MirrorError(f"{label} must be a positive integer")
+    return value
+
+
+def validate_contract(contract: dict[str, Any]) -> None:
+    exact_keys(
+        contract,
+        {
+            "schema_version",
+            "kind",
+            "source_identity",
+            "target",
+            "accepted_release_modes",
+            "required_assets",
+            "release",
+            "limits",
+        },
+        "contract",
+    )
+    if contract["schema_version"] != 1:
+        raise MirrorError("contract.schema_version must be 1")
+    if contract["kind"] != "trajectory-public-release-mirror-contract":
+        raise MirrorError("contract.kind is not supported")
+
+    source = exact_keys(
+        contract["source_identity"],
+        {
+            "repository",
+            "workflow_ref",
+            "environment",
+            "event_name",
+            "ref",
+            "read_policy",
+            "request_artifact_prefix",
+        },
+        "contract.source_identity",
+    )
+    for field in source:
+        require_string(source[field], f"contract.source_identity.{field}")
+
+    target = exact_keys(contract["target"], {"repository", "environment", "ref"}, "contract.target")
+    for field in target:
+        require_string(target[field], f"contract.target.{field}")
+
+    if contract["accepted_release_modes"] != ["full"]:
+        raise MirrorError("contract must accept only full releases")
+    assets = contract["required_assets"]
+    if not isinstance(assets, list) or len(assets) != 7 or len(set(assets)) != 7:
+        raise MirrorError("contract.required_assets must contain seven unique names")
+    for name in assets:
+        require_string(name, "contract.required_assets entry")
+        if Path(name).name != name:
+            raise MirrorError(f"asset name must be a basename: {name}")
+    if assets[-1] != "checksums.sha256":
+        raise MirrorError("checksums.sha256 must be the final required asset")
+
+    release = exact_keys(contract["release"], {"prerelease", "make_latest"}, "contract.release")
+    if release != {"prerelease": False, "make_latest": True}:
+        raise MirrorError("contract.release must require non-prerelease and latest")
+
+    limits = exact_keys(
+        contract["limits"],
+        {"max_request_bytes", "max_asset_bytes", "max_total_asset_bytes"},
+        "contract.limits",
+    )
+    for field, value in limits.items():
+        require_positive_int(value, f"contract.limits.{field}")
+    if limits["max_request_bytes"] > 65536:
+        raise MirrorError("contract.limits.max_request_bytes exceeds workflow input safety bound")
+    if limits["max_asset_bytes"] > limits["max_total_asset_bytes"]:
+        raise MirrorError("contract asset size limit exceeds total size limit")
+
+
+def validate_asset_records(
+    records: Any,
+    required_names: list[str],
+    limits: dict[str, int],
+    label: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(records, list) or len(records) != len(required_names):
+        raise MirrorError(f"{label} must contain exactly {len(required_names)} assets")
+    normalized: list[dict[str, Any]] = []
+    total_size = 0
+    for index, record_value in enumerate(records):
+        record = exact_keys(record_value, {"name", "size", "sha256"}, f"{label}[{index}]")
+        name = require_string(record["name"], f"{label}[{index}].name")
+        if name != required_names[index]:
+            raise MirrorError(f"{label} must use canonical asset order")
+        size = require_positive_int(record["size"], f"{label}[{index}].size")
+        if size > limits["max_asset_bytes"]:
+            raise MirrorError(f"{label}[{index}].size exceeds the per-asset limit")
+        total_size += size
+        digest = require_string(record["sha256"], f"{label}[{index}].sha256")
+        if not SHA256_RE.fullmatch(digest):
+            raise MirrorError(f"{label}[{index}].sha256 must be lowercase SHA256")
+        normalized.append({"name": name, "size": size, "sha256": digest})
+    if total_size > limits["max_total_asset_bytes"]:
+        raise MirrorError(f"{label} exceeds the total asset size limit")
+    return normalized
+
+
+def validate_request(
+    request: dict[str, Any],
+    contract: dict[str, Any],
+    *,
+    source_run_id: int,
+    expected_repository: str,
+    expected_target_sha: str,
+) -> dict[str, Any]:
+    validate_contract(contract)
+    exact_keys(
+        request,
+        {
+            "schema_version",
+            "kind",
+            "release_mode",
+            "version",
+            "tag",
+            "source",
+            "target",
+            "release",
+            "asset_manifest",
+            "asset_manifest_sha256",
+            "publication_receipt",
+            "publication_receipt_sha256",
+        },
+        "request",
+    )
+    if request["schema_version"] != 1 or request["kind"] != REQUEST_KIND:
+        raise MirrorError("request schema or kind is not supported")
+    if request["release_mode"] not in contract["accepted_release_modes"]:
+        raise MirrorError("only full releases may be published publicly")
+
+    version = require_string(request["version"], "request.version")
+    if not VERSION_RE.fullmatch(version):
+        raise MirrorError("request.version must be X.Y.Z without a prerelease suffix")
+    tag = require_string(request["tag"], "request.tag")
+    if tag != f"v{version}":
+        raise MirrorError("request.tag must be v followed by request.version")
+
+    source = exact_keys(
+        request["source"],
+        {"repository", "workflow_ref", "environment", "event_name", "ref", "sha", "run_id"},
+        "request.source",
+    )
+    for field in ("repository", "workflow_ref", "environment", "event_name", "ref"):
+        if source[field] != contract["source_identity"][field]:
+            raise MirrorError(f"request.source.{field} does not match the trusted source")
+    source_sha = require_string(source["sha"], "request.source.sha")
+    if not SOURCE_SHA_RE.fullmatch(source_sha):
+        raise MirrorError("request.source.sha must be a lowercase 40-character Git SHA")
+    if require_positive_int(source["run_id"], "request.source.run_id") != source_run_id:
+        raise MirrorError("request.source.run_id does not match the authenticated source run")
+
+    target = exact_keys(request["target"], {"repository", "ref", "sha"}, "request.target")
+    if target["repository"] != contract["target"]["repository"] or target["repository"] != expected_repository:
+        raise MirrorError("request.target.repository does not match this repository")
+    if target["ref"] != contract["target"]["ref"]:
+        raise MirrorError("request.target.ref must be the protected main ref")
+    if target["sha"] != expected_target_sha or not SOURCE_SHA_RE.fullmatch(str(target["sha"])):
+        raise MirrorError("request.target.sha must match the workflow checkout")
+
+    release = exact_keys(
+        request["release"],
+        {
+            "source_release_id",
+            "name",
+            "body",
+            "target_commitish",
+            "prerelease",
+            "make_latest",
+        },
+        "request.release",
+    )
+    require_positive_int(release["source_release_id"], "request.release.source_release_id")
+    require_string(release["name"], "request.release.name")
+    require_string(release["body"], "request.release.body", nonempty=False)
+    if release["target_commitish"] != expected_target_sha:
+        raise MirrorError("request.release.target_commitish must match the workflow checkout")
+    if release["prerelease"] is not False:
+        raise MirrorError("prerelease requests must not publish publicly")
+    if release["make_latest"] is not True:
+        raise MirrorError("full public releases must set latest")
+
+    manifest = exact_keys(
+        request["asset_manifest"],
+        {"schema_version", "kind", "version", "tag", "source_sha", "assets"},
+        "request.asset_manifest",
+    )
+    if manifest["schema_version"] != 1 or manifest["kind"] != MANIFEST_KIND:
+        raise MirrorError("request.asset_manifest schema or kind is not supported")
+    if manifest["version"] != version or manifest["tag"] != tag or manifest["source_sha"] != source_sha:
+        raise MirrorError("request.asset_manifest identity does not match the request")
+    assets = validate_asset_records(
+        manifest["assets"],
+        contract["required_assets"],
+        contract["limits"],
+        "request.asset_manifest.assets",
+    )
+    manifest_sha = require_string(request["asset_manifest_sha256"], "request.asset_manifest_sha256")
+    if not SHA256_RE.fullmatch(manifest_sha) or sha256_bytes(canonical_json(manifest)) != manifest_sha:
+        raise MirrorError("request.asset_manifest_sha256 does not match the canonical manifest")
+
+    receipt = exact_keys(
+        request["publication_receipt"],
+        {
+            "schema_version",
+            "kind",
+            "status",
+            "release_mode",
+            "version",
+            "tag",
+            "source_sha",
+            "source_run_id",
+            "published_at",
+            "asset_manifest_sha256",
+            "assets",
+            "release_metadata",
+        },
+        "request.publication_receipt",
+    )
+    if receipt["schema_version"] != 1 or receipt["kind"] != PUBLICATION_RECEIPT_KIND:
+        raise MirrorError("request.publication_receipt schema or kind is not supported")
+    if receipt["status"] != "published" or receipt["release_mode"] != "full":
+        raise MirrorError("request.publication_receipt must prove a completed full publication")
+    expected_identity = (version, tag, source_sha, source_run_id, manifest_sha)
+    actual_identity = (
+        receipt["version"],
+        receipt["tag"],
+        receipt["source_sha"],
+        receipt["source_run_id"],
+        receipt["asset_manifest_sha256"],
+    )
+    if actual_identity != expected_identity:
+        raise MirrorError("request.publication_receipt identity does not match the request")
+    if not TIMESTAMP_RE.fullmatch(str(receipt["published_at"])):
+        raise MirrorError("request.publication_receipt.published_at must be a UTC timestamp")
+    receipt_assets = validate_asset_records(
+        receipt["assets"],
+        contract["required_assets"],
+        contract["limits"],
+        "request.publication_receipt.assets",
+    )
+    if receipt_assets != assets:
+        raise MirrorError("request.publication_receipt assets do not match the manifest")
+
+    release_metadata = exact_keys(
+        receipt["release_metadata"],
+        {"name_sha256", "body_sha256"},
+        "request.publication_receipt.release_metadata",
+    )
+    expected_metadata = {
+        "name_sha256": sha256_bytes(release["name"].encode()),
+        "body_sha256": sha256_bytes(release["body"].encode()),
+    }
+    if release_metadata != expected_metadata:
+        raise MirrorError("request.publication_receipt release metadata does not match the request")
+
+    receipt_sha = require_string(request["publication_receipt_sha256"], "request.publication_receipt_sha256")
+    if not SHA256_RE.fullmatch(receipt_sha) or sha256_bytes(canonical_json(receipt)) != receipt_sha:
+        raise MirrorError("request.publication_receipt_sha256 does not match the canonical receipt")
+    return request
+
+
+def validate_repository_metadata(metadata: dict[str, Any], request: dict[str, Any]) -> None:
+    stable = metadata.get("stable")
+    if not isinstance(stable, dict):
+        raise MirrorError("RELEASES.json must contain stable metadata")
+    expected = {
+        "version": request["version"],
+        "tag": request["tag"],
+        "released_at": request["publication_receipt"]["published_at"],
+    }
+    if stable != expected:
+        raise MirrorError("RELEASES.json stable metadata does not match the publication receipt")
+
+
+def validate_public_download_url(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or parsed.username or parsed.password:
+        raise MirrorError("GitHub download redirect must use credential-free HTTPS")
+    if parsed.port not in (None, 443):
+        raise MirrorError("GitHub download redirect must use the default HTTPS port")
+    if not any(hostname.endswith(suffix) for suffix in PUBLIC_DOWNLOAD_SUFFIXES):
+        raise MirrorError(f"GitHub download redirect uses an unapproved host: {hostname}")
+
+
+def copy_bounded(response: Any, destination: Path, max_bytes: int) -> None:
+    written = 0
+    with destination.open("wb") as handle:
+        while True:
+            chunk = response.read(min(CHUNK_SIZE, max_bytes + 1 - written))
+            if not chunk:
+                break
+            written += len(chunk)
+            if written > max_bytes:
+                raise MirrorError(f"download exceeds the {max_bytes}-byte bound")
+            handle.write(chunk)
+
+
+class GitHubClient:
+    def __init__(self, repository: str, token: str, api_url: str = "https://api.github.com") -> None:
+        if api_url.rstrip("/") != "https://api.github.com":
+            raise MirrorError("public release automation requires the canonical GitHub API")
+        self.repository = repository
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.no_redirect = urllib.request.build_opener(NoRedirect())
+        self.public_download = urllib.request.build_opener(SafePublicRedirect())
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        accept: str = "application/vnd.github+json",
+    ) -> Any:
+        data = canonical_json(payload) if payload is not None else None
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": accept,
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "trajectory-public-release-publication",
+                **({"Content-Type": "application/json"} if data is not None else {}),
+            },
+        )
+        try:
+            return self.no_redirect.open(request, timeout=60)
+        except urllib.error.HTTPError as error:
+            detail = error.read(4096).decode("utf-8", errors="replace")
+            raise GitHubAPIError(method, path, error.code, detail) from error
+        except urllib.error.URLError as error:
+            raise MirrorError(f"GitHub API {method} {path} failed: {error.reason}") from error
+
+    def _json(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        with self._request(method, path, payload=payload) as response:
+            value = json.load(response)
+        if not isinstance(value, dict):
+            raise MirrorError(f"GitHub API {method} {path} returned a non-object")
+        return value
+
+    def _download(self, path: str, destination: Path, max_bytes: int) -> None:
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            method="GET",
+            headers={
+                "Accept": "application/octet-stream",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "trajectory-public-release-publication",
+            },
+        )
+        try:
+            response = self.no_redirect.open(request, timeout=60)
+        except urllib.error.HTTPError as error:
+            if error.code not in (301, 302, 303, 307, 308):
+                detail = error.read(4096).decode("utf-8", errors="replace")
+                raise GitHubAPIError("GET", path, error.code, detail) from error
+            location = error.headers.get("Location")
+            if not location:
+                raise MirrorError("GitHub download redirect omitted Location") from error
+            validate_public_download_url(location)
+            public_request = urllib.request.Request(
+                location,
+                method="GET",
+                headers={"User-Agent": "trajectory-public-release-publication"},
+            )
+            try:
+                response = self.public_download.open(public_request, timeout=60)
+            except (urllib.error.HTTPError, urllib.error.URLError) as public_error:
+                raise MirrorError(f"GitHub public download failed: {public_error}") from public_error
+        except urllib.error.URLError as error:
+            raise MirrorError(f"GitHub API GET {path} failed: {error.reason}") from error
+        with response:
+            copy_bounded(response, destination, max_bytes)
+
+    def get_workflow_run(self, run_id: int) -> dict[str, Any]:
+        return self._json("GET", f"/repos/{self.repository}/actions/runs/{run_id}")
+
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, Any]]:
+        value = self._json(
+            "GET",
+            f"/repos/{self.repository}/actions/runs/{run_id}/artifacts?per_page=100",
+        )
+        artifacts = value.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise MirrorError("source workflow artifacts response is malformed")
+        return artifacts
+
+    def download_artifact(self, artifact_id: int, destination: Path, max_bytes: int) -> None:
+        self._download(
+            f"/repos/{self.repository}/actions/artifacts/{artifact_id}/zip",
+            destination,
+            max_bytes,
+        )
+
+    def get_release(self, release_id: int) -> dict[str, Any]:
+        return self._json("GET", f"/repos/{self.repository}/releases/{release_id}")
+
+    def get_release_by_tag(self, tag: str) -> dict[str, Any] | None:
+        path = f"/repos/{self.repository}/releases/tags/{urllib.parse.quote(tag, safe='')}"
+        try:
+            return self._json("GET", path)
+        except GitHubAPIError as error:
+            if error.status == 404:
+                return None
+            raise
+
+    def get_latest_release(self) -> dict[str, Any]:
+        return self._json("GET", f"/repos/{self.repository}/releases/latest")
+
+    def download_asset(self, asset_id: int, destination: Path, max_bytes: int) -> None:
+        self._download(
+            f"/repos/{self.repository}/releases/assets/{asset_id}",
+            destination,
+            max_bytes,
+        )
+
+    def create_draft_release(self, request: dict[str, Any]) -> dict[str, Any]:
+        return self._json(
+            "POST",
+            f"/repos/{self.repository}/releases",
+            payload={
+                "tag_name": request["tag"],
+                "target_commitish": request["release"]["target_commitish"],
+                "name": request["release"]["name"],
+                "body": request["release"]["body"],
+                "draft": True,
+                "prerelease": False,
+                "generate_release_notes": False,
+            },
+        )
+
+    def upload_asset(self, release_id: int, name: str, source: Path) -> dict[str, Any]:
+        connection = http.client.HTTPSConnection("uploads.github.com", timeout=120)
+        path = (
+            f"/repos/{self.repository}/releases/{release_id}/assets?"
+            + urllib.parse.urlencode({"name": name})
+        )
+        content_type = (
+            "application/vnd.microsoft.portable-executable"
+            if name.endswith(".exe")
+            else "application/octet-stream"
+        )
+        try:
+            connection.putrequest("POST", path)
+            connection.putheader("Accept", "application/vnd.github+json")
+            connection.putheader("Authorization", f"Bearer {self.token}")
+            connection.putheader("Content-Type", content_type)
+            connection.putheader("Content-Length", str(source.stat().st_size))
+            connection.putheader("X-GitHub-Api-Version", "2022-11-28")
+            connection.putheader("User-Agent", "trajectory-public-release-publication")
+            connection.endheaders()
+            with source.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(CHUNK_SIZE), b""):
+                    connection.send(chunk)
+            response = connection.getresponse()
+            body = response.read()
+        finally:
+            connection.close()
+        if response.status != 201:
+            detail = body[:4096].decode("utf-8", errors="replace")
+            raise GitHubAPIError("POST", path, response.status, detail)
+        try:
+            value = json.loads(body)
+        except json.JSONDecodeError as error:
+            raise MirrorError("GitHub asset upload returned invalid JSON") from error
+        if not isinstance(value, dict):
+            raise MirrorError("GitHub asset upload returned a non-object")
+        return value
+
+    def publish_release(self, release_id: int) -> dict[str, Any]:
+        return self._json(
+            "PATCH",
+            f"/repos/{self.repository}/releases/{release_id}",
+            payload={"draft": False, "prerelease": False, "make_latest": "true"},
+        )
+
+
+def request_json_url(url: str, headers: dict[str, str]) -> dict[str, Any]:
+    request = urllib.request.Request(url, method="GET", headers=headers)
+    opener = urllib.request.build_opener(NoRedirect())
+    try:
+        with opener.open(request, timeout=60) as response:
+            value = json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read(4096).decode("utf-8", errors="replace")
+        raise MirrorError(f"token exchange request failed: HTTP {error.code}: {detail}") from error
+    except (urllib.error.URLError, json.JSONDecodeError) as error:
+        raise MirrorError(f"token exchange request failed: {error}") from error
+    if not isinstance(value, dict):
+        raise MirrorError("token exchange returned a non-object")
+    return value
+
+
+def exchange_source_token(contract: dict[str, Any]) -> str:
+    domain = require_string(os.environ.get("OCTO_STS_DOMAIN"), "OCTO_STS_DOMAIN")
+    audience = require_string(os.environ.get("OCTO_STS_AUDIENCE"), "OCTO_STS_AUDIENCE")
+    oidc_url = require_string(
+        os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL"),
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+    )
+    oidc_request_token = require_string(
+        os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    )
+    if not HOST_RE.fullmatch(domain) or "/" in domain:
+        raise MirrorError("OCTO_STS_DOMAIN must be a hostname without a URL scheme")
+    parsed_oidc = urllib.parse.urlparse(oidc_url)
+    if parsed_oidc.scheme != "https" or not (parsed_oidc.hostname or "").endswith(
+        ".actions.githubusercontent.com"
+    ):
+        raise MirrorError("GitHub OIDC request URL is not trusted")
+    query = urllib.parse.parse_qsl(parsed_oidc.query, keep_blank_values=True)
+    query.append(("audience", audience))
+    oidc_request_url = urllib.parse.urlunparse(
+        parsed_oidc._replace(query=urllib.parse.urlencode(query))
+    )
+    oidc = request_json_url(
+        oidc_request_url,
+        {"Authorization": f"Bearer {oidc_request_token}"},
+    )
+    oidc_token = require_string(oidc.get("value"), "GitHub OIDC token")
+    exchange_url = (
+        f"https://{domain}/sts/exchange?"
+        + urllib.parse.urlencode(
+            {
+                "scope": contract["source_identity"]["repository"],
+                "identity": contract["source_identity"]["read_policy"],
+            }
+        )
+    )
+    exchanged = request_json_url(
+        exchange_url,
+        {"Authorization": f"Bearer {oidc_token}"},
+    )
+    return require_string(exchanged.get("token"), "Octo STS source token")
+
+
+def validate_source_run(
+    source_client: Any,
+    contract: dict[str, Any],
+    source_run_id: int,
+) -> dict[str, Any]:
+    run: dict[str, Any] | None = None
+    for attempt in range(13):
+        run = source_client.get_workflow_run(source_run_id)
+        if run.get("status") == "completed":
+            break
+        if attempt == 12:
+            raise MirrorError("source publication workflow did not reach a terminal state")
+        time.sleep(5)
+    assert run is not None
+    source = contract["source_identity"]
+    repository = run.get("repository")
+    if not isinstance(repository, dict) or repository.get("full_name") != source["repository"]:
+        raise MirrorError("source workflow run repository does not match the trusted source")
+    expected_path = source["workflow_ref"].split("@", 1)[0].split(source["repository"] + "/", 1)[1]
+    expected_branch = source["ref"].removeprefix("refs/heads/")
+    expected = {
+        "event": source["event_name"],
+        "path": expected_path,
+        "head_branch": expected_branch,
+        "status": "completed",
+        "conclusion": "success",
+    }
+    for field, value in expected.items():
+        if run.get(field) != value:
+            raise MirrorError(f"source workflow run {field} does not match the trusted source")
+    head_sha = run.get("head_sha")
+    if not isinstance(head_sha, str) or not SOURCE_SHA_RE.fullmatch(head_sha):
+        raise MirrorError("source workflow run head SHA is invalid")
+    return run
+
+
+def load_authenticated_request(
+    source_client: Any,
+    contract: dict[str, Any],
+    *,
+    source_run_id: int,
+    request_sha256: str,
+    scratch: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not SHA256_RE.fullmatch(request_sha256):
+        raise MirrorError("request SHA256 must be 64 lowercase hex characters")
+    run = validate_source_run(source_client, contract, source_run_id)
+    expected_name = contract["source_identity"]["request_artifact_prefix"] + request_sha256
+    matches = [
+        artifact
+        for artifact in source_client.list_run_artifacts(source_run_id)
+        if isinstance(artifact, dict) and artifact.get("name") == expected_name
+    ]
+    if len(matches) != 1:
+        raise MirrorError("source run must contain exactly one matching request artifact")
+    artifact = matches[0]
+    if artifact.get("expired") is not False:
+        raise MirrorError("source request artifact is expired")
+    artifact_id = require_positive_int(artifact.get("id"), "source request artifact ID")
+    archive = scratch / "source-request.zip"
+    source_client.download_artifact(
+        artifact_id,
+        archive,
+        max(contract["limits"]["max_request_bytes"] * 4, CHUNK_SIZE),
+    )
+    try:
+        with zipfile.ZipFile(archive) as bundle:
+            entries = [entry for entry in bundle.infolist() if not entry.is_dir()]
+            if len(entries) != 1 or entries[0].filename != "public-release-request.json":
+                raise MirrorError("source request artifact must contain only public-release-request.json")
+            entry = entries[0]
+            if entry.file_size > contract["limits"]["max_request_bytes"]:
+                raise MirrorError("source request exceeds the request size limit")
+            with bundle.open(entry) as handle:
+                raw = handle.read(contract["limits"]["max_request_bytes"] + 1)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise MirrorError(f"source request artifact is not a valid zip: {error}") from error
+    if len(raw) > contract["limits"]["max_request_bytes"]:
+        raise MirrorError("source request exceeds the request size limit")
+    if sha256_bytes(raw) != request_sha256:
+        raise MirrorError("source request artifact SHA256 does not match workflow input")
+    try:
+        request = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise MirrorError(f"source request is not valid JSON: {error}") from error
+    if not isinstance(request, dict):
+        raise MirrorError("source request must be a JSON object")
+    return request, run
+
+
+def validate_release_metadata(
+    release: dict[str, Any],
+    request: dict[str, Any],
+) -> None:
+    expected = {
+        "tag_name": request["tag"],
+        "name": request["release"]["name"],
+        "body": request["release"]["body"],
+        "prerelease": False,
+        "target_commitish": request["release"]["target_commitish"],
+    }
+    for field, value in expected.items():
+        if release.get(field) != value:
+            raise MirrorError(f"GitHub release {field} does not match the request")
+    if release.get("draft") not in (True, False):
+        raise MirrorError("GitHub release draft state is invalid")
+
+
+def release_assets_by_name(release: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise MirrorError("GitHub release assets are missing")
+    by_name: dict[str, dict[str, Any]] = {}
+    for asset in assets:
+        if not isinstance(asset, dict) or not isinstance(asset.get("name"), str):
+            raise MirrorError("GitHub release contains malformed asset metadata")
+        if asset["name"] in by_name:
+            raise MirrorError(f"GitHub release contains duplicate asset: {asset['name']}")
+        by_name[asset["name"]] = asset
+    return by_name
+
+
+def validate_remote_asset(
+    client: Any,
+    asset: dict[str, Any],
+    expected: dict[str, Any],
+    scratch: Path,
+) -> tuple[int, str, int, str]:
+    if asset.get("state") != "uploaded":
+        raise MirrorError(f"GitHub release asset is not uploaded: {expected['name']}")
+    if asset.get("size") != expected["size"]:
+        raise MirrorError(f"GitHub release asset size mismatch: {expected['name']}")
+    asset_id = require_positive_int(asset.get("id"), f"GitHub asset ID for {expected['name']}")
+    api_digest = asset.get("digest")
+    if api_digest not in (None, f"sha256:{expected['sha256']}"):
+        raise MirrorError(f"GitHub release asset API digest mismatch: {expected['name']}")
+    if api_digest is None:
+        destination = scratch / f"verify-{asset_id}-{expected['name']}"
+        client.download_asset(asset_id, destination, expected["size"])
+        if destination.stat().st_size != expected["size"] or sha256_file(destination) != expected["sha256"]:
+            raise MirrorError(f"downloaded asset mismatch: {expected['name']}")
+    return (asset_id, expected["name"], expected["size"], expected["sha256"])
+
+
+def materialize_source_assets(
+    source_client: Any,
+    request: dict[str, Any],
+    contract: dict[str, Any],
+    scratch: Path,
+) -> dict[str, Path]:
+    release = source_client.get_release(request["release"]["source_release_id"])
+    if release.get("id") != request["release"]["source_release_id"]:
+        raise MirrorError("source release ID does not match the request")
+    if release.get("tag_name") != request["tag"]:
+        raise MirrorError("source release tag does not match the request")
+    if release.get("draft") is not False or release.get("prerelease") is not False:
+        raise MirrorError("source release must already be a published full release")
+    by_name = release_assets_by_name(release)
+    required_names = contract["required_assets"]
+    if set(by_name) != set(required_names):
+        raise MirrorError("source release does not contain exactly the seven canonical assets")
+    paths: dict[str, Path] = {}
+    for expected in request["asset_manifest"]["assets"]:
+        validate_remote_asset(source_client, by_name[expected["name"]], expected, scratch)
+        destination = scratch / f"source-{expected['name']}"
+        source_client.download_asset(by_name[expected["name"]]["id"], destination, expected["size"])
+        if destination.stat().st_size != expected["size"] or sha256_file(destination) != expected["sha256"]:
+            raise MirrorError(f"source release asset bytes do not match: {expected['name']}")
+        paths[expected["name"]] = destination
+    checksum_lines = paths["checksums.sha256"].read_text(encoding="ascii").splitlines()
+    binary_assets = request["asset_manifest"]["assets"][:-1]
+    expected_lines = [f"{asset['sha256']}  {asset['name']}" for asset in binary_assets]
+    if checksum_lines != expected_lines:
+        raise MirrorError("checksums.sha256 does not exactly describe the six canonical binaries")
+    return paths
+
+
+def ensure_target_assets(
+    target_client: Any,
+    release: dict[str, Any],
+    request: dict[str, Any],
+    contract: dict[str, Any],
+    source_paths: dict[str, Path],
+    scratch: Path,
+) -> tuple[dict[str, Any], tuple[tuple[int, str, int, str], ...]]:
+    by_name = release_assets_by_name(release)
+    required_names = contract["required_assets"]
+    if not set(by_name).issubset(set(required_names)):
+        raise MirrorError("target release contains an unexpected asset")
+    if release["draft"] is False and set(by_name) != set(required_names):
+        raise MirrorError("published target release is missing a canonical asset")
+
+    expected_by_name = {
+        asset["name"]: asset for asset in request["asset_manifest"]["assets"]
+    }
+    for name, asset in by_name.items():
+        validate_remote_asset(target_client, asset, expected_by_name[name], scratch)
+    if release["draft"]:
+        for name in required_names:
+            if name not in by_name:
+                target_client.upload_asset(release["id"], name, source_paths[name])
+
+    refreshed = target_client.get_release(release["id"])
+    validate_release_metadata(refreshed, request)
+    refreshed_assets = release_assets_by_name(refreshed)
+    if set(refreshed_assets) != set(required_names):
+        raise MirrorError("target draft does not contain exactly the seven canonical assets")
+    fingerprint = tuple(
+        validate_remote_asset(
+            target_client,
+            refreshed_assets[expected["name"]],
+            expected,
+            scratch,
+        )
+        for expected in request["asset_manifest"]["assets"]
+    )
+    return refreshed, fingerprint
+
+
+def publish_target_release(
+    target_client: Any,
+    request: dict[str, Any],
+    contract: dict[str, Any],
+    source_paths: dict[str, Path],
+    scratch: Path,
+) -> tuple[dict[str, Any], str]:
+    release = target_client.get_release_by_tag(request["tag"])
+    action = "verified"
+    if release is None:
+        release = target_client.create_draft_release(request)
+        action = "published"
+    validate_release_metadata(release, request)
+    release, before_assets = ensure_target_assets(
+        target_client,
+        release,
+        request,
+        contract,
+        source_paths,
+        scratch,
+    )
+    if release["draft"]:
+        target_client.publish_release(release["id"])
+        action = "published"
+    latest = target_client.get_latest_release()
+    if latest.get("id") != release["id"] or latest.get("tag_name") != request["tag"]:
+        target_client.publish_release(release["id"])
+        latest = target_client.get_latest_release()
+    if latest.get("id") != release["id"] or latest.get("tag_name") != request["tag"]:
+        raise MirrorError("published release is not GitHub latest")
+
+    final = target_client.get_release(release["id"])
+    validate_release_metadata(final, request)
+    if final.get("draft") is not False or final.get("prerelease") is not False:
+        raise MirrorError("published release state is not a full public release")
+    final_assets = release_assets_by_name(final)
+    if set(final_assets) != set(contract["required_assets"]):
+        raise MirrorError("published release asset set changed during publication")
+    after_assets = tuple(
+        validate_remote_asset(
+            target_client,
+            final_assets[expected["name"]],
+            expected,
+            scratch,
+        )
+        for expected in request["asset_manifest"]["assets"]
+    )
+    if after_assets != before_assets:
+        raise MirrorError("published release assets changed during publication")
+    return final, action
+
+
+def apply_release(
+    *,
+    contract: dict[str, Any],
+    metadata: dict[str, Any],
+    source_run_id: int,
+    request_sha256: str,
+    expected_repository: str,
+    expected_target_sha: str,
+    workflow_run_id: int,
+    source_client: Any,
+    target_client: Any,
+    receipt_out: Path,
+) -> dict[str, Any]:
+    validate_contract(contract)
+    with tempfile.TemporaryDirectory(prefix="trajectory-public-release-") as directory:
+        scratch = Path(directory)
+        request, source_run = load_authenticated_request(
+            source_client,
+            contract,
+            source_run_id=source_run_id,
+            request_sha256=request_sha256,
+            scratch=scratch,
+        )
+        validate_request(
+            request,
+            contract,
+            source_run_id=source_run_id,
+            expected_repository=expected_repository,
+            expected_target_sha=expected_target_sha,
+        )
+        if request["source"]["sha"] != source_run["head_sha"]:
+            raise MirrorError("request source SHA does not match the authenticated source run")
+        validate_repository_metadata(metadata, request)
+        source_paths = materialize_source_assets(source_client, request, contract, scratch)
+        target_release, action = publish_target_release(
+            target_client,
+            request,
+            contract,
+            source_paths,
+            scratch,
+        )
+
+    receipt = {
+        "schema_version": 1,
+        "kind": TARGET_RECEIPT_KIND,
+        "status": action,
+        "version": request["version"],
+        "tag": request["tag"],
+        "source_sha": request["source"]["sha"],
+        "source_run_id": source_run_id,
+        "target_sha": expected_target_sha,
+        "target_release_id": target_release["id"],
+        "workflow_run_id": workflow_run_id,
+        "request_sha256": request_sha256,
+        "asset_manifest_sha256": request["asset_manifest_sha256"],
+        "publication_receipt_sha256": request["publication_receipt_sha256"],
+        "assets": request["asset_manifest"]["assets"],
+        "latest": True,
+    }
+    receipt_out.parent.mkdir(parents=True, exist_ok=True)
+    receipt_out.write_bytes(canonical_json(receipt) + b"\n")
+    return receipt
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-contract")
+    validate.add_argument("--contract", required=True, type=Path)
+
+    apply = subparsers.add_parser("apply")
+    apply.add_argument("--contract", required=True, type=Path)
+    apply.add_argument("--source-run-id", required=True, type=int)
+    apply.add_argument("--request-sha256", required=True)
+    apply.add_argument("--metadata", required=True, type=Path)
+    apply.add_argument("--expected-repository", required=True)
+    apply.add_argument("--expected-target-sha", required=True)
+    apply.add_argument("--workflow-run-id", required=True, type=int)
+    apply.add_argument("--receipt-out", required=True, type=Path)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        contract = load_json(args.contract)
+        validate_contract(contract)
+        if args.command == "validate-contract":
+            return 0
+
+        target_token = os.environ.get("GITHUB_TOKEN")
+        if not target_token:
+            raise MirrorError("GITHUB_TOKEN is required")
+        source_token = exchange_source_token(contract)
+        source_client = GitHubClient(contract["source_identity"]["repository"], source_token)
+        target_client = GitHubClient(args.expected_repository, target_token)
+        receipt = apply_release(
+            contract=contract,
+            metadata=load_json(args.metadata),
+            source_run_id=args.source_run_id,
+            request_sha256=args.request_sha256,
+            expected_repository=args.expected_repository,
+            expected_target_sha=args.expected_target_sha,
+            workflow_run_id=args.workflow_run_id,
+            source_client=source_client,
+            target_client=target_client,
+            receipt_out=args.receipt_out,
+        )
+        print(f"Public GitHub release {receipt['tag']} {receipt['status']} with exact assets")
+        return 0
+    except MirrorError as error:
+        print(f"public release publication failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/public_release_mirror.py
+++ b/.github/scripts/public_release_mirror.py
@@ -27,11 +27,12 @@ SOURCE_PUBLICATION_RECEIPT_KIND = "trajectory.public_release_publication.receipt
 TARGET_RECEIPT_KIND = "trajectory-public-release-receipt"
 SOURCE_REQUEST_FILENAME = "public-release-request.json"
 SOURCE_RECEIPT_FILENAME = "public-release-publication-receipt.json"
+OCTO_STS_DOMAIN = "webhooks.build.datadoghq.com"
+OCTO_STS_AUDIENCE = "dd-octo-sts"
 VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
-HOST_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$")
 PUBLIC_DOWNLOAD_SUFFIXES = (
     ".actions.githubusercontent.com",
     ".blob.core.windows.net",
@@ -906,8 +907,6 @@ def request_json_url(url: str, headers: dict[str, str]) -> dict[str, Any]:
 
 
 def exchange_source_token(contract: dict[str, Any]) -> str:
-    domain = require_string(os.environ.get("OCTO_STS_DOMAIN"), "OCTO_STS_DOMAIN")
-    audience = require_string(os.environ.get("OCTO_STS_AUDIENCE"), "OCTO_STS_AUDIENCE")
     oidc_url = require_string(
         os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL"),
         "ACTIONS_ID_TOKEN_REQUEST_URL",
@@ -916,15 +915,13 @@ def exchange_source_token(contract: dict[str, Any]) -> str:
         os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
         "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
     )
-    if not HOST_RE.fullmatch(domain) or "/" in domain:
-        raise MirrorError("OCTO_STS_DOMAIN must be a hostname without a URL scheme")
     parsed_oidc = urllib.parse.urlparse(oidc_url)
     if parsed_oidc.scheme != "https" or not (parsed_oidc.hostname or "").endswith(
         ".actions.githubusercontent.com"
     ):
         raise MirrorError("GitHub OIDC request URL is not trusted")
     query = urllib.parse.parse_qsl(parsed_oidc.query, keep_blank_values=True)
-    query.append(("audience", audience))
+    query.append(("audience", OCTO_STS_AUDIENCE))
     oidc_request_url = urllib.parse.urlunparse(
         parsed_oidc._replace(query=urllib.parse.urlencode(query))
     )
@@ -934,7 +931,7 @@ def exchange_source_token(contract: dict[str, Any]) -> str:
     )
     oidc_token = require_string(oidc.get("value"), "GitHub OIDC token")
     exchange_url = (
-        f"https://{domain}/sts/exchange?"
+        f"https://{OCTO_STS_DOMAIN}/sts/exchange?"
         + urllib.parse.urlencode(
             {
                 "scope": contract["source_identity"]["repository"],

--- a/.github/scripts/public_release_mirror.py
+++ b/.github/scripts/public_release_mirror.py
@@ -23,7 +23,10 @@ from typing import Any
 REQUEST_KIND = "trajectory-public-release-mirror-request"
 MANIFEST_KIND = "trajectory-release-asset-manifest"
 PUBLICATION_RECEIPT_KIND = "trajectory-publication-receipt"
+SOURCE_PUBLICATION_RECEIPT_KIND = "trajectory.public_release_publication.receipt"
 TARGET_RECEIPT_KIND = "trajectory-public-release-receipt"
+SOURCE_REQUEST_FILENAME = "public-release-request.json"
+SOURCE_RECEIPT_FILENAME = "public-release-publication-receipt.json"
 VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -128,6 +131,12 @@ def require_positive_int(value: Any, label: str) -> int:
     return value
 
 
+def require_nonnegative_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise MirrorError(f"{label} must be a non-negative integer")
+    return value
+
+
 def validate_contract(contract: dict[str, Any]) -> None:
     exact_keys(
         contract,
@@ -157,7 +166,7 @@ def validate_contract(contract: dict[str, Any]) -> None:
             "event_name",
             "ref",
             "read_policy",
-            "request_artifact_prefix",
+            "publication_artifact_prefix",
         },
         "contract.source_identity",
     )
@@ -186,13 +195,20 @@ def validate_contract(contract: dict[str, Any]) -> None:
 
     limits = exact_keys(
         contract["limits"],
-        {"max_request_bytes", "max_asset_bytes", "max_total_asset_bytes"},
+        {
+            "max_request_bytes",
+            "max_source_receipt_bytes",
+            "max_asset_bytes",
+            "max_total_asset_bytes",
+        },
         "contract.limits",
     )
     for field, value in limits.items():
         require_positive_int(value, f"contract.limits.{field}")
     if limits["max_request_bytes"] > 65536:
         raise MirrorError("contract.limits.max_request_bytes exceeds workflow input safety bound")
+    if limits["max_source_receipt_bytes"] > 65536:
+        raise MirrorError("contract.limits.max_source_receipt_bytes exceeds safety bound")
     if limits["max_asset_bytes"] > limits["max_total_asset_bytes"]:
         raise MirrorError("contract asset size limit exceeds total size limit")
 
@@ -230,6 +246,7 @@ def validate_request(
     contract: dict[str, Any],
     *,
     source_run_id: int,
+    expected_source_workflow_sha: str,
     expected_repository: str,
     expected_target_sha: str,
 ) -> dict[str, Any]:
@@ -266,15 +283,34 @@ def validate_request(
 
     source = exact_keys(
         request["source"],
-        {"repository", "workflow_ref", "environment", "event_name", "ref", "sha", "run_id"},
+        {
+            "repository",
+            "workflow_ref",
+            "environment",
+            "event_name",
+            "ref",
+            "sha",
+            "candidate_sha",
+            "run_id",
+        },
         "request.source",
     )
     for field in ("repository", "workflow_ref", "environment", "event_name", "ref"):
         if source[field] != contract["source_identity"][field]:
             raise MirrorError(f"request.source.{field} does not match the trusted source")
-    source_sha = require_string(source["sha"], "request.source.sha")
-    if not SOURCE_SHA_RE.fullmatch(source_sha):
+    source_workflow_sha = require_string(source["sha"], "request.source.sha")
+    if not SOURCE_SHA_RE.fullmatch(source_workflow_sha):
         raise MirrorError("request.source.sha must be a lowercase 40-character Git SHA")
+    if source_workflow_sha != expected_source_workflow_sha:
+        raise MirrorError("request.source.sha does not match the authenticated source run head SHA")
+    candidate_source_sha = require_string(
+        source["candidate_sha"],
+        "request.source.candidate_sha",
+    )
+    if not SOURCE_SHA_RE.fullmatch(candidate_source_sha):
+        raise MirrorError(
+            "request.source.candidate_sha must be a lowercase 40-character Git SHA"
+        )
     if require_positive_int(source["run_id"], "request.source.run_id") != source_run_id:
         raise MirrorError("request.source.run_id does not match the authenticated source run")
 
@@ -315,7 +351,11 @@ def validate_request(
     )
     if manifest["schema_version"] != 1 or manifest["kind"] != MANIFEST_KIND:
         raise MirrorError("request.asset_manifest schema or kind is not supported")
-    if manifest["version"] != version or manifest["tag"] != tag or manifest["source_sha"] != source_sha:
+    if (
+        manifest["version"] != version
+        or manifest["tag"] != tag
+        or manifest["source_sha"] != candidate_source_sha
+    ):
         raise MirrorError("request.asset_manifest identity does not match the request")
     assets = validate_asset_records(
         manifest["assets"],
@@ -349,7 +389,13 @@ def validate_request(
         raise MirrorError("request.publication_receipt schema or kind is not supported")
     if receipt["status"] != "published" or receipt["release_mode"] != "full":
         raise MirrorError("request.publication_receipt must prove a completed full publication")
-    expected_identity = (version, tag, source_sha, source_run_id, manifest_sha)
+    expected_identity = (
+        version,
+        tag,
+        candidate_source_sha,
+        source_run_id,
+        manifest_sha,
+    )
     actual_identity = (
         receipt["version"],
         receipt["tag"],
@@ -386,6 +432,234 @@ def validate_request(
     if not SHA256_RE.fullmatch(receipt_sha) or sha256_bytes(canonical_json(receipt)) != receipt_sha:
         raise MirrorError("request.publication_receipt_sha256 does not match the canonical receipt")
     return request
+
+
+def validate_source_publication_receipt(
+    receipt: dict[str, Any],
+    request: dict[str, Any],
+    contract: dict[str, Any],
+    source_run: dict[str, Any],
+) -> None:
+    exact_keys(
+        receipt,
+        {
+            "schema_version",
+            "kind",
+            "terminal_status",
+            "mode",
+            "binding",
+            "publication",
+            "guarantees",
+            "lifecycle",
+            "blockers",
+            "outcome",
+            "candidate_publication_receipt_sha256",
+            "mutation_summary",
+        },
+        "source publication receipt",
+    )
+    if (
+        receipt["schema_version"] != 1
+        or receipt["kind"] != SOURCE_PUBLICATION_RECEIPT_KIND
+        or receipt["terminal_status"] != "success"
+        or receipt["mode"] != "full"
+        or receipt["blockers"] != []
+    ):
+        raise MirrorError("source publication receipt must prove a successful full publication")
+
+    binding = exact_keys(
+        receipt["binding"],
+        {
+            "repository",
+            "source_sha",
+            "version",
+            "workflow",
+            "readiness",
+            "candidate_build",
+            "pilot",
+            "signed_tag",
+            "candidate_publication",
+        },
+        "source publication receipt.binding",
+    )
+    for field in (
+        "readiness",
+        "candidate_build",
+        "pilot",
+        "signed_tag",
+        "candidate_publication",
+    ):
+        if not isinstance(binding[field], dict):
+            raise MirrorError(f"source publication receipt.binding.{field} must be an object")
+    if (
+        binding["repository"] != contract["source_identity"]["repository"]
+        or binding["repository"] != request["source"]["repository"]
+        or binding["source_sha"] != request["source"]["candidate_sha"]
+        or binding["version"] != request["version"]
+    ):
+        raise MirrorError("source publication receipt release identity does not match the request")
+
+    workflow = exact_keys(
+        binding["workflow"],
+        {
+            "name",
+            "ref",
+            "sha",
+            "default_branch",
+            "dispatch_ref",
+            "dispatch_sha",
+            "run_id",
+            "run_attempt",
+        },
+        "source publication receipt.binding.workflow",
+    )
+    expected_branch = contract["source_identity"]["ref"].removeprefix("refs/heads/")
+    expected_workflow = {
+        "name": source_run["name"],
+        "ref": request["source"]["workflow_ref"],
+        "sha": request["source"]["sha"],
+        "default_branch": expected_branch,
+        "dispatch_ref": request["source"]["ref"],
+        "dispatch_sha": request["source"]["sha"],
+        "run_id": source_run["id"],
+        "run_attempt": source_run["run_attempt"],
+    }
+    if workflow != expected_workflow:
+        raise MirrorError("source publication receipt workflow identity does not match the run")
+
+    publication = exact_keys(
+        receipt["publication"],
+        {
+            "tag",
+            "tag_target",
+            "tag_object_sha",
+            "tag_object_sha256",
+            "tag_signature_verified",
+            "tag_signer_identity",
+            "tag_signer_fingerprint",
+            "tag_trust_sha256",
+            "release_id",
+            "title",
+            "body",
+            "body_sha256",
+            "changelog_path",
+            "prerelease",
+            "latest",
+            "assets",
+            "url",
+        },
+        "source publication receipt.publication",
+    )
+    release = request["release"]
+    if (
+        publication["tag"] != request["tag"]
+        or publication["tag_target"] != request["source"]["candidate_sha"]
+        or publication["release_id"] != release["source_release_id"]
+        or publication["title"] != release["name"]
+        or publication["body"] != release["body"]
+        or publication["body_sha256"]
+        != f"sha256:{sha256_bytes(release['body'].encode())}"
+        or publication["prerelease"] is not False
+        or publication["latest"] is not True
+        or publication["tag_signature_verified"] is not True
+    ):
+        raise MirrorError("source publication receipt stable release metadata does not match")
+    for field in (
+        "tag_object_sha",
+        "tag_object_sha256",
+        "tag_signer_identity",
+        "tag_signer_fingerprint",
+        "tag_trust_sha256",
+        "changelog_path",
+        "url",
+    ):
+        require_string(publication[field], f"source publication receipt.publication.{field}")
+    require_positive_int(publication["release_id"], "source publication receipt.publication.release_id")
+
+    raw_assets = publication["assets"]
+    required_names = contract["required_assets"]
+    if not isinstance(raw_assets, list) or len(raw_assets) != len(required_names):
+        raise MirrorError("source publication receipt must contain exactly seven assets")
+    assets_by_name: dict[str, dict[str, Any]] = {}
+    for index, value in enumerate(raw_assets):
+        asset = exact_keys(
+            value,
+            {"name", "sha256", "size_bytes"},
+            f"source publication receipt.publication.assets[{index}]",
+        )
+        name = require_string(
+            asset["name"],
+            f"source publication receipt.publication.assets[{index}].name",
+        )
+        if name in assets_by_name:
+            raise MirrorError(f"source publication receipt contains duplicate asset: {name}")
+        source_digest = require_string(
+            asset["sha256"],
+            f"source publication receipt.publication.assets[{index}].sha256",
+        )
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", source_digest):
+            raise MirrorError("source publication receipt asset digest is not canonical")
+        assets_by_name[name] = {
+            "name": name,
+            "size": require_positive_int(
+                asset["size_bytes"],
+                f"source publication receipt.publication.assets[{index}].size_bytes",
+            ),
+            "sha256": source_digest.removeprefix("sha256:"),
+        }
+    if set(assets_by_name) != set(required_names):
+        raise MirrorError("source publication receipt does not contain the seven canonical assets")
+    normalized_assets = [assets_by_name[name] for name in required_names]
+    if normalized_assets != request["asset_manifest"]["assets"]:
+        raise MirrorError("source publication receipt assets do not match the request manifest")
+
+    guarantees = exact_keys(
+        receipt["guarantees"],
+        {
+            "rebuild_performed",
+            "asset_uploads",
+            "asset_reuploads",
+            "metadata_only_promotion",
+        },
+        "source publication receipt.guarantees",
+    )
+    if guarantees != {
+        "rebuild_performed": False,
+        "asset_uploads": [],
+        "asset_reuploads": [],
+        "metadata_only_promotion": True,
+    }:
+        raise MirrorError("source publication receipt does not prove metadata-only full promotion")
+
+    lifecycle = exact_keys(
+        receipt["lifecycle"],
+        {"issued_at", "expires_at"},
+        "source publication receipt.lifecycle",
+    )
+    for field in lifecycle:
+        if not TIMESTAMP_RE.fullmatch(str(lifecycle[field])):
+            raise MirrorError(f"source publication receipt.lifecycle.{field} must be a UTC timestamp")
+    if lifecycle["issued_at"] != request["publication_receipt"]["published_at"]:
+        raise MirrorError("source publication receipt timestamp does not match the request")
+
+    candidate_receipt_sha = require_string(
+        receipt["candidate_publication_receipt_sha256"],
+        "source publication receipt.candidate_publication_receipt_sha256",
+    )
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", candidate_receipt_sha):
+        raise MirrorError("source publication receipt candidate digest is not canonical")
+    if receipt["outcome"] not in ("promoted", "idempotent"):
+        raise MirrorError("source publication receipt outcome is not a successful full outcome")
+    mutation = exact_keys(
+        receipt["mutation_summary"],
+        {"count", "metadata_updates"},
+        "source publication receipt.mutation_summary",
+    )
+    require_nonnegative_int(mutation["count"], "source publication receipt.mutation_summary.count")
+    require_nonnegative_int(
+        mutation["metadata_updates"],
+        "source publication receipt.mutation_summary.metadata_updates",
+    )
 
 
 def validate_repository_metadata(metadata: dict[str, Any], request: dict[str, Any]) -> None:
@@ -696,6 +970,7 @@ def validate_source_run(
     expected_path = source["workflow_ref"].split("@", 1)[0].split(source["repository"] + "/", 1)[1]
     expected_branch = source["ref"].removeprefix("refs/heads/")
     expected = {
+        "id": source_run_id,
         "event": source["event_name"],
         "path": expected_path,
         "head_branch": expected_branch,
@@ -708,61 +983,89 @@ def validate_source_run(
     head_sha = run.get("head_sha")
     if not isinstance(head_sha, str) or not SOURCE_SHA_RE.fullmatch(head_sha):
         raise MirrorError("source workflow run head SHA is invalid")
+    require_string(run.get("name"), "source workflow run name")
+    require_positive_int(run.get("run_attempt"), "source workflow run attempt")
     return run
 
 
-def load_authenticated_request(
+def load_authenticated_source_evidence(
     source_client: Any,
     contract: dict[str, Any],
     *,
     source_run_id: int,
     request_sha256: str,
     scratch: Path,
-) -> tuple[dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     if not SHA256_RE.fullmatch(request_sha256):
         raise MirrorError("request SHA256 must be 64 lowercase hex characters")
     run = validate_source_run(source_client, contract, source_run_id)
-    expected_name = contract["source_identity"]["request_artifact_prefix"] + request_sha256
+    expected_name = (
+        contract["source_identity"]["publication_artifact_prefix"]
+        + f"{source_run_id}-{run['run_attempt']}"
+    )
     matches = [
         artifact
         for artifact in source_client.list_run_artifacts(source_run_id)
         if isinstance(artifact, dict) and artifact.get("name") == expected_name
     ]
     if len(matches) != 1:
-        raise MirrorError("source run must contain exactly one matching request artifact")
+        raise MirrorError("source run must contain exactly one matching publication artifact")
     artifact = matches[0]
     if artifact.get("expired") is not False:
-        raise MirrorError("source request artifact is expired")
-    artifact_id = require_positive_int(artifact.get("id"), "source request artifact ID")
-    archive = scratch / "source-request.zip"
+        raise MirrorError("source publication artifact is expired")
+    artifact_id = require_positive_int(artifact.get("id"), "source publication artifact ID")
+    archive = scratch / "source-publication.zip"
+    maximum_bundle_bytes = (
+        contract["limits"]["max_request_bytes"]
+        + contract["limits"]["max_source_receipt_bytes"]
+    )
     source_client.download_artifact(
         artifact_id,
         archive,
-        max(contract["limits"]["max_request_bytes"] * 4, CHUNK_SIZE),
+        max(maximum_bundle_bytes * 4, CHUNK_SIZE),
     )
     try:
         with zipfile.ZipFile(archive) as bundle:
             entries = [entry for entry in bundle.infolist() if not entry.is_dir()]
-            if len(entries) != 1 or entries[0].filename != "public-release-request.json":
-                raise MirrorError("source request artifact must contain only public-release-request.json")
-            entry = entries[0]
-            if entry.file_size > contract["limits"]["max_request_bytes"]:
+            expected_entries = {SOURCE_REQUEST_FILENAME, SOURCE_RECEIPT_FILENAME}
+            if len(entries) != 2 or {entry.filename for entry in entries} != expected_entries:
+                raise MirrorError(
+                    "source publication artifact must contain exactly the request and receipt JSON files"
+                )
+            entries_by_name = {entry.filename: entry for entry in entries}
+            request_entry = entries_by_name[SOURCE_REQUEST_FILENAME]
+            receipt_entry = entries_by_name[SOURCE_RECEIPT_FILENAME]
+            if request_entry.file_size > contract["limits"]["max_request_bytes"]:
                 raise MirrorError("source request exceeds the request size limit")
-            with bundle.open(entry) as handle:
-                raw = handle.read(contract["limits"]["max_request_bytes"] + 1)
+            if receipt_entry.file_size > contract["limits"]["max_source_receipt_bytes"]:
+                raise MirrorError("source publication receipt exceeds the receipt size limit")
+            with bundle.open(request_entry) as handle:
+                raw_request = handle.read(contract["limits"]["max_request_bytes"] + 1)
+            with bundle.open(receipt_entry) as handle:
+                raw_receipt = handle.read(
+                    contract["limits"]["max_source_receipt_bytes"] + 1
+                )
     except (OSError, zipfile.BadZipFile) as error:
-        raise MirrorError(f"source request artifact is not a valid zip: {error}") from error
-    if len(raw) > contract["limits"]["max_request_bytes"]:
+        raise MirrorError(f"source publication artifact is not a valid zip: {error}") from error
+    if len(raw_request) > contract["limits"]["max_request_bytes"]:
         raise MirrorError("source request exceeds the request size limit")
-    if sha256_bytes(raw) != request_sha256:
+    if len(raw_receipt) > contract["limits"]["max_source_receipt_bytes"]:
+        raise MirrorError("source publication receipt exceeds the receipt size limit")
+    if sha256_bytes(raw_request) != request_sha256:
         raise MirrorError("source request artifact SHA256 does not match workflow input")
     try:
-        request = json.loads(raw)
+        request = json.loads(raw_request)
     except json.JSONDecodeError as error:
         raise MirrorError(f"source request is not valid JSON: {error}") from error
+    try:
+        source_receipt = json.loads(raw_receipt)
+    except json.JSONDecodeError as error:
+        raise MirrorError(f"source publication receipt is not valid JSON: {error}") from error
     if not isinstance(request, dict):
         raise MirrorError("source request must be a JSON object")
-    return request, run
+    if not isinstance(source_receipt, dict):
+        raise MirrorError("source publication receipt must be a JSON object")
+    return request, source_receipt, run
 
 
 def validate_release_metadata(
@@ -962,7 +1265,7 @@ def apply_release(
     validate_contract(contract)
     with tempfile.TemporaryDirectory(prefix="trajectory-public-release-") as directory:
         scratch = Path(directory)
-        request, source_run = load_authenticated_request(
+        request, source_receipt, source_run = load_authenticated_source_evidence(
             source_client,
             contract,
             source_run_id=source_run_id,
@@ -973,11 +1276,16 @@ def apply_release(
             request,
             contract,
             source_run_id=source_run_id,
+            expected_source_workflow_sha=source_run["head_sha"],
             expected_repository=expected_repository,
             expected_target_sha=expected_target_sha,
         )
-        if request["source"]["sha"] != source_run["head_sha"]:
-            raise MirrorError("request source SHA does not match the authenticated source run")
+        validate_source_publication_receipt(
+            source_receipt,
+            request,
+            contract,
+            source_run,
+        )
         validate_repository_metadata(metadata, request)
         source_paths = materialize_source_assets(source_client, request, contract, scratch)
         target_release, action = publish_target_release(
@@ -994,8 +1302,10 @@ def apply_release(
         "status": action,
         "version": request["version"],
         "tag": request["tag"],
-        "source_sha": request["source"]["sha"],
+        "candidate_source_sha": request["source"]["candidate_sha"],
+        "source_workflow_sha": request["source"]["sha"],
         "source_run_id": source_run_id,
+        "source_run_attempt": source_run["run_attempt"],
         "target_sha": expected_target_sha,
         "target_release_id": target_release["id"],
         "workflow_run_id": workflow_run_id,

--- a/.github/workflows/public-release-mirror.yml
+++ b/.github/workflows/public-release-mirror.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Validate and publish public release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          OCTO_STS_DOMAIN: ${{ vars.OCTO_STS_DOMAIN }}
-          OCTO_STS_AUDIENCE: ${{ vars.OCTO_STS_AUDIENCE }}
         run: |
           python3 .github/scripts/public_release_mirror.py apply \
             --contract contracts/public-release-mirror-v1.json \

--- a/.github/workflows/public-release-mirror.yml
+++ b/.github/workflows/public-release-mirror.yml
@@ -1,0 +1,56 @@
+name: Public Release Publication
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Source publication workflow run containing the immutable request
+        required: true
+        type: string
+      request_sha256:
+        description: SHA256 of public-release-request.json in the source run
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-release-${{ inputs.source_run_id }}-${{ inputs.request_sha256 }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Validate and publish exact public release
+    runs-on: ubuntu-latest
+    environment: public-release-mirror
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Validate and publish public release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OCTO_STS_DOMAIN: ${{ vars.OCTO_STS_DOMAIN }}
+          OCTO_STS_AUDIENCE: ${{ vars.OCTO_STS_AUDIENCE }}
+        run: |
+          python3 .github/scripts/public_release_mirror.py apply \
+            --contract contracts/public-release-mirror-v1.json \
+            --source-run-id "${{ inputs.source_run_id }}" \
+            --request-sha256 "${{ inputs.request_sha256 }}" \
+            --metadata RELEASES.json \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-target-sha "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --receipt-out "$RUNNER_TEMP/public-release-receipt.json"
+
+      - name: Retain publication receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-release-receipt-${{ inputs.request_sha256 }}
+          path: ${{ runner.temp }}/public-release-receipt.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,7 @@ jobs:
               ".agents/plugins/marketplace.json",
               ".claude-plugin/marketplace.json",
               "RELEASES.json",
+              "contracts/public-release-mirror-v1.json",
               "gemini-extension.json",
               "plugin/trajectory/.claude-plugin/plugin.json",
               "plugin/trajectory/.mcp.json",
@@ -56,5 +57,15 @@ jobs:
           if "Download attempt $attempt of 3 failed" not in installer:
               raise SystemExit("public installer must retain bounded download retries")
           PY
+      - name: Validate protected release publication
+        run: |
+          python3 .github/scripts/public_release_mirror.py validate-contract \
+            --contract contracts/public-release-mirror-v1.json
+          python3 -m unittest discover -s tests -p 'test_*.py' -v
+      - name: Parse workflow and policy YAML
+        run: |
+          ruby -e 'require "yaml"; ARGV.each { |path| YAML.parse_file(path) }' \
+            .github/workflows/*.yml \
+            .github/chainguard/*.yaml
       - name: Validate shell syntax
         run: bash -n install.sh uninstall.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,6 +59,9 @@ jobs:
           PY
       - name: Validate protected release publication
         run: |
+          python3 -m py_compile \
+            .github/scripts/public_release_mirror.py \
+            tests/test_public_release_mirror.py
           python3 .github/scripts/public_release_mirror.py validate-contract \
             --contract contracts/public-release-mirror-v1.json
           python3 -m unittest discover -s tests -p 'test_*.py' -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,16 @@ This repository contains distribution metadata, documentation, and coding-agent 
 
 ```bash
 python3 -m json.tool RELEASES.json >/dev/null
+python3 .github/scripts/public_release_mirror.py validate-contract \
+  --contract contracts/public-release-mirror-v1.json
+python3 -m unittest discover -s tests -p 'test_*.py' -v
+ruby -e 'require "yaml"; ARGV.each { |path| YAML.parse_file(path) }' \
+  .github/workflows/*.yml .github/chainguard/*.yaml
 bash -n install.sh
 ```
 
-These checks validate release metadata JSON and shell syntax for the installer.
+These checks validate release metadata, protected publication contracts,
+workflow and policy syntax, and shell syntax for the installer.
 
 ## Pull Requests
 

--- a/contracts/public-release-mirror-v1.json
+++ b/contracts/public-release-mirror-v1.json
@@ -8,7 +8,7 @@
     "event_name": "workflow_dispatch",
     "ref": "refs/heads/main",
     "read_policy": "trajectory-labs.public-release-read",
-    "request_artifact_prefix": "public-release-request-"
+    "publication_artifact_prefix": "public-release-publication-"
   },
   "target": {
     "repository": "datadog-labs/trajectory",
@@ -33,6 +33,7 @@
   },
   "limits": {
     "max_request_bytes": 49152,
+    "max_source_receipt_bytes": 65536,
     "max_asset_bytes": 300000000,
     "max_total_asset_bytes": 1000000000
   }

--- a/contracts/public-release-mirror-v1.json
+++ b/contracts/public-release-mirror-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "kind": "trajectory-public-release-mirror-contract",
+  "source_identity": {
+    "repository": "DataDog/trajectory",
+    "workflow_ref": "DataDog/trajectory/.github/workflows/public-release-publication.yml@refs/heads/main",
+    "environment": "public-release-publication",
+    "event_name": "workflow_dispatch",
+    "ref": "refs/heads/main",
+    "read_policy": "trajectory-labs.public-release-read",
+    "request_artifact_prefix": "public-release-request-"
+  },
+  "target": {
+    "repository": "datadog-labs/trajectory",
+    "environment": "public-release-mirror",
+    "ref": "refs/heads/main"
+  },
+  "accepted_release_modes": [
+    "full"
+  ],
+  "required_assets": [
+    "trajectory-darwin-amd64",
+    "trajectory-darwin-arm64",
+    "trajectory-darwin-universal",
+    "trajectory-linux-amd64",
+    "trajectory-linux-arm64",
+    "trajectory-windows-amd64.exe",
+    "checksums.sha256"
+  ],
+  "release": {
+    "prerelease": false,
+    "make_latest": true
+  },
+  "limits": {
+    "max_request_bytes": 49152,
+    "max_asset_bytes": 300000000,
+    "max_total_asset_bytes": 1000000000
+  }
+}

--- a/docs/PUBLIC-RELEASE-AUTOMATION.md
+++ b/docs/PUBLIC-RELEASE-AUTOMATION.md
@@ -1,0 +1,84 @@
+# Protected Public Release Publication
+
+Public GitHub Releases are published by
+`.github/workflows/public-release-mirror.yml`. The workflow is a protected,
+full-release-only gate. It does not build, sign, transform, or rename release
+artifacts.
+
+The machine-readable interface is
+[`contracts/public-release-mirror-v1.json`](../contracts/public-release-mirror-v1.json).
+That contract is authoritative for the trusted caller, protected target,
+release mode, and seven canonical assets.
+
+## Publication Sequence
+
+1. The stable entry in `RELEASES.json` lands on `main` with the exact version,
+   tag, and source publication timestamp.
+2. The trusted source workflow exchanges its protected GitHub OIDC identity
+   for a short-lived `actions:write` token under the checked-in Octo STS
+   policy. That token can dispatch this workflow but cannot mutate repository
+   contents or releases.
+3. The source workflow uploads `public-release-request.json` as the immutable
+   source-run artifact named `public-release-request-<sha256>`, then dispatches
+   the target workflow with only the source run ID and request SHA256.
+4. After target-environment approval, the target job uses its own OIDC identity
+   to obtain a short-lived, read-only source token. The reciprocal source
+   policy grants only `actions:read` and `contents:read` to this exact target
+   workflow on `main`.
+5. The target job fetches the request artifact and source GitHub Release,
+   validates the source run, version, tag, source SHA, publication receipt,
+   release title and body, target SHA, exact asset manifest, downloaded asset
+   hashes and sizes, and checksum contents.
+6. Using only its target-scoped job token, the target job creates or resumes a
+   draft release, uploads missing exact assets without overwriting existing
+   ones, publishes the normal GitHub Release, marks it latest, and revalidates
+   the final metadata and asset identities. Replaying the same request verifies
+   the existing release idempotently.
+
+The target environment must allow deployments only from `main`, require
+maintainer approval, and provide the Octo STS domain and audience as protected
+environment variables. No broker URL or credential is stored in this
+repository.
+
+The reciprocal source policy named by the contract must trust only:
+
+```yaml
+subject: repo:datadog-labs/trajectory:environment:public-release-mirror
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  repository: datadog-labs/trajectory
+  job_workflow_ref: datadog-labs/trajectory/\.github/workflows/public-release-mirror\.yml@refs/heads/main
+permissions:
+  actions: read
+  contents: read
+```
+
+The source policy and source request artifact producer must land before this
+workflow is activated. The public workflow fails closed when either is absent.
+
+## Fail-Closed Rules
+
+- Only `full` release requests are accepted. Candidate, prerelease, or
+  suffixed-version requests stop before any target repository mutation.
+- The release must contain exactly the seven contract assets. Missing, extra,
+  duplicate, incomplete, renamed, or reordered assets are rejected.
+- The request must be an immutable artifact from the exact successful source
+  workflow run. Self-asserted source fields or recomputed unkeyed hashes are not
+  accepted as source authentication.
+- Every downloaded byte must stay within the contract size bounds and match
+  the manifest SHA256 and size. The checksum file must contain exactly the six
+  binary basenames in canonical order.
+- The publication receipt must bind the same source SHA, source run, version,
+  tag, manifest, assets, title, and body.
+- Existing assets are never overwritten. Matching partial drafts may resume;
+  published releases succeed only when their metadata and assets match exactly.
+- Download redirects are HTTPS-only, allowlisted, bounded, and never receive a
+  GitHub API authorization header.
+- Final release metadata and asset identities are checked again after
+  publication before a success receipt is written.
+- `RELEASES.json` must already contain matching stable metadata. The workflow
+  does not commit repository metadata.
+
+Successful runs retain a content-bound publication receipt as a GitHub Actions
+artifact for 90 days.

--- a/docs/PUBLIC-RELEASE-AUTOMATION.md
+++ b/docs/PUBLIC-RELEASE-AUTOMATION.md
@@ -18,17 +18,22 @@ release mode, and seven canonical assets.
    for a short-lived `actions:write` token under the checked-in Octo STS
    policy. That token can dispatch this workflow but cannot mutate repository
    contents or releases.
-3. The source workflow uploads `public-release-request.json` as the immutable
-   source-run artifact named `public-release-request-<sha256>`, then dispatches
-   the target workflow with only the source run ID and request SHA256.
+3. The source workflow writes `public-release-request.json` beside its terminal
+   `public-release-publication-receipt.json` in the existing immutable artifact
+   named `public-release-publication-<run_id>-<run_attempt>`, then dispatches the
+   target workflow with only the source run ID and request SHA256. This handoff
+   does not add another source artifact or source CI job.
 4. After target-environment approval, the target job uses its own OIDC identity
    to obtain a short-lived, read-only source token. The reciprocal source
    policy grants only `actions:read` and `contents:read` to this exact target
    workflow on `main`.
-5. The target job fetches the request artifact and source GitHub Release,
-   validates the source run, version, tag, source SHA, publication receipt,
-   release title and body, target SHA, exact asset manifest, downloaded asset
-   hashes and sizes, and checksum contents.
+5. The target job derives the exact artifact name from the authenticated run ID
+   and run attempt, requires exactly the request and terminal receipt files,
+   verifies the request bytes against the dispatched SHA256, and fetches the
+   source GitHub Release. It validates the source run, version, tag, source
+   workflow SHA, candidate source SHA, both publication receipts, release title
+   and body, target SHA, exact asset manifest, downloaded asset hashes and
+   sizes, and checksum contents.
 6. Using only its target-scoped job token, the target job creates or resumes a
    draft release, uploads missing exact assets without overwriting existing
    ones, publishes the normal GitHub Release, marks it latest, and revalidates
@@ -54,8 +59,32 @@ permissions:
   contents: read
 ```
 
-The source policy and source request artifact producer must land before this
+The source policy and source evidence producer must land before this
 workflow is activated. The public workflow fails closed when either is absent.
+
+## Source Identity
+
+The request carries two distinct full Git SHAs under its exact-key `source`
+object:
+
+- `sha` is the source publication workflow commit. It must equal the
+  authenticated source workflow run's `head_sha`.
+- `candidate_sha` is the commit from which the candidate binaries were built.
+  Both `asset_manifest.source_sha` and `publication_receipt.source_sha` must
+  equal this value.
+
+The manifest and publication receipt SHA256 fields cover their canonical JSON
+objects after these candidate bindings are populated. The request artifact
+SHA256 covers the exact request, including both source identities. The retained
+target receipt reports these values separately as `source_workflow_sha` and
+`candidate_source_sha`, along with the authenticated source run attempt; it
+does not emit an ambiguous `source_sha` field.
+
+The separate terminal source receipt must use the successful `full` schema and
+bind the same authenticated run ID, run attempt, workflow SHA, candidate source
+SHA, version, tag, publication timestamp, stable release ID/title/body, and
+seven manifest assets as the request. It must also prove a metadata-only full
+promotion with no rebuild or asset upload.
 
 ## Fail-Closed Rules
 
@@ -63,14 +92,16 @@ workflow is activated. The public workflow fails closed when either is absent.
   suffixed-version requests stop before any target repository mutation.
 - The release must contain exactly the seven contract assets. Missing, extra,
   duplicate, incomplete, renamed, or reordered assets are rejected.
-- The request must be an immutable artifact from the exact successful source
-  workflow run. Self-asserted source fields or recomputed unkeyed hashes are not
-  accepted as source authentication.
+- Source evidence must come from exactly one non-expired artifact named from
+  the authenticated run ID and run attempt. Legacy digest-named artifacts,
+  missing or extra archive files, self-asserted source fields, and request bytes
+  that do not match the dispatched SHA256 are rejected.
 - Every downloaded byte must stay within the contract size bounds and match
   the manifest SHA256 and size. The checksum file must contain exactly the six
   binary basenames in canonical order.
-- The publication receipt must bind the same source SHA, source run, version,
-  tag, manifest, assets, title, and body.
+- The compact request receipt and terminal source receipt must bind the same
+  candidate source SHA, source run, version, tag, manifest, assets, title, body,
+  and source publication timestamp.
 - Existing assets are never overwritten. Matching partial drafts may resume;
   published releases succeed only when their metadata and assets match exactly.
 - Download redirects are HTTPS-only, allowlisted, bounded, and never receive a

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -928,8 +928,6 @@ class PublicReleaseMirrorTests(unittest.TestCase):
             return {"value": "oidc-token"} if len(calls) == 1 else {"token": "source-token"}
 
         environment = {
-            "OCTO_STS_DOMAIN": "sts.example.test",
-            "OCTO_STS_AUDIENCE": "trajectory-public-release",
             "ACTIONS_ID_TOKEN_REQUEST_URL": (
                 "https://pipelines.actions.githubusercontent.com/token?api-version=2.0"
             ),
@@ -943,9 +941,13 @@ class PublicReleaseMirrorTests(unittest.TestCase):
             self.assertEqual(MIRROR.exchange_source_token(self.contract), "source-token")
 
         self.assertEqual(len(calls), 2)
-        self.assertIn("audience=trajectory-public-release", calls[0][0])
+        self.assertIn("audience=dd-octo-sts", calls[0][0])
         self.assertEqual(calls[0][1]["Authorization"], "Bearer runner-token")
-        self.assertTrue(calls[1][0].startswith("https://sts.example.test/sts/exchange?"))
+        self.assertTrue(
+            calls[1][0].startswith(
+                "https://webhooks.build.datadoghq.com/sts/exchange?"
+            )
+        )
         self.assertIn("scope=DataDog%2Ftrajectory", calls[1][0])
         self.assertIn("identity=trajectory-labs.public-release-read", calls[1][0])
         self.assertEqual(calls[1][1]["Authorization"], "Bearer oidc-token")
@@ -1053,8 +1055,8 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("environment: public-release-mirror", workflow)
         self.assertIn("id-token: write", workflow)
-        self.assertIn("OCTO_STS_DOMAIN: ${{ vars.OCTO_STS_DOMAIN }}", workflow)
-        self.assertIn("OCTO_STS_AUDIENCE: ${{ vars.OCTO_STS_AUDIENCE }}", workflow)
+        self.assertNotIn("OCTO_STS_DOMAIN", workflow)
+        self.assertNotIn("OCTO_STS_AUDIENCE", workflow)
         self.assertNotIn("pull_request:", workflow)
         self.assertNotIn("\n  push:", workflow)
         uses = re.findall(r"uses:\s+(\S+)", workflow)

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import tempfile
+import unittest
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / ".github" / "scripts" / "public_release_mirror.py"
+CONTRACT_PATH = ROOT / "contracts" / "public-release-mirror-v1.json"
+SPEC = importlib.util.spec_from_file_location("public_release_mirror", SCRIPT)
+assert SPEC and SPEC.loader
+MIRROR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MIRROR)
+
+SOURCE_SHA = "a" * 40
+TARGET_SHA = "b" * 40
+SOURCE_RUN_ID = 9001
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def canonical_digest(value: Any) -> str:
+    return digest(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
+
+
+def build_fixture(
+    *,
+    release_mode: str = "full",
+    prerelease: bool = False,
+    valid_checksum_manifest: bool = True,
+) -> tuple[dict[str, Any], dict[int, bytes], bytes]:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    binary_names = contract["required_assets"][:-1]
+    contents: dict[str, bytes] = {
+        name: f"fixture bytes for {name}\n".encode() for name in binary_names
+    }
+    checksum_lines = [f"{digest(contents[name])}  {name}" for name in binary_names]
+    if not valid_checksum_manifest:
+        checksum_lines[0] = f"{'0' * 64}  {binary_names[0]}"
+    contents["checksums.sha256"] = ("\n".join(checksum_lines) + "\n").encode()
+
+    assets = [
+        {"name": name, "size": len(contents[name]), "sha256": digest(contents[name])}
+        for name in contract["required_assets"]
+    ]
+    manifest = {
+        "schema_version": 1,
+        "kind": "trajectory-release-asset-manifest",
+        "version": "0.5.28",
+        "tag": "v0.5.28",
+        "source_sha": SOURCE_SHA,
+        "assets": assets,
+    }
+    manifest_sha = canonical_digest(manifest)
+    release = {
+        "source_release_id": 6001,
+        "name": "Trajectory 0.5.28",
+        "body": "Trajectory 0.5.28 public binary release.",
+        "target_commitish": TARGET_SHA,
+        "prerelease": prerelease,
+        "make_latest": True,
+    }
+    publication_receipt = {
+        "schema_version": 1,
+        "kind": "trajectory-publication-receipt",
+        "status": "published",
+        "release_mode": release_mode,
+        "version": "0.5.28",
+        "tag": "v0.5.28",
+        "source_sha": SOURCE_SHA,
+        "source_run_id": SOURCE_RUN_ID,
+        "published_at": "2026-07-25T12:34:56Z",
+        "asset_manifest_sha256": manifest_sha,
+        "assets": copy.deepcopy(assets),
+        "release_metadata": {
+            "name_sha256": digest(release["name"].encode()),
+            "body_sha256": digest(release["body"].encode()),
+        },
+    }
+    request = {
+        "schema_version": 1,
+        "kind": "trajectory-public-release-mirror-request",
+        "release_mode": release_mode,
+        "version": "0.5.28",
+        "tag": "v0.5.28",
+        "source": {
+            "repository": "DataDog/trajectory",
+            "workflow_ref": (
+                "DataDog/trajectory/.github/workflows/"
+                "public-release-publication.yml@refs/heads/main"
+            ),
+            "environment": "public-release-publication",
+            "event_name": "workflow_dispatch",
+            "ref": "refs/heads/main",
+            "sha": SOURCE_SHA,
+            "run_id": SOURCE_RUN_ID,
+        },
+        "target": {
+            "repository": "datadog-labs/trajectory",
+            "ref": "refs/heads/main",
+            "sha": TARGET_SHA,
+        },
+        "release": release,
+        "asset_manifest": manifest,
+        "asset_manifest_sha256": manifest_sha,
+        "publication_receipt": publication_receipt,
+        "publication_receipt_sha256": canonical_digest(publication_receipt),
+    }
+    payloads = {index + 1: contents[name] for index, name in enumerate(contract["required_assets"])}
+    raw = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+    return request, payloads, raw
+
+
+def metadata_for(request: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "stable": {
+            "version": request["version"],
+            "tag": request["tag"],
+            "released_at": request["publication_receipt"]["published_at"],
+        },
+        "beta": {
+            "version": "0.5.27",
+            "tag": "v0.5.27",
+            "released_at": "2026-07-24T19:23:32Z",
+        },
+    }
+
+
+def release_assets(request: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": index + 1,
+            "name": asset["name"],
+            "size": asset["size"],
+            "digest": f"sha256:{asset['sha256']}",
+            "state": "uploaded",
+        }
+        for index, asset in enumerate(request["asset_manifest"]["assets"])
+    ]
+
+
+class FakeSource:
+    def __init__(
+        self,
+        request: dict[str, Any],
+        payloads: dict[int, bytes],
+        raw_request: bytes,
+    ) -> None:
+        self.request = request
+        self.payloads = payloads
+        self.raw_request = raw_request
+        self.request_sha256 = digest(raw_request)
+        self.run = {
+            "id": SOURCE_RUN_ID,
+            "repository": {"full_name": "DataDog/trajectory"},
+            "event": "workflow_dispatch",
+            "path": ".github/workflows/public-release-publication.yml",
+            "head_branch": "main",
+            "head_sha": SOURCE_SHA,
+            "status": "completed",
+            "conclusion": "success",
+        }
+        self.release = {
+            "id": request["release"]["source_release_id"],
+            "tag_name": request["tag"],
+            "name": request["release"]["name"],
+            "body": request["release"]["body"],
+            "target_commitish": SOURCE_SHA,
+            "draft": False,
+            "prerelease": False,
+            "assets": release_assets(request),
+        }
+        self.artifact_name = f"public-release-request-{self.request_sha256}"
+        self.archive_entries = {"public-release-request.json": raw_request}
+
+    def get_workflow_run(self, run_id: int) -> dict[str, Any]:
+        assert run_id == SOURCE_RUN_ID
+        return copy.deepcopy(self.run)
+
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, Any]]:
+        assert run_id == SOURCE_RUN_ID
+        return [{"id": 5001, "name": self.artifact_name, "expired": False}]
+
+    def download_artifact(self, artifact_id: int, destination: Path, max_bytes: int) -> None:
+        assert artifact_id == 5001
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for name, content in self.archive_entries.items():
+                archive.writestr(name, content)
+        if destination.stat().st_size > max_bytes:
+            raise MIRROR.MirrorError("fixture archive exceeded bound")
+
+    def get_release(self, release_id: int) -> dict[str, Any]:
+        assert release_id == self.release["id"]
+        return copy.deepcopy(self.release)
+
+    def download_asset(self, asset_id: int, destination: Path, max_bytes: int) -> None:
+        content = self.payloads[asset_id]
+        if len(content) > max_bytes:
+            raise MIRROR.MirrorError("fixture asset exceeded bound")
+        destination.write_bytes(content)
+
+
+class FakeTarget:
+    def __init__(
+        self,
+        request: dict[str, Any],
+        payloads: dict[int, bytes],
+        *,
+        state: str,
+        latest: bool = False,
+    ) -> None:
+        self.request = request
+        self.payloads: dict[int, bytes] = {}
+        self.next_asset_id = 101
+        self.create_calls = 0
+        self.publish_calls = 0
+        self.upload_calls: list[str] = []
+        self.mutate_after_publish: str | None = None
+        if state == "absent":
+            self.release: dict[str, Any] | None = None
+        else:
+            self.release = self._release(draft=state == "draft")
+            for index, source_asset in enumerate(request["asset_manifest"]["assets"]):
+                target_id = self.release["assets"][index]["id"]
+                self.payloads[target_id] = payloads[index + 1]
+        self.latest = (
+            copy.deepcopy(self.release)
+            if latest and self.release is not None
+            else {"id": 1, "tag_name": "v0.5.27"}
+        )
+
+    def _release(self, *, draft: bool) -> dict[str, Any]:
+        return {
+            "id": 7001,
+            "tag_name": self.request["tag"],
+            "name": self.request["release"]["name"],
+            "body": self.request["release"]["body"],
+            "target_commitish": TARGET_SHA,
+            "draft": draft,
+            "prerelease": False,
+            "assets": [
+                {
+                    **asset,
+                    "id": 100 + index,
+                }
+                for index, asset in enumerate(release_assets(self.request), start=1)
+            ],
+        }
+
+    def get_release_by_tag(self, tag: str) -> dict[str, Any] | None:
+        assert tag == self.request["tag"]
+        return copy.deepcopy(self.release)
+
+    def create_draft_release(self, request: dict[str, Any]) -> dict[str, Any]:
+        assert self.release is None
+        self.create_calls += 1
+        self.release = {
+            "id": 7001,
+            "tag_name": request["tag"],
+            "name": request["release"]["name"],
+            "body": request["release"]["body"],
+            "target_commitish": request["release"]["target_commitish"],
+            "draft": True,
+            "prerelease": False,
+            "assets": [],
+        }
+        return copy.deepcopy(self.release)
+
+    def upload_asset(self, release_id: int, name: str, source: Path) -> dict[str, Any]:
+        assert self.release is not None and release_id == self.release["id"]
+        expected = next(
+            asset for asset in self.request["asset_manifest"]["assets"] if asset["name"] == name
+        )
+        content = source.read_bytes()
+        assert len(content) == expected["size"] and digest(content) == expected["sha256"]
+        asset = {
+            "id": self.next_asset_id,
+            "name": name,
+            "size": len(content),
+            "digest": f"sha256:{digest(content)}",
+            "state": "uploaded",
+        }
+        self.next_asset_id += 1
+        self.release["assets"].append(asset)
+        self.payloads[asset["id"]] = content
+        self.upload_calls.append(name)
+        return copy.deepcopy(asset)
+
+    def get_release(self, release_id: int) -> dict[str, Any]:
+        assert self.release is not None and release_id == self.release["id"]
+        return copy.deepcopy(self.release)
+
+    def publish_release(self, release_id: int) -> dict[str, Any]:
+        assert self.release is not None and release_id == self.release["id"]
+        self.publish_calls += 1
+        self.release["draft"] = False
+        self.release["prerelease"] = False
+        if self.mutate_after_publish == "asset":
+            self.release["assets"][0]["id"] += 1000
+        elif self.mutate_after_publish == "metadata":
+            self.release["body"] = "changed after validation"
+        self.latest = copy.deepcopy(self.release)
+        return copy.deepcopy(self.release)
+
+    def get_latest_release(self) -> dict[str, Any]:
+        return copy.deepcopy(self.latest)
+
+    def download_asset(self, asset_id: int, destination: Path, max_bytes: int) -> None:
+        content = self.payloads[asset_id]
+        if len(content) > max_bytes:
+            raise MIRROR.MirrorError("fixture asset exceeded bound")
+        destination.write_bytes(content)
+
+
+class PublicReleaseMirrorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    def apply(
+        self,
+        request: dict[str, Any],
+        payloads: dict[int, bytes],
+        raw: bytes,
+        target: FakeTarget,
+        *,
+        source: FakeSource | None = None,
+        metadata: dict[str, Any] | None = None,
+        request_sha256: str | None = None,
+    ) -> dict[str, Any]:
+        source = source or FakeSource(request, payloads, raw)
+        with tempfile.TemporaryDirectory() as directory:
+            return MIRROR.apply_release(
+                contract=self.contract,
+                metadata=metadata if metadata is not None else metadata_for(request),
+                source_run_id=SOURCE_RUN_ID,
+                request_sha256=request_sha256 or digest(raw),
+                expected_repository="datadog-labs/trajectory",
+                expected_target_sha=TARGET_SHA,
+                workflow_run_id=8001,
+                source_client=source,
+                target_client=target,
+                receipt_out=Path(directory) / "receipt.json",
+            )
+
+    def test_contract_accepts_only_full_and_exactly_seven_bounded_assets(self) -> None:
+        MIRROR.validate_contract(self.contract)
+        self.assertEqual(self.contract["accepted_release_modes"], ["full"])
+        self.assertEqual(len(self.contract["required_assets"]), 7)
+        self.assertLessEqual(self.contract["limits"]["max_request_bytes"], 65536)
+
+    def test_candidate_and_prerelease_requests_fail_before_target_mutation(self) -> None:
+        cases = (
+            build_fixture(release_mode="candidate"),
+            build_fixture(prerelease=True),
+        )
+        for request, payloads, raw in cases:
+            with self.subTest(mode=request["release_mode"], prerelease=request["release"]["prerelease"]):
+                target = FakeTarget(request, payloads, state="absent")
+                with self.assertRaises(MIRROR.MirrorError):
+                    self.apply(request, payloads, raw, target)
+                self.assertEqual(target.create_calls, 0)
+                self.assertEqual(target.publish_calls, 0)
+
+    def test_request_must_come_from_exact_authenticated_source_run_artifact(self) -> None:
+        request, payloads, raw = build_fixture()
+        source = FakeSource(request, payloads, raw)
+        target = FakeTarget(request, payloads, state="absent")
+        source.run["path"] = ".github/workflows/other.yml"
+        with self.assertRaisesRegex(MIRROR.MirrorError, "run path"):
+            self.apply(request, payloads, raw, target, source=source)
+        self.assertEqual(target.create_calls, 0)
+
+        forged = copy.deepcopy(request)
+        forged["source"]["sha"] = "f" * 40
+        forged_raw = json.dumps(forged, sort_keys=True, separators=(",", ":")).encode()
+        source = FakeSource(request, payloads, raw)
+        with self.assertRaisesRegex(MIRROR.MirrorError, "exactly one matching"):
+            self.apply(
+                forged,
+                payloads,
+                forged_raw,
+                target,
+                source=source,
+                request_sha256=digest(forged_raw),
+            )
+        self.assertEqual(target.create_calls, 0)
+
+    def test_source_sha_and_publication_receipt_are_bound_to_source_run(self) -> None:
+        request, payloads, _ = build_fixture()
+        request["source"]["sha"] = "f" * 40
+        request["asset_manifest"]["source_sha"] = "f" * 40
+        request["publication_receipt"]["source_sha"] = "f" * 40
+        request["asset_manifest_sha256"] = canonical_digest(request["asset_manifest"])
+        request["publication_receipt"]["asset_manifest_sha256"] = request["asset_manifest_sha256"]
+        request["publication_receipt_sha256"] = canonical_digest(request["publication_receipt"])
+        raw = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+        target = FakeTarget(request, payloads, state="absent")
+        with self.assertRaisesRegex(MIRROR.MirrorError, "authenticated source run"):
+            self.apply(request, payloads, raw, target)
+        self.assertEqual(target.create_calls, 0)
+
+    def test_absent_target_release_is_created_uploaded_and_published(self) -> None:
+        request, payloads, raw = build_fixture()
+        target = FakeTarget(request, payloads, state="absent")
+        receipt = self.apply(request, payloads, raw, target)
+        self.assertEqual(receipt["status"], "published")
+        self.assertEqual(target.create_calls, 1)
+        self.assertEqual(target.upload_calls, self.contract["required_assets"])
+        self.assertEqual(target.publish_calls, 1)
+
+    def test_existing_published_latest_release_is_idempotently_verified(self) -> None:
+        request, payloads, raw = build_fixture()
+        target = FakeTarget(request, payloads, state="published", latest=True)
+        receipt = self.apply(request, payloads, raw, target)
+        self.assertEqual(receipt["status"], "verified")
+        self.assertEqual(target.create_calls, 0)
+        self.assertEqual(target.upload_calls, [])
+        self.assertEqual(target.publish_calls, 0)
+
+    def test_partial_draft_resumes_without_overwriting_existing_assets(self) -> None:
+        request, payloads, raw = build_fixture()
+        target = FakeTarget(request, payloads, state="draft")
+        assert target.release is not None
+        kept = target.release["assets"][:2]
+        kept_ids = {asset["id"] for asset in kept}
+        target.release["assets"] = kept
+        target.payloads = {
+            asset_id: content
+            for asset_id, content in target.payloads.items()
+            if asset_id in kept_ids
+        }
+        self.apply(request, payloads, raw, target)
+        self.assertEqual(target.upload_calls, self.contract["required_assets"][2:])
+        self.assertEqual(target.publish_calls, 1)
+
+    def test_existing_release_mismatch_never_overwrites(self) -> None:
+        cases = ("metadata", "extra", "digest", "size")
+        for case in cases:
+            request, payloads, raw = build_fixture()
+            target = FakeTarget(request, payloads, state="draft")
+            assert target.release is not None
+            if case == "metadata":
+                target.release["name"] = "Different title"
+            elif case == "extra":
+                target.release["assets"].append(
+                    {
+                        "id": 999,
+                        "name": "unexpected",
+                        "size": 1,
+                        "digest": f"sha256:{'0' * 64}",
+                        "state": "uploaded",
+                    }
+                )
+            elif case == "digest":
+                target.release["assets"][0]["digest"] = f"sha256:{'0' * 64}"
+            else:
+                target.release["assets"][0]["size"] += 1
+            with self.subTest(case=case), self.assertRaises(MIRROR.MirrorError):
+                self.apply(request, payloads, raw, target)
+            self.assertEqual(target.upload_calls, [])
+            self.assertEqual(target.publish_calls, 0)
+
+    def test_post_publish_asset_or_metadata_race_fails_receipt(self) -> None:
+        for mutation in ("asset", "metadata"):
+            request, payloads, raw = build_fixture()
+            target = FakeTarget(request, payloads, state="draft")
+            target.mutate_after_publish = mutation
+            with self.subTest(mutation=mutation), self.assertRaises(MIRROR.MirrorError):
+                self.apply(request, payloads, raw, target)
+
+    def test_source_release_and_checksum_bytes_must_match_manifest(self) -> None:
+        request, payloads, raw = build_fixture()
+        source = FakeSource(request, payloads, raw)
+        source.payloads[1] = b"different bytes"
+        target = FakeTarget(request, payloads, state="absent")
+        with self.assertRaisesRegex(MIRROR.MirrorError, "source release asset bytes"):
+            self.apply(request, payloads, raw, target, source=source)
+        self.assertEqual(target.create_calls, 0)
+
+        request, payloads, raw = build_fixture(valid_checksum_manifest=False)
+        target = FakeTarget(request, payloads, state="absent")
+        with self.assertRaisesRegex(MIRROR.MirrorError, "checksums.sha256"):
+            self.apply(request, payloads, raw, target)
+        self.assertEqual(target.create_calls, 0)
+
+    def test_public_metadata_comes_from_authenticated_receipt_not_source_release_copy(self) -> None:
+        request, payloads, raw = build_fixture()
+        source = FakeSource(request, payloads, raw)
+        source.release["name"] = "Source publication"
+        source.release["body"] = "Source-side release record"
+        target = FakeTarget(request, payloads, state="absent")
+        self.apply(request, payloads, raw, target, source=source)
+        assert target.release is not None
+        self.assertEqual(target.release["name"], request["release"]["name"])
+        self.assertEqual(target.release["body"], request["release"]["body"])
+
+    def test_repository_metadata_must_match_stable_receipt(self) -> None:
+        request, payloads, raw = build_fixture()
+        target = FakeTarget(request, payloads, state="absent")
+        metadata = metadata_for(request)
+        metadata["stable"]["version"] = "0.5.27"
+        with self.assertRaisesRegex(MIRROR.MirrorError, "stable metadata"):
+            self.apply(request, payloads, raw, target, metadata=metadata)
+        self.assertEqual(target.create_calls, 0)
+
+    def test_redirects_strip_authorization_and_reject_untrusted_hosts(self) -> None:
+        request = urllib.request.Request(
+            "https://api.github.com/repos/example/release/assets/1",
+            headers={"Authorization": "Bearer sentinel"},
+        )
+        handler = MIRROR.SafePublicRedirect()
+        redirected = handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "https://release-assets.githubusercontent.com/object",
+        )
+        assert redirected is not None
+        self.assertIsNone(redirected.get_header("Authorization"))
+        with self.assertRaises(MIRROR.MirrorError):
+            handler.redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://example.invalid/object",
+            )
+        self.assertIsNone(
+            MIRROR.NoRedirect().redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://release-assets.githubusercontent.com/object",
+            )
+        )
+
+    def test_source_token_exchange_requests_only_contract_read_policy(self) -> None:
+        calls: list[tuple[str, dict[str, str]]] = []
+
+        def fake_request(url: str, headers: dict[str, str]) -> dict[str, str]:
+            calls.append((url, headers))
+            return {"value": "oidc-token"} if len(calls) == 1 else {"token": "source-token"}
+
+        environment = {
+            "OCTO_STS_DOMAIN": "sts.example.test",
+            "OCTO_STS_AUDIENCE": "trajectory-public-release",
+            "ACTIONS_ID_TOKEN_REQUEST_URL": (
+                "https://pipelines.actions.githubusercontent.com/token?api-version=2.0"
+            ),
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-token",
+        }
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.object(
+            MIRROR,
+            "request_json_url",
+            side_effect=fake_request,
+        ):
+            self.assertEqual(MIRROR.exchange_source_token(self.contract), "source-token")
+
+        self.assertEqual(len(calls), 2)
+        self.assertIn("audience=trajectory-public-release", calls[0][0])
+        self.assertEqual(calls[0][1]["Authorization"], "Bearer runner-token")
+        self.assertTrue(calls[1][0].startswith("https://sts.example.test/sts/exchange?"))
+        self.assertIn("scope=DataDog%2Ftrajectory", calls[1][0])
+        self.assertIn("identity=trajectory-labs.public-release-read", calls[1][0])
+        self.assertEqual(calls[1][1]["Authorization"], "Bearer oidc-token")
+
+    def test_github_client_creates_draft_and_sets_latest_only_on_publish(self) -> None:
+        request, _, _ = build_fixture()
+        client = MIRROR.GitHubClient("datadog-labs/trajectory", "target-token")
+        calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+        def fake_json(
+            method: str,
+            path: str,
+            *,
+            payload: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            calls.append((method, path, payload))
+            return {"id": 7001}
+
+        with mock.patch.object(client, "_json", side_effect=fake_json):
+            client.create_draft_release(request)
+            client.publish_release(7001)
+
+        self.assertEqual(calls[0][0:2], ("POST", "/repos/datadog-labs/trajectory/releases"))
+        self.assertEqual(
+            calls[0][2],
+            {
+                "tag_name": "v0.5.28",
+                "target_commitish": TARGET_SHA,
+                "name": "Trajectory 0.5.28",
+                "body": "Trajectory 0.5.28 public binary release.",
+                "draft": True,
+                "prerelease": False,
+                "generate_release_notes": False,
+            },
+        )
+        self.assertEqual(
+            calls[1],
+            (
+                "PATCH",
+                "/repos/datadog-labs/trajectory/releases/7001",
+                {"draft": False, "prerelease": False, "make_latest": "true"},
+            ),
+        )
+
+    def test_asset_upload_streams_only_to_github_upload_host(self) -> None:
+        class FakeResponse:
+            status = 201
+
+            def read(self) -> bytes:
+                return b'{"id": 123}'
+
+        class FakeConnection:
+            instances: list["FakeConnection"] = []
+
+            def __init__(self, host: str, timeout: int) -> None:
+                self.host = host
+                self.timeout = timeout
+                self.path = ""
+                self.headers: dict[str, str] = {}
+                self.body = bytearray()
+                self.instances.append(self)
+
+            def putrequest(self, method: str, path: str) -> None:
+                self.method = method
+                self.path = path
+
+            def putheader(self, name: str, value: str) -> None:
+                self.headers[name] = value
+
+            def endheaders(self) -> None:
+                return None
+
+            def send(self, chunk: bytes) -> None:
+                self.body.extend(chunk)
+
+            def getresponse(self) -> FakeResponse:
+                return FakeResponse()
+
+            def close(self) -> None:
+                return None
+
+        client = MIRROR.GitHubClient("datadog-labs/trajectory", "target-token")
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "trajectory-linux-amd64"
+            source.write_bytes(b"release bytes")
+            with mock.patch.object(
+                MIRROR.http.client,
+                "HTTPSConnection",
+                FakeConnection,
+            ):
+                client.upload_asset(7001, source.name, source)
+
+        connection = FakeConnection.instances[0]
+        self.assertEqual(connection.host, "uploads.github.com")
+        self.assertEqual(connection.method, "POST")
+        self.assertIn("name=trajectory-linux-amd64", connection.path)
+        self.assertEqual(connection.headers["Authorization"], "Bearer target-token")
+        self.assertEqual(bytes(connection.body), b"release bytes")
+
+    def test_workflow_and_sts_policy_are_narrow_and_pinned(self) -> None:
+        workflow = (ROOT / ".github/workflows/public-release-mirror.yml").read_text()
+        policy = (
+            ROOT / ".github/chainguard/trajectory.public-release-publication.sts.yaml"
+        ).read_text()
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("environment: public-release-mirror", workflow)
+        self.assertIn("id-token: write", workflow)
+        self.assertIn("OCTO_STS_DOMAIN: ${{ vars.OCTO_STS_DOMAIN }}", workflow)
+        self.assertIn("OCTO_STS_AUDIENCE: ${{ vars.OCTO_STS_AUDIENCE }}", workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertNotIn("\n  push:", workflow)
+        uses = re.findall(r"uses:\s+(\S+)", workflow)
+        self.assertTrue(uses)
+        for action in uses:
+            self.assertRegex(action, r"@[0-9a-f]{40}$")
+
+        self.assertIn(
+            "subject: repo:DataDog/trajectory:environment:public-release-publication",
+            policy,
+        )
+        self.assertIn("event_name: workflow_dispatch", policy)
+        self.assertIn("ref: refs/heads/main", policy)
+        self.assertIn("repository: DataDog/trajectory", policy)
+        self.assertIn(
+            r"job_workflow_ref: DataDog/trajectory/\.github/workflows/"
+            r"public-release-publication\.yml@refs/heads/main",
+            policy,
+        )
+        permissions = policy.split("permissions:", 1)[1]
+        self.assertIn("actions: write", permissions)
+        self.assertNotIn("contents:", permissions)
+
+    def test_publication_surface_contains_no_credentials_or_non_github_urls(self) -> None:
+        paths = (
+            ROOT / ".github/workflows/public-release-mirror.yml",
+            ROOT / ".github/chainguard/trajectory.public-release-publication.sts.yaml",
+            ROOT / ".github/scripts/public_release_mirror.py",
+            ROOT / "contracts/public-release-mirror-v1.json",
+            ROOT / "docs/PUBLIC-RELEASE-AUTOMATION.md",
+        )
+        text = "\n".join(path.read_text(encoding="utf-8").lower() for path in paths)
+        for forbidden in (
+            "github_pat_",
+            "ghp_",
+            "dd_api_key",
+            "dd_app_key",
+            "secrets.",
+        ):
+            self.assertNotIn(forbidden, text)
+        for url in re.findall(r"https?://[a-z0-9.-]+", text):
+            self.assertRegex(
+                url,
+                r"^https://(?:api\.github\.com|github\.com|"
+                r"token\.actions\.githubusercontent\.com)$",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -23,9 +23,11 @@ assert SPEC and SPEC.loader
 MIRROR = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MIRROR)
 
-SOURCE_SHA = "a" * 40
+SOURCE_WORKFLOW_SHA = "a" * 40
+CANDIDATE_SOURCE_SHA = "c" * 40
 TARGET_SHA = "b" * 40
 SOURCE_RUN_ID = 9001
+SOURCE_RUN_ATTEMPT = 3
 
 
 def digest(value: bytes) -> str:
@@ -61,7 +63,7 @@ def build_fixture(
         "kind": "trajectory-release-asset-manifest",
         "version": "0.5.28",
         "tag": "v0.5.28",
-        "source_sha": SOURCE_SHA,
+        "source_sha": CANDIDATE_SOURCE_SHA,
         "assets": assets,
     }
     manifest_sha = canonical_digest(manifest)
@@ -80,7 +82,7 @@ def build_fixture(
         "release_mode": release_mode,
         "version": "0.5.28",
         "tag": "v0.5.28",
-        "source_sha": SOURCE_SHA,
+        "source_sha": CANDIDATE_SOURCE_SHA,
         "source_run_id": SOURCE_RUN_ID,
         "published_at": "2026-07-25T12:34:56Z",
         "asset_manifest_sha256": manifest_sha,
@@ -105,7 +107,8 @@ def build_fixture(
             "environment": "public-release-publication",
             "event_name": "workflow_dispatch",
             "ref": "refs/heads/main",
-            "sha": SOURCE_SHA,
+            "sha": SOURCE_WORKFLOW_SHA,
+            "candidate_sha": CANDIDATE_SOURCE_SHA,
             "run_id": SOURCE_RUN_ID,
         },
         "target": {
@@ -152,12 +155,112 @@ def release_assets(request: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def source_publication_receipt(request: dict[str, Any]) -> dict[str, Any]:
+    publication_receipt = request["publication_receipt"]
+    return {
+        "schema_version": 1,
+        "kind": "trajectory.public_release_publication.receipt",
+        "terminal_status": "success",
+        "mode": "full",
+        "binding": {
+            "repository": request["source"]["repository"],
+            "source_sha": request["source"]["candidate_sha"],
+            "version": request["version"],
+            "workflow": {
+                "name": "Public Release Publication",
+                "ref": request["source"]["workflow_ref"],
+                "sha": request["source"]["sha"],
+                "default_branch": "main",
+                "dispatch_ref": request["source"]["ref"],
+                "dispatch_sha": request["source"]["sha"],
+                "run_id": SOURCE_RUN_ID,
+                "run_attempt": SOURCE_RUN_ATTEMPT,
+            },
+            "readiness": {
+                "run_id": "7001",
+                "run_attempt": "1",
+                "receipt_sha256": "sha256:" + "1" * 64,
+                "validation_tag": "release-ci-v0.5.28-ccccccccc",
+            },
+            "candidate_build": {
+                "run_id": 7000,
+                "run_attempt": 1,
+                "receipt_sha256": "sha256:" + "2" * 64,
+                "validation_tag": "release-ci-v0.5.28-ccccccccc",
+            },
+            "pilot": {
+                "aggregate_sha256": "sha256:" + "3" * 64,
+                "artifact_sha256": "sha256:" + "4" * 64,
+                "issued_at": "2026-07-25T12:00:00Z",
+                "expires_at": "2026-07-25T13:00:00Z",
+            },
+            "signed_tag": {
+                "object_sha": "d" * 40,
+                "object_sha256": "sha256:" + "5" * 64,
+                "target": request["source"]["candidate_sha"],
+                "signer_identity": "release-signer",
+                "trust_sha256": "sha256:" + "6" * 64,
+            },
+            "candidate_publication": {
+                "run_id": 8001,
+                "run_attempt": 1,
+                "receipt_sha256": "sha256:" + "7" * 64,
+            },
+        },
+        "publication": {
+            "tag": request["tag"],
+            "tag_target": request["source"]["candidate_sha"],
+            "tag_object_sha": "d" * 40,
+            "tag_object_sha256": "sha256:" + "5" * 64,
+            "tag_signature_verified": True,
+            "tag_signer_identity": "release-signer",
+            "tag_signer_fingerprint": "SHA256:fixture",
+            "tag_trust_sha256": "sha256:" + "6" * 64,
+            "release_id": request["release"]["source_release_id"],
+            "title": request["release"]["name"],
+            "body": request["release"]["body"],
+            "body_sha256": "sha256:" + digest(request["release"]["body"].encode()),
+            "changelog_path": "docs/changelog/v0.5.28.md",
+            "prerelease": False,
+            "latest": True,
+            "assets": sorted(
+                [
+                    {
+                        "name": asset["name"],
+                        "sha256": f"sha256:{asset['sha256']}",
+                        "size_bytes": asset["size"],
+                    }
+                    for asset in request["asset_manifest"]["assets"]
+                ],
+                key=lambda asset: asset["name"],
+            ),
+            "url": "https://github.com/DataDog/trajectory/releases/tag/v0.5.28",
+        },
+        "guarantees": {
+            "rebuild_performed": False,
+            "asset_uploads": [],
+            "asset_reuploads": [],
+            "metadata_only_promotion": True,
+        },
+        "lifecycle": {
+            "issued_at": publication_receipt["published_at"],
+            "expires_at": "2026-07-26T12:34:56Z",
+        },
+        "blockers": [],
+        "outcome": "promoted",
+        "candidate_publication_receipt_sha256": "sha256:" + "7" * 64,
+        "mutation_summary": {"count": 1, "metadata_updates": 1},
+    }
+
+
 class FakeSource:
     def __init__(
         self,
         request: dict[str, Any],
         payloads: dict[int, bytes],
         raw_request: bytes,
+        *,
+        source_receipt: dict[str, Any] | None = None,
     ) -> None:
         self.request = request
         self.payloads = payloads
@@ -167,9 +270,11 @@ class FakeSource:
             "id": SOURCE_RUN_ID,
             "repository": {"full_name": "DataDog/trajectory"},
             "event": "workflow_dispatch",
+            "name": "Public Release Publication",
             "path": ".github/workflows/public-release-publication.yml",
             "head_branch": "main",
-            "head_sha": SOURCE_SHA,
+            "head_sha": SOURCE_WORKFLOW_SHA,
+            "run_attempt": SOURCE_RUN_ATTEMPT,
             "status": "completed",
             "conclusion": "success",
         }
@@ -178,13 +283,21 @@ class FakeSource:
             "tag_name": request["tag"],
             "name": request["release"]["name"],
             "body": request["release"]["body"],
-            "target_commitish": SOURCE_SHA,
+            "target_commitish": CANDIDATE_SOURCE_SHA,
             "draft": False,
             "prerelease": False,
             "assets": release_assets(request),
         }
-        self.artifact_name = f"public-release-request-{self.request_sha256}"
-        self.archive_entries = {"public-release-request.json": raw_request}
+        self.artifact_name = (
+            f"public-release-publication-{SOURCE_RUN_ID}-{SOURCE_RUN_ATTEMPT}"
+        )
+        self.archive_entries = {
+            "public-release-request.json": raw_request,
+            "public-release-publication-receipt.json": json.dumps(
+                source_receipt or source_publication_receipt(request),
+                sort_keys=True,
+            ).encode(),
+        }
 
     def get_workflow_run(self, run_id: int) -> dict[str, Any]:
         assert run_id == SOURCE_RUN_ID
@@ -360,6 +473,14 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         self.assertEqual(self.contract["accepted_release_modes"], ["full"])
         self.assertEqual(len(self.contract["required_assets"]), 7)
         self.assertLessEqual(self.contract["limits"]["max_request_bytes"], 65536)
+        self.assertLessEqual(
+            self.contract["limits"]["max_source_receipt_bytes"],
+            65536,
+        )
+        self.assertEqual(
+            self.contract["source_identity"]["publication_artifact_prefix"],
+            "public-release-publication-",
+        )
 
     def test_candidate_and_prerelease_requests_fail_before_target_mutation(self) -> None:
         cases = (
@@ -387,7 +508,7 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         forged["source"]["sha"] = "f" * 40
         forged_raw = json.dumps(forged, sort_keys=True, separators=(",", ":")).encode()
         source = FakeSource(request, payloads, raw)
-        with self.assertRaisesRegex(MIRROR.MirrorError, "exactly one matching"):
+        with self.assertRaisesRegex(MIRROR.MirrorError, "SHA256"):
             self.apply(
                 forged,
                 payloads,
@@ -398,25 +519,272 @@ class PublicReleaseMirrorTests(unittest.TestCase):
             )
         self.assertEqual(target.create_calls, 0)
 
-    def test_source_sha_and_publication_receipt_are_bound_to_source_run(self) -> None:
+    def test_source_artifact_name_is_derived_from_authenticated_run_attempt(self) -> None:
+        request, payloads, raw = build_fixture()
+        target = FakeTarget(request, payloads, state="absent")
+        for case in ("legacy_name", "different_attempt"):
+            source = FakeSource(request, payloads, raw)
+            if case == "legacy_name":
+                source.artifact_name = f"public-release-request-{source.request_sha256}"
+            else:
+                source.run["run_attempt"] = SOURCE_RUN_ATTEMPT + 1
+            with self.subTest(case=case), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                "exactly one matching publication artifact",
+            ):
+                self.apply(request, payloads, raw, target, source=source)
+            self.assertEqual(target.create_calls, 0)
+
+    def test_source_artifact_requires_exact_request_and_receipt_files(self) -> None:
+        request, payloads, raw = build_fixture()
+        cases = ("missing_receipt", "renamed_receipt", "extra_file")
+        for case in cases:
+            source = FakeSource(request, payloads, raw)
+            receipt_bytes = source.archive_entries.pop(
+                "public-release-publication-receipt.json"
+            )
+            if case == "renamed_receipt":
+                source.archive_entries["receipt.json"] = receipt_bytes
+            elif case == "extra_file":
+                source.archive_entries[
+                    "public-release-publication-receipt.json"
+                ] = receipt_bytes
+                source.archive_entries["unexpected.json"] = b"{}"
+            target = FakeTarget(request, payloads, state="absent")
+            with self.subTest(case=case), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                "exactly the request and receipt JSON files",
+            ):
+                self.apply(request, payloads, raw, target, source=source)
+            self.assertEqual(target.create_calls, 0)
+
+    def test_source_publication_receipt_is_size_bounded(self) -> None:
+        request, payloads, raw = build_fixture()
+        source = FakeSource(request, payloads, raw)
+        source.archive_entries["public-release-publication-receipt.json"] = b" " * (
+            self.contract["limits"]["max_source_receipt_bytes"] + 1
+        )
+        target = FakeTarget(request, payloads, state="absent")
+        with self.assertRaisesRegex(MIRROR.MirrorError, "receipt size limit"):
+            self.apply(request, payloads, raw, target, source=source)
+        self.assertEqual(target.create_calls, 0)
+
+    def test_terminal_source_receipt_binds_full_publication_request(self) -> None:
+        cases = (
+            "terminal_status",
+            "mode",
+            "workflow_sha",
+            "workflow_run_id",
+            "workflow_run_attempt",
+            "candidate_sha",
+            "version",
+            "tag",
+            "tag_target",
+            "release_id",
+            "title",
+            "body",
+            "prerelease",
+            "latest",
+            "published_at",
+            "asset",
+            "asset_count",
+            "asset_schema",
+            "guarantees",
+        )
+        for case in cases:
+            request, payloads, raw = build_fixture()
+            receipt = source_publication_receipt(request)
+            if case == "terminal_status":
+                receipt["terminal_status"] = "blocked"
+            elif case == "mode":
+                receipt["mode"] = "candidate"
+            elif case == "workflow_sha":
+                receipt["binding"]["workflow"]["sha"] = "f" * 40
+            elif case == "workflow_run_id":
+                receipt["binding"]["workflow"]["run_id"] = SOURCE_RUN_ID + 1
+            elif case == "workflow_run_attempt":
+                receipt["binding"]["workflow"]["run_attempt"] = SOURCE_RUN_ATTEMPT + 1
+            elif case == "candidate_sha":
+                receipt["binding"]["source_sha"] = "f" * 40
+            elif case == "version":
+                receipt["binding"]["version"] = "0.5.29"
+            elif case == "tag":
+                receipt["publication"]["tag"] = "v0.5.29"
+            elif case == "tag_target":
+                receipt["publication"]["tag_target"] = "f" * 40
+            elif case == "release_id":
+                receipt["publication"]["release_id"] += 1
+            elif case == "title":
+                receipt["publication"]["title"] = "Different release"
+            elif case == "body":
+                receipt["publication"]["body"] = "Different body"
+            elif case == "prerelease":
+                receipt["publication"]["prerelease"] = True
+            elif case == "latest":
+                receipt["publication"]["latest"] = False
+            elif case == "published_at":
+                receipt["lifecycle"]["issued_at"] = "2026-07-25T12:34:57Z"
+            elif case == "asset":
+                receipt["publication"]["assets"][0]["sha256"] = "sha256:" + "f" * 64
+            elif case == "asset_count":
+                receipt["publication"]["assets"].pop()
+            elif case == "asset_schema":
+                receipt["publication"]["assets"][0]["size"] = receipt["publication"][
+                    "assets"
+                ][0]["size_bytes"]
+            else:
+                receipt["guarantees"]["asset_uploads"] = ["trajectory-linux-amd64"]
+            source = FakeSource(
+                request,
+                payloads,
+                raw,
+                source_receipt=receipt,
+            )
+            target = FakeTarget(request, payloads, state="absent")
+            with self.subTest(case=case), self.assertRaises(MIRROR.MirrorError):
+                self.apply(request, payloads, raw, target, source=source)
+            self.assertEqual(target.create_calls, 0)
+
+    def test_terminal_source_receipt_uses_exact_schema(self) -> None:
+        for case in ("missing", "extra"):
+            request, payloads, raw = build_fixture()
+            receipt = source_publication_receipt(request)
+            if case == "missing":
+                del receipt["mutation_summary"]
+            else:
+                receipt["unexpected"] = True
+            source = FakeSource(
+                request,
+                payloads,
+                raw,
+                source_receipt=receipt,
+            )
+            target = FakeTarget(request, payloads, state="absent")
+            with self.subTest(case=case), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                "source publication receipt keys do not match contract",
+            ):
+                self.apply(request, payloads, raw, target, source=source)
+            self.assertEqual(target.create_calls, 0)
+
+    def test_source_workflow_sha_is_bound_to_authenticated_source_run(self) -> None:
         request, payloads, _ = build_fixture()
         request["source"]["sha"] = "f" * 40
-        request["asset_manifest"]["source_sha"] = "f" * 40
-        request["publication_receipt"]["source_sha"] = "f" * 40
-        request["asset_manifest_sha256"] = canonical_digest(request["asset_manifest"])
-        request["publication_receipt"]["asset_manifest_sha256"] = request["asset_manifest_sha256"]
-        request["publication_receipt_sha256"] = canonical_digest(request["publication_receipt"])
         raw = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
         target = FakeTarget(request, payloads, state="absent")
-        with self.assertRaisesRegex(MIRROR.MirrorError, "authenticated source run"):
+        with self.assertRaisesRegex(MIRROR.MirrorError, "authenticated source run head SHA"):
             self.apply(request, payloads, raw, target)
         self.assertEqual(target.create_calls, 0)
+
+    def test_candidate_source_sha_requires_exact_full_sha_schema(self) -> None:
+        cases = {
+            "missing": None,
+            "renamed": CANDIDATE_SOURCE_SHA,
+            "short": "c" * 39,
+            "uppercase": "C" * 40,
+        }
+        for case, value in cases.items():
+            request, payloads, _ = build_fixture()
+            source_receipt = source_publication_receipt(request)
+            if case == "missing":
+                del request["source"]["candidate_sha"]
+            elif case == "renamed":
+                request["source"]["candidate_source_sha"] = value
+            else:
+                request["source"]["candidate_sha"] = value
+            raw = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+            source = FakeSource(
+                request,
+                payloads,
+                raw,
+                source_receipt=source_receipt,
+            )
+            target = FakeTarget(request, payloads, state="absent")
+            with self.subTest(case=case), self.assertRaises(MIRROR.MirrorError):
+                self.apply(request, payloads, raw, target, source=source)
+            self.assertEqual(target.create_calls, 0)
+
+    def test_manifest_and_publication_receipt_bind_candidate_source_sha(self) -> None:
+        for record in ("manifest", "publication_receipt"):
+            request, payloads, _ = build_fixture()
+            if record == "manifest":
+                request["asset_manifest"]["source_sha"] = "f" * 40
+                request["asset_manifest_sha256"] = canonical_digest(
+                    request["asset_manifest"]
+                )
+                request["publication_receipt"]["asset_manifest_sha256"] = request[
+                    "asset_manifest_sha256"
+                ]
+            else:
+                request["publication_receipt"]["source_sha"] = "f" * 40
+            request["publication_receipt_sha256"] = canonical_digest(
+                request["publication_receipt"]
+            )
+            raw = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+            target = FakeTarget(request, payloads, state="absent")
+            with self.subTest(record=record), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                f"{record} identity",
+            ):
+                self.apply(request, payloads, raw, target)
+            self.assertEqual(target.create_calls, 0)
+
+    def test_candidate_source_identity_changes_require_fresh_canonical_digests(self) -> None:
+        cases = {
+            "manifest": "canonical manifest",
+            "publication_receipt": "canonical receipt",
+        }
+        for record, error in cases.items():
+            request, payloads, _ = build_fixture()
+            request["source"]["candidate_sha"] = "f" * 40
+            request["asset_manifest"]["source_sha"] = "f" * 40
+            request["publication_receipt"]["source_sha"] = "f" * 40
+            if record == "publication_receipt":
+                request["asset_manifest_sha256"] = canonical_digest(
+                    request["asset_manifest"]
+                )
+                request["publication_receipt"]["asset_manifest_sha256"] = request[
+                    "asset_manifest_sha256"
+                ]
+            raw = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+            target = FakeTarget(request, payloads, state="absent")
+            with self.subTest(record=record), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                error,
+            ):
+                self.apply(request, payloads, raw, target)
+            self.assertEqual(target.create_calls, 0)
 
     def test_absent_target_release_is_created_uploaded_and_published(self) -> None:
         request, payloads, raw = build_fixture()
         target = FakeTarget(request, payloads, state="absent")
         receipt = self.apply(request, payloads, raw, target)
         self.assertEqual(receipt["status"], "published")
+        self.assertEqual(
+            set(receipt),
+            {
+                "schema_version",
+                "kind",
+                "status",
+                "version",
+                "tag",
+                "candidate_source_sha",
+                "source_workflow_sha",
+                "source_run_id",
+                "source_run_attempt",
+                "target_sha",
+                "target_release_id",
+                "workflow_run_id",
+                "request_sha256",
+                "asset_manifest_sha256",
+                "publication_receipt_sha256",
+                "assets",
+                "latest",
+            },
+        )
+        self.assertEqual(receipt["candidate_source_sha"], CANDIDATE_SOURCE_SHA)
+        self.assertEqual(receipt["source_workflow_sha"], SOURCE_WORKFLOW_SHA)
+        self.assertEqual(receipt["source_run_attempt"], SOURCE_RUN_ATTEMPT)
         self.assertEqual(target.create_calls, 1)
         self.assertEqual(target.upload_calls, self.contract["required_assets"])
         self.assertEqual(target.publish_calls, 1)


### PR DESCRIPTION
## What does this PR do?

Adds the protected, full-release-only public GitHub Release publication target for TRA-236. The source workflow receives only `actions:write` to dispatch this gate. After environment approval, the target job proves source identity through an immutable source-run request artifact and a reciprocal read-only OIDC token, validates the exact seven assets and bound metadata, creates or resumes a draft without overwriting assets, publishes latest, and revalidates final state. Candidate and prerelease requests fail before target mutation.

The target path is bounded, strips API authorization across download redirects, supports exact idempotent replay, and retains a content-bound publication receipt.

Activation dependencies outside this target PR:
- source policy `trajectory-labs.public-release-read` granting this exact target workflow only `actions:read` and `contents:read`;
- source publication upload of `public-release-request-<sha256>`;
- protected environment variables `OCTO_STS_DOMAIN` and `OCTO_STS_AUDIENCE`.

## Validation

- 18 focused unit/contract tests
- Python compile and Ruff
- Ruby YAML parse and yamllint
- shell syntax validation
- source public-boundary scan: 0 blocked literals
- `git diff --check`
- focused security review findings resolved with regression coverage

## Checklist

- [x] Tests or validation updated
- [x] Documentation updated where needed
- [x] No secrets, local paths, or non-public references included
- [x] Release metadata unchanged because install behavior did not change