### PR TITLE
Harden public release receipt readback

### DIFF
--- a/.github/chainguard/release-controller-read.sts.yaml
+++ b/.github/chainguard/release-controller-read.sts.yaml
@@ -1,0 +1,19 @@
+# Grants one protected release pipeline a short-lived token to correlate the
+# exact target workflow run and read its retained receipt. It cannot mutate
+# repository contents, releases, actions, or workflow state.
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/.*:.*"
+
+claim_pattern:
+  project_id: "10409"
+  ref_type: "branch"
+  ref: "private-release-execution/[A-Za-z0-9._:+-]+"
+  ref_path: "refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
+  ref_protected: "true"
+  pipeline_source: "push"
+  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/[^/]+//.gitlab-ci.yml@refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
+
+permissions:
+  actions: read
+  contents: read

--- a/.github/chainguard/release-controller-read.sts.yaml
+++ b/.github/chainguard/release-controller-read.sts.yaml
@@ -1,18 +1,17 @@
-# Grants one protected release pipeline a short-lived token to correlate the
-# exact target workflow run and read its retained receipt. It cannot mutate
+# Grants one protected GitHub Actions workflow a short-lived token to correlate
+# the exact target workflow run and read its retained receipt. It cannot mutate
 # repository contents, releases, actions, or workflow state.
-issuer: https://gitlab.ddbuild.io
+issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: "project_path:DataDog/.*:.*"
+subject_pattern: "repo:DataDog/.*:.*"
 
 claim_pattern:
-  project_id: "10409"
-  ref_type: "branch"
-  ref: "private-release-execution/[A-Za-z0-9._:+-]+"
-  ref_path: "refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
-  ref_protected: "true"
-  pipeline_source: "push"
-  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/[^/]+//.gitlab-ci.yml@refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
+  repository_id: "1175392283"
+  repository_owner_id: "365230"
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  runner_environment: github-hosted
+  job_workflow_ref: DataDog/[^/]+/\.github/workflows/private-release-execute\.yml@refs/heads/main
 
 permissions:
   actions: read

--- a/.github/workflows/public-release-mirror.yml
+++ b/.github/workflows/public-release-mirror.yml
@@ -1,4 +1,5 @@
 name: Public Release Publication
+run-name: public-release-${{ inputs.source_run_id }}-${{ inputs.request_sha256 }}
 
 on:
   workflow_dispatch:

--- a/docs/PUBLIC-RELEASE-AUTOMATION.md
+++ b/docs/PUBLIC-RELEASE-AUTOMATION.md
@@ -121,12 +121,11 @@ polling by time window or branch alone. The workflow display name is exactly
 `public-release-<source_run_id>-<request_sha256>`, and the retained artifact is
 exactly `public-release-receipt-<request_sha256>`.
 
-The checked-in `release-controller-read` Octo STS policy grants a single
-protected GitLab release-pipeline identity only `actions:read` and
-`contents:read`. Its trust boundary uses the stable project ID plus protected
-push-pipeline, immutable request branch, and branch-bound root CI configuration
-claims; it does not encode the controller project path or any publication
-endpoint.
+The checked-in `release-controller-read` Octo STS policy grants a protected
+GitHub Actions workflow identity only `actions:read` and `contents:read`. Its
+trust boundary uses stable repository and owner IDs, `workflow_dispatch`,
+`main`, a GitHub-hosted runner, and the exact workflow path without encoding
+the controller repository name or any publication endpoint.
 
 After selecting the unique successful target run with the canonical display
 name, the controller must download the exact receipt artifact from that run

--- a/docs/PUBLIC-RELEASE-AUTOMATION.md
+++ b/docs/PUBLIC-RELEASE-AUTOMATION.md
@@ -113,3 +113,28 @@ promotion with no rebuild or asset upload.
 
 Successful runs retain a content-bound publication receipt as a GitHub Actions
 artifact for 90 days.
+
+## Controller Readback
+
+The dispatching release controller can correlate the target run without
+polling by time window or branch alone. The workflow display name is exactly
+`public-release-<source_run_id>-<request_sha256>`, and the retained artifact is
+exactly `public-release-receipt-<request_sha256>`.
+
+The checked-in `release-controller-read` Octo STS policy grants a single
+protected GitLab release-pipeline identity only `actions:read` and
+`contents:read`. Its trust boundary uses the stable project ID plus protected
+push-pipeline, immutable request branch, and branch-bound root CI configuration
+claims; it does not encode the controller project path or any publication
+endpoint.
+
+After selecting the unique successful target run with the canonical display
+name, the controller must download the exact receipt artifact from that run
+and require all three bindings to match:
+
+- `source_run_id` equals the dispatched source run.
+- `request_sha256` equals the dispatched request digest.
+- `workflow_run_id` equals the selected target run.
+
+These bindings make a stale, unrelated, or replayed receipt unusable as
+evidence for a different release transaction.

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -789,6 +789,15 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         self.assertEqual(target.upload_calls, self.contract["required_assets"])
         self.assertEqual(target.publish_calls, 1)
 
+    def test_target_receipt_binds_exact_correlated_workflow_run(self) -> None:
+        request, payloads, raw = build_fixture()
+        target = FakeTarget(request, payloads, state="absent")
+        receipt = self.apply(request, payloads, raw, target)
+
+        self.assertEqual(receipt["source_run_id"], SOURCE_RUN_ID)
+        self.assertEqual(receipt["request_sha256"], digest(raw))
+        self.assertEqual(receipt["workflow_run_id"], 8001)
+
     def test_existing_published_latest_release_is_idempotently_verified(self) -> None:
         request, payloads, raw = build_fixture()
         target = FakeTarget(request, payloads, state="published", latest=True)
@@ -1049,12 +1058,24 @@ class PublicReleaseMirrorTests(unittest.TestCase):
 
     def test_workflow_and_sts_policy_are_narrow_and_pinned(self) -> None:
         workflow = (ROOT / ".github/workflows/public-release-mirror.yml").read_text()
-        policy = (
+        dispatch_policy = (
             ROOT / ".github/chainguard/trajectory.public-release-publication.sts.yaml"
+        ).read_text()
+        read_policy = (
+            ROOT / ".github/chainguard/release-controller-read.sts.yaml"
         ).read_text()
         self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("environment: public-release-mirror", workflow)
         self.assertIn("id-token: write", workflow)
+        self.assertIn(
+            "run-name: public-release-${{ inputs.source_run_id }}-"
+            "${{ inputs.request_sha256 }}",
+            workflow,
+        )
+        self.assertIn(
+            "name: public-release-receipt-${{ inputs.request_sha256 }}",
+            workflow,
+        )
         self.assertNotIn("OCTO_STS_DOMAIN", workflow)
         self.assertNotIn("OCTO_STS_AUDIENCE", workflow)
         self.assertNotIn("pull_request:", workflow)
@@ -1066,23 +1087,49 @@ class PublicReleaseMirrorTests(unittest.TestCase):
 
         self.assertIn(
             "subject: repo:DataDog/trajectory:environment:public-release-publication",
-            policy,
+            dispatch_policy,
         )
-        self.assertIn("event_name: workflow_dispatch", policy)
-        self.assertIn("ref: refs/heads/main", policy)
-        self.assertIn("repository: DataDog/trajectory", policy)
+        self.assertIn("event_name: workflow_dispatch", dispatch_policy)
+        self.assertIn("ref: refs/heads/main", dispatch_policy)
+        self.assertIn("repository: DataDog/trajectory", dispatch_policy)
         self.assertIn(
             r"job_workflow_ref: DataDog/trajectory/\.github/workflows/"
             r"public-release-publication\.yml@refs/heads/main",
-            policy,
+            dispatch_policy,
         )
-        permissions = policy.split("permissions:", 1)[1]
-        self.assertIn("actions: write", permissions)
-        self.assertNotIn("contents:", permissions)
+        dispatch_permissions = dispatch_policy.split("permissions:", 1)[1]
+        self.assertIn("actions: write", dispatch_permissions)
+        self.assertNotIn("contents:", dispatch_permissions)
 
-    def test_publication_surface_contains_no_credentials_or_non_github_urls(self) -> None:
+        expected_read_policy = """\
+# Grants one protected release pipeline a short-lived token to correlate the
+# exact target workflow run and read its retained receipt. It cannot mutate
+# repository contents, releases, actions, or workflow state.
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/.*:.*"
+
+claim_pattern:
+  project_id: "10409"
+  ref_type: "branch"
+  ref: "private-release-execution/[A-Za-z0-9._:+-]+"
+  ref_path: "refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
+  ref_protected: "true"
+  pipeline_source: "push"
+  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/[^/]+//.gitlab-ci.yml@refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
+
+permissions:
+  actions: read
+  contents: read
+"""
+        self.assertEqual(read_policy, expected_read_policy)
+        self.assertNotIn("actions: write", read_policy)
+        self.assertNotIn("contents: write", read_policy)
+
+    def test_publication_surface_contains_no_credentials_or_unexpected_urls(self) -> None:
         paths = (
             ROOT / ".github/workflows/public-release-mirror.yml",
+            ROOT / ".github/chainguard/release-controller-read.sts.yaml",
             ROOT / ".github/chainguard/trajectory.public-release-publication.sts.yaml",
             ROOT / ".github/scripts/public_release_mirror.py",
             ROOT / "contracts/public-release-mirror-v1.json",
@@ -1100,7 +1147,7 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         for url in re.findall(r"https?://[a-z0-9.-]+", text):
             self.assertRegex(
                 url,
-                r"^https://(?:api\.github\.com|github\.com|"
+                r"^https://(?:api\.github\.com|github\.com|gitlab\.ddbuild\.io|"
                 r"token\.actions\.githubusercontent\.com)$",
             )
 

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -1102,21 +1102,20 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         self.assertNotIn("contents:", dispatch_permissions)
 
         expected_read_policy = """\
-# Grants one protected release pipeline a short-lived token to correlate the
-# exact target workflow run and read its retained receipt. It cannot mutate
+# Grants one protected GitHub Actions workflow a short-lived token to correlate
+# the exact target workflow run and read its retained receipt. It cannot mutate
 # repository contents, releases, actions, or workflow state.
-issuer: https://gitlab.ddbuild.io
+issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: "project_path:DataDog/.*:.*"
+subject_pattern: "repo:DataDog/.*:.*"
 
 claim_pattern:
-  project_id: "10409"
-  ref_type: "branch"
-  ref: "private-release-execution/[A-Za-z0-9._:+-]+"
-  ref_path: "refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
-  ref_protected: "true"
-  pipeline_source: "push"
-  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/[^/]+//.gitlab-ci.yml@refs/heads/private-release-execution/[A-Za-z0-9._:+-]+"
+  repository_id: "1175392283"
+  repository_owner_id: "365230"
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  runner_environment: github-hosted
+  job_workflow_ref: DataDog/[^/]+/\\.github/workflows/private-release-execute\\.yml@refs/heads/main
 
 permissions:
   actions: read
@@ -1147,7 +1146,7 @@ permissions:
         for url in re.findall(r"https?://[a-z0-9.-]+", text):
             self.assertRegex(
                 url,
-                r"^https://(?:api\.github\.com|github\.com|gitlab\.ddbuild\.io|"
+                r"^https://(?:api\.github\.com|github\.com|"
                 r"token\.actions\.githubusercontent\.com)$",
             )
 


### PR DESCRIPTION
## What does this PR do?

- adds a read-only GitLab OIDC trust policy for the protected release controller, constrained to project ID `10409`, protected immutable request branches, and branch-bound CI configuration
- gives each target publication run a deterministic name derived from `source_run_id` and `request_sha256`
- documents and tests exact run, artifact, and receipt correlation without changing release assets or publication behavior

Feature flag decision: not needed - release infrastructure only.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py' -v` (27 passed)\n- Python bytecode compilation\n- Ruby YAML parsing for all workflows and STS policies\n- `git diff --check`\n- public automation private-literal scan\n\n## Checklist\n\n- [x] Tests or validation updated\n- [x] Documentation updated where needed\n- [x] No secrets, local paths, or non-public references included\n- [x] Release metadata unchanged because install behavior did not change