### PR TITLE
chore: publish v0.5.28 release metadata

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.27",
-    "tag": "v0.5.27",
-    "released_at": "2026-07-24T19:23:32Z"
+    "version": "0.5.28",
+    "tag": "v0.5.28",
+    "released_at": "2026-07-28T20:17:03Z"
   },
   "beta": {
-    "version": "0.5.27",
-    "tag": "v0.5.27",
-    "released_at": "2026-07-24T19:23:32Z"
+    "version": "0.5.28",
+    "tag": "v0.5.28",
+    "released_at": "2026-07-28T20:17:03Z"
   }
 }


### PR DESCRIPTION
## Summary

- advance the stable and beta release channels to v0.5.28
- record the v0.5.28 publication timestamp
- preserve the existing public metadata schema

## Validation

- `python3 -m pytest -q tests/test_public_release_mirror.py` (33 passed)
- `python3 -m json.tool RELEASES.json`
- exact release metadata schema/value assertion
- `git diff --check`