### PR TITLE
Accept waived pilot mirror evidence

### DIFF
--- a/.github/scripts/public_release_mirror.py
+++ b/.github/scripts/public_release_mirror.py
@@ -242,6 +242,71 @@ def validate_asset_records(
     return normalized
 
 
+def validate_pilot_binding(
+    value: Any,
+    label: str,
+    *,
+    prefixed_digests: bool = False,
+) -> dict[str, Any]:
+    pilot = exact_keys(
+        value,
+        {
+            "status",
+            "aggregate_sha256",
+            "artifact_sha256",
+            "issued_at",
+            "expires_at",
+            "waiver_sha256",
+        },
+        label,
+    )
+    status = require_string(pilot["status"], f"{label}.status")
+    if status not in {"pass", "waived"}:
+        raise MirrorError(f"{label}.status must be pass or waived")
+
+    def validate_digest(field: str, raw: Any) -> str:
+        digest = require_string(raw, f"{label}.{field}")
+        if prefixed_digests:
+            if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+                raise MirrorError(
+                    f"{label}.{field} must be canonical sha256:<64 lowercase hex>"
+                )
+            return digest.removeprefix("sha256:")
+        if not SHA256_RE.fullmatch(digest):
+            raise MirrorError(f"{label}.{field} must be lowercase SHA256")
+        return digest
+
+    normalized = {
+        "status": status,
+        "aggregate_sha256": validate_digest(
+            "aggregate_sha256",
+            pilot["aggregate_sha256"],
+        ),
+        "artifact_sha256": validate_digest(
+            "artifact_sha256",
+            pilot["artifact_sha256"],
+        ),
+        "issued_at": require_string(pilot["issued_at"], f"{label}.issued_at"),
+        "expires_at": require_string(pilot["expires_at"], f"{label}.expires_at"),
+        "waiver_sha256": None,
+    }
+    for field in ("issued_at", "expires_at"):
+        if not TIMESTAMP_RE.fullmatch(normalized[field]):
+            raise MirrorError(f"{label}.{field} must be a UTC timestamp")
+
+    waiver = pilot["waiver_sha256"]
+    if status == "pass":
+        if waiver is not None:
+            raise MirrorError(
+                f"{label}.waiver_sha256 is forbidden when status is pass"
+            )
+    else:
+        if waiver is None:
+            raise MirrorError(f"{label}.waiver_sha256 is required when status is waived")
+        normalized["waiver_sha256"] = validate_digest("waiver_sha256", waiver)
+    return normalized
+
+
 def validate_request(
     request: dict[str, Any],
     contract: dict[str, Any],
@@ -263,6 +328,7 @@ def validate_request(
             "source",
             "target",
             "release",
+            "pilot",
             "asset_manifest",
             "asset_manifest_sha256",
             "publication_receipt",
@@ -345,6 +411,8 @@ def validate_request(
     if release["make_latest"] is not True:
         raise MirrorError("full public releases must set latest")
 
+    pilot = validate_pilot_binding(request["pilot"], "request.pilot")
+
     manifest = exact_keys(
         request["asset_manifest"],
         {"schema_version", "kind", "version", "tag", "source_sha", "assets"},
@@ -382,6 +450,7 @@ def validate_request(
             "published_at",
             "asset_manifest_sha256",
             "assets",
+            "pilot",
             "release_metadata",
         },
         "request.publication_receipt",
@@ -416,6 +485,13 @@ def validate_request(
     )
     if receipt_assets != assets:
         raise MirrorError("request.publication_receipt assets do not match the manifest")
+
+    receipt_pilot = validate_pilot_binding(
+        receipt["pilot"],
+        "request.publication_receipt.pilot",
+    )
+    if receipt_pilot != pilot:
+        raise MirrorError("request pilot copies do not match")
 
     release_metadata = exact_keys(
         receipt["release_metadata"],
@@ -527,6 +603,14 @@ def validate_source_publication_receipt(
     }
     if workflow != expected_workflow:
         raise MirrorError("source publication receipt workflow identity does not match the run")
+
+    source_pilot = validate_pilot_binding(
+        binding["pilot"],
+        "source publication receipt.binding.pilot",
+        prefixed_digests=True,
+    )
+    if source_pilot != request["pilot"]:
+        raise MirrorError("source publication receipt pilot does not match the request")
 
     publication = exact_keys(
         receipt["publication"],

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -38,6 +38,24 @@ def canonical_digest(value: Any) -> str:
     return digest(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
 
 
+def pilot_fixture(status: str = "pass") -> dict[str, Any]:
+    return {
+        "status": status,
+        "aggregate_sha256": "3" * 64,
+        "artifact_sha256": "4" * 64,
+        "issued_at": "2026-07-25T12:00:00Z",
+        "expires_at": "2026-07-25T13:00:00Z",
+        "waiver_sha256": "5" * 64 if status == "waived" else None,
+    }
+
+
+def refresh_request(request: dict[str, Any]) -> bytes:
+    request["publication_receipt_sha256"] = canonical_digest(
+        request["publication_receipt"]
+    )
+    return json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+
+
 def build_fixture(
     *,
     release_mode: str = "full",
@@ -75,6 +93,7 @@ def build_fixture(
         "prerelease": prerelease,
         "make_latest": True,
     }
+    pilot = pilot_fixture()
     publication_receipt = {
         "schema_version": 1,
         "kind": "trajectory-publication-receipt",
@@ -87,6 +106,7 @@ def build_fixture(
         "published_at": "2026-07-25T12:34:56Z",
         "asset_manifest_sha256": manifest_sha,
         "assets": copy.deepcopy(assets),
+        "pilot": copy.deepcopy(pilot),
         "release_metadata": {
             "name_sha256": digest(release["name"].encode()),
             "body_sha256": digest(release["body"].encode()),
@@ -117,6 +137,7 @@ def build_fixture(
             "sha": TARGET_SHA,
         },
         "release": release,
+        "pilot": pilot,
         "asset_manifest": manifest,
         "asset_manifest_sha256": manifest_sha,
         "publication_receipt": publication_receipt,
@@ -189,10 +210,20 @@ def source_publication_receipt(request: dict[str, Any]) -> dict[str, Any]:
                 "validation_tag": "release-ci-v0.5.28-ccccccccc",
             },
             "pilot": {
-                "aggregate_sha256": "sha256:" + "3" * 64,
-                "artifact_sha256": "sha256:" + "4" * 64,
-                "issued_at": "2026-07-25T12:00:00Z",
-                "expires_at": "2026-07-25T13:00:00Z",
+                "status": request["pilot"]["status"],
+                "aggregate_sha256": (
+                    "sha256:" + request["pilot"]["aggregate_sha256"]
+                ),
+                "artifact_sha256": (
+                    "sha256:" + request["pilot"]["artifact_sha256"]
+                ),
+                "issued_at": request["pilot"]["issued_at"],
+                "expires_at": request["pilot"]["expires_at"],
+                "waiver_sha256": (
+                    "sha256:" + request["pilot"]["waiver_sha256"]
+                    if request["pilot"]["waiver_sha256"] is not None
+                    else None
+                ),
             },
             "signed_tag": {
                 "object_sha": "d" * 40,
@@ -481,6 +512,127 @@ class PublicReleaseMirrorTests(unittest.TestCase):
             self.contract["source_identity"]["publication_artifact_prefix"],
             "public-release-publication-",
         )
+
+    def test_pass_and_waived_pilot_contracts_publish(self) -> None:
+        for status in ("pass", "waived"):
+            request, payloads, _ = build_fixture()
+            request["pilot"] = pilot_fixture(status)
+            request["publication_receipt"]["pilot"] = copy.deepcopy(request["pilot"])
+            raw = refresh_request(request)
+            target = FakeTarget(request, payloads, state="absent")
+
+            with self.subTest(status=status):
+                receipt = self.apply(request, payloads, raw, target)
+                self.assertEqual(receipt["status"], "published")
+                self.assertEqual(target.create_calls, 1)
+                self.assertEqual(target.publish_calls, 1)
+
+    def test_pilot_waiver_semantics_reject_ambiguous_requests(self) -> None:
+        for case in ("missing_waiver", "pass_with_waiver"):
+            request, payloads, _ = build_fixture()
+            if case == "missing_waiver":
+                request["pilot"]["status"] = "waived"
+                request["publication_receipt"]["pilot"]["status"] = "waived"
+            else:
+                request["pilot"]["waiver_sha256"] = "5" * 64
+                request["publication_receipt"]["pilot"]["waiver_sha256"] = "5" * 64
+            raw = refresh_request(request)
+            target = FakeTarget(request, payloads, state="absent")
+
+            with self.subTest(case=case), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                "waiver_sha256",
+            ):
+                self.apply(request, payloads, raw, target)
+            self.assertEqual(target.create_calls, 0)
+            self.assertEqual(target.publish_calls, 0)
+
+    def test_pilot_copies_must_match_exactly(self) -> None:
+        request, payloads, _ = build_fixture()
+        request["pilot"] = pilot_fixture("waived")
+        raw = refresh_request(request)
+        target = FakeTarget(request, payloads, state="absent")
+
+        with self.assertRaisesRegex(MIRROR.MirrorError, "pilot copies do not match"):
+            self.apply(request, payloads, raw, target)
+        self.assertEqual(target.create_calls, 0)
+        self.assertEqual(target.publish_calls, 0)
+
+    def test_pilot_contract_rejects_extra_keys_in_both_copies(self) -> None:
+        for location in ("request", "publication_receipt"):
+            request, payloads, _ = build_fixture()
+            if location == "request":
+                request["pilot"]["unexpected"] = True
+            else:
+                request["publication_receipt"]["pilot"]["unexpected"] = True
+            raw = refresh_request(request)
+            target = FakeTarget(request, payloads, state="absent")
+
+            with self.subTest(location=location), self.assertRaisesRegex(
+                MIRROR.MirrorError,
+                "pilot keys do not match contract",
+            ):
+                self.apply(request, payloads, raw, target)
+            self.assertEqual(target.create_calls, 0)
+            self.assertEqual(target.publish_calls, 0)
+
+    def test_pilot_contract_rejects_missing_and_malformed_fields(self) -> None:
+        cases = (
+            ("missing_top_level", None, None),
+            ("missing_nested_field", "artifact_sha256", None),
+            ("malformed_aggregate", "aggregate_sha256", "sha256:" + "3" * 64),
+            ("malformed_artifact", "artifact_sha256", "4" * 63),
+            ("malformed_issued_at", "issued_at", "2026-07-25 12:00:00Z"),
+            ("malformed_expires_at", "expires_at", "tomorrow"),
+            ("unsupported_status", "status", "blocked"),
+        )
+        for case, field, value in cases:
+            request, payloads, _ = build_fixture()
+            source_receipt = source_publication_receipt(request)
+            if case == "missing_top_level":
+                del request["pilot"]
+            elif case == "missing_nested_field":
+                assert field is not None
+                del request["publication_receipt"]["pilot"][field]
+            else:
+                assert field is not None
+                request["pilot"][field] = value
+                request["publication_receipt"]["pilot"][field] = value
+            raw = refresh_request(request)
+            source = FakeSource(
+                request,
+                payloads,
+                raw,
+                source_receipt=source_receipt,
+            )
+            target = FakeTarget(request, payloads, state="absent")
+
+            with self.subTest(case=case), self.assertRaises(MIRROR.MirrorError):
+                self.apply(request, payloads, raw, target, source=source)
+            self.assertEqual(target.create_calls, 0)
+            self.assertEqual(target.publish_calls, 0)
+
+    def test_source_receipt_pilot_must_match_handoff(self) -> None:
+        request, payloads, raw = build_fixture()
+        source_receipt = source_publication_receipt(request)
+        source_receipt["binding"]["pilot"]["aggregate_sha256"] = (
+            "sha256:" + "f" * 64
+        )
+        source = FakeSource(
+            request,
+            payloads,
+            raw,
+            source_receipt=source_receipt,
+        )
+        target = FakeTarget(request, payloads, state="absent")
+
+        with self.assertRaisesRegex(
+            MIRROR.MirrorError,
+            "source publication receipt pilot does not match",
+        ):
+            self.apply(request, payloads, raw, target, source=source)
+        self.assertEqual(target.create_calls, 0)
+        self.assertEqual(target.publish_calls, 0)
 
     def test_candidate_and_prerelease_requests_fail_before_target_mutation(self) -> None:
         cases = (


### PR DESCRIPTION
## Summary
- accept the public release pilot binding for both pass and waived outcomes
- enforce exact request/receipt/source-evidence equality and closed schemas
- reject missing, malformed, ambiguous, drifted, or extra pilot fields before release mutation

## Validation
- `python3 -m unittest discover -s tests -p 'test_public_release_mirror.py' -v` (33 passed)
- Python compile
- Ruff
- mirror contract and JSON validation
- `git diff --check`