### PR TITLE
Fix direct-workflow OIDC claim

### DIFF
--- a/.github/chainguard/release-controller-read.sts.yaml
+++ b/.github/chainguard/release-controller-read.sts.yaml
@@ -11,7 +11,7 @@ claim_pattern:
   event_name: workflow_dispatch
   ref: refs/heads/main
   runner_environment: github-hosted
-  job_workflow_ref: DataDog/[^/]+/\.github/workflows/private-release-execute\.yml@refs/heads/main
+  workflow_ref: DataDog/[^/]+/\.github/workflows/private-release-execute\.yml@refs/heads/main
 
 permissions:
   actions: read

--- a/docs/PUBLIC-RELEASE-AUTOMATION.md
+++ b/docs/PUBLIC-RELEASE-AUTOMATION.md
@@ -125,7 +125,10 @@ The checked-in `release-controller-read` Octo STS policy grants a protected
 GitHub Actions workflow identity only `actions:read` and `contents:read`. Its
 trust boundary uses stable repository and owner IDs, `workflow_dispatch`,
 `main`, a GitHub-hosted runner, and the exact workflow path without encoding
-the controller repository name or any publication endpoint.
+the controller repository name or any publication endpoint. Because the
+controller is a directly dispatched workflow rather than a reusable workflow,
+the policy binds the `workflow_ref` OIDC claim and rejects
+`job_workflow_ref`.
 
 After selecting the unique successful target run with the canonical display
 name, the controller must download the exact receipt artifact from that run

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -1115,13 +1115,14 @@ claim_pattern:
   event_name: workflow_dispatch
   ref: refs/heads/main
   runner_environment: github-hosted
-  job_workflow_ref: DataDog/[^/]+/\\.github/workflows/private-release-execute\\.yml@refs/heads/main
+  workflow_ref: DataDog/[^/]+/\\.github/workflows/private-release-execute\\.yml@refs/heads/main
 
 permissions:
   actions: read
   contents: read
 """
         self.assertEqual(read_policy, expected_read_policy)
+        self.assertNotIn("job_workflow_ref:", read_policy)
         self.assertNotIn("actions: write", read_policy)
         self.assertNotIn("contents: write", read_policy)
 


### PR DESCRIPTION
## Summary
- bind the release-controller read policy to the direct workflow `workflow_ref` claim
- preserve the generic public boundary and read-only permissions
- document the direct versus reusable workflow distinction and prevent `job_workflow_ref` regressions

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py' -v` (27 passed)\n- YAML policy parse and exact permission assertions\n- public-boundary scan\n- `git diff --check`\n\nFeature flag decision: not needed - release authentication policy only.