### PR TITLE
Update Trajectory 0.5.29 metadata and plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,6 +15,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "trajectory-security",
+      "source": {
+        "source": "local",
+        "path": "./plugin/trajectory-security"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Security"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,11 @@
     {
       "name": "trajectory",
       "source": "./plugin/trajectory"
+    },
+    {
+      "name": "trajectory-security",
+      "source": "./plugin/trajectory-security",
+      "category": "Security"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -92,10 +92,13 @@ agent behavior becomes something you can graph, alert on, compare, and improve.
 - **Datadog-native export** for configurable LLM Observability traces and
   operational metrics for tokens, cost, duration, tool use, capture health, and
   attribution workflows.
+- **Agent Security controls** through the independently installable
+  `trajectory-security` plugin for Claude Code, Codex, and Cursor.
 - **Investigation tools** including `trajectory status`, `trajectory view`,
   diagnostics, support bundles, MCP tools, and historical backfill.
 - **Privacy and capacity controls** including `/incognito`, local-only capture,
-  durable `trajectory disable` / `trajectory enable` capture control,
+  durable `trajectory config capture disable` / `trajectory config capture enable`
+  capture control,
   sensitivity scanning, configurable trace detail, and controls for
   Trajectory-owned LLM calls.
 - **Workflow attribution** across repositories, commits, pull requests, and
@@ -123,6 +126,13 @@ trajectory-darwin-universal
 trajectory-linux-amd64
 trajectory-linux-arm64
 trajectory-windows-amd64.exe
+
+trajectory-mdm-darwin-amd64
+trajectory-mdm-darwin-arm64
+trajectory-mdm-darwin-universal
+trajectory-mdm-linux-amd64
+trajectory-mdm-linux-arm64
+trajectory-mdm-windows-amd64.exe
 ```
 
 ## Supported Clients
@@ -197,6 +207,7 @@ the broader observability stack.
 commands/                 Gemini command assets
 docs/                     Public user documentation
 plugin/trajectory/        Claude Code plugin
+plugin/trajectory-security/ Standalone Agent Security plugin
 plugin/trajectory-codex/  Codex plugin
 plugin/trajectory-gemini/ Gemini context assets
 plugin/trajectory-antigravity/ Antigravity CLI plugin
@@ -220,6 +231,8 @@ This repository accepts changes to public docs, marketplace metadata, plugin ass
 - [docs/REPORTS.md](docs/REPORTS.md): summary, outcomes, Patterns, historical analysis, and session drilldown
 - [docs/CONFIGURATION.md](docs/CONFIGURATION.md): config files, managed defaults, environment overrides, and common settings
 - [docs/API-APP-KEY-MANAGEMENT.md](docs/API-APP-KEY-MANAGEMENT.md): Datadog API/application key storage, resolution, permissions, and rotation
+- [docs/SECURITY.md](docs/SECURITY.md): standalone Agent Security plugin setup, modes, destinations, and secret handling
+- [docs/MANAGED-ENDPOINTS.md](docs/MANAGED-ENDPOINTS.md): managed endpoint bundle preparation and endpoint verification
 - [docs/FEATURE-FLAGS.md](docs/FEATURE-FLAGS.md): feature-flag commands, runtime overrides, and registered flags
 - [docs/SUPPORTED-CLIENTS.md](docs/SUPPORTED-CLIENTS.md): supported coding-agent clients and version requirements
 - [docs/CLIENT-INSTRUMENTATION.md](docs/CLIENT-INSTRUMENTATION.md): per-client hook, watcher, MCP, and backfill surfaces

--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.28",
-    "tag": "v0.5.28",
-    "released_at": "2026-07-28T20:17:03Z"
+    "version": "0.5.29",
+    "tag": "v0.5.29",
+    "released_at": "2026-07-31T10:44:28Z"
   },
   "beta": {
-    "version": "0.5.28",
-    "tag": "v0.5.28",
-    "released_at": "2026-07-28T20:17:03Z"
+    "version": "0.5.29",
+    "tag": "v0.5.29",
+    "released_at": "2026-07-31T10:44:28Z"
   }
 }

--- a/docs/CLIENT-INSTRUMENTATION.md
+++ b/docs/CLIENT-INSTRUMENTATION.md
@@ -18,7 +18,7 @@ trajectory user-guide clients
 | Client | Setup path | Live capture surface | Backfill |
 |---|---|---|---|
 | Claude Code | `trajectory setup --clients cc` (`--install-client-shims` optional) | Marketplace plugin hooks plus MCP; optional transparent `trajectory claude` launcher | Transcript backfill |
-| Codex CLI | `trajectory setup --clients codex` (`--install-client-shims` optional) | Three boundary command hooks plus authoritative rollout reconciliation by default; optional full ten-hook compatibility and transparent `trajectory codex` launcher with complete Responses API request/response capture | Codex rollout backfill |
+| Codex CLI | `trajectory setup --clients codex` (`--install-client-shims` optional) | CLI and Desktop session, prompt, Stop, and SessionEnd boundary hooks plus authoritative rollout reconciliation by default; optional full eleven-hook compatibility and transparent `trajectory codex` launcher with complete Responses API request/response capture | Codex rollout backfill |
 | GitHub Copilot CLI | `trajectory setup --clients copilot`; optionally install the explicit command shim and enable `copilot_cli_durable_history` / `copilot_cli_native_otel` | Beta plugin command hooks plus MCP, bounded session-state reconciliation, and strict content-disabled native OTel request capture | Enable `copilot_durable_history`; `trajectory backfill --from-copilot-sessions` remains the explicit bulk-history and repair path |
 | Gemini CLI | `trajectory setup --clients gemini` | Managed command hooks plus MCP | Gemini transcript backfill |
 | Antigravity CLI (`agy`) | `trajectory setup --clients agy` | Antigravity plugin command hooks plus MCP | Default-off exact prompt plus schema-v1 generation-usage reconciliation |
@@ -517,9 +517,10 @@ Finder does not inherit shell `OTEL_*` env, and there is no verified
 Setup writes a local Codex marketplace under `~/.trajectory/codex-marketplace`
 and registers it with Codex. The plugin provides command hooks, MCP
 configuration, and the `/incognito` skill. `codex_boundary_capture` is on by
-default and activates `SessionStart`, `UserPromptSubmit`, and `Stop` plus
-paired Bash-only `PreToolUse` and `PostToolUse` evidence hooks.
-Disabling it activates all ten events supported by current Codex and is the
+default and activates `SessionStart`, `UserPromptSubmit`, `Stop`, and
+`SessionEnd` plus paired Bash-only `PreToolUse` and `PostToolUse` evidence
+hooks. The same installed hook contract applies when Codex Desktop runs the
+plugin. Disabling it activates all eleven events supported by current Codex and is the
 full-hook compatibility path.
 
 Setup extracts a same-platform minimal hook helper and, on Darwin, native relay
@@ -555,7 +556,7 @@ definite-unavailability and compatibility fallback.
 Codex is a hybrid capture integration, not a simple hook-to-JSONL integration.
 There are two upstream Codex streams:
 
-- **Command hook payloads** cover the three default lifecycle/turn boundaries
+- **Command hook payloads** cover the four default lifecycle/turn boundaries
   plus paired Bash-only before/after evidence. The paired tool hooks do not
   emit canonical events. Full-hook compatibility additionally activates all
   tool, permission, compaction, and subagent events. Codex waits for each command.
@@ -584,10 +585,10 @@ cannot replay an already captured session.
 The JSONL under `~/.trajectory/trajectories/` is the normalized result of
 merging those streams. At each boundary, `trajectory serve` reads the rollout
 forward, derives canonical tool phases in one ordered durable batch, applies
-token/model enrichment, and then dispatches the boundary event. Watcher-seen
-assistant messages wake an immediate drain without adding a command hook.
-Watcher-seen `shutdown_complete` performs the final drain and exact-once
-`session_end`, because current Codex has no `SessionEnd` hook.
+token/model enrichment, and then dispatches the boundary event. Every watcher
+event becomes a reconciliation wake while hooks are active. Hook-delivered
+`SessionEnd` and watcher-seen `shutdown_complete` converge on one final drain
+and exact-once `session_end`.
 Boundary mode never fast-forwards a large unread rollout suffix. Its source
 cursor is committed only after the derived canonical events are persisted; a
 write failure leaves the source checkpoint retryable.
@@ -604,8 +605,9 @@ available. For that rescue process only, it overrides Codex watcher-disable
 environment variables and suppresses unrelated client watchers;
 `trajectory config capture disable` and `TRAJECTORY_DISABLED=1` still suppress all capture.
 The durable user-scoped command also suppresses an already-running watcher.
-Hook-active sentinels under `~/.trajectory/state/codex-hook-active/` suppress
-duplicate non-message watcher events while boundary hooks own the session.
+Hook-active sentinels under `~/.trajectory/state/codex-hook-active/` route
+watcher activity through the shared reconciler. They do not authorize dropping
+a watcher fact that a hook missed.
 
 `codex exec --ephemeral` does not write a rollout. Default boundary mode
 therefore cannot derive tool, permission, compaction, or subagent detail for an
@@ -1772,6 +1774,20 @@ or 10 ms admission timeout fails closed so the durable delivery can retry
 without replacing richer or stale history. Existing history still requires
 explicit `backfill --from-opencode`.
 
+### Nested session topology
+
+OpenCode records the exact immediate `parentID` from native `session.created`
+events on a child session's first `SessionStart`. Immediate ancestry is kept
+separate from semantic Task-launch correlation: an exact parent remains
+navigable even when concurrent or ambiguous Task calls fail closed rather than
+claiming a subagent launch.
+
+The local viewer keeps each child as a separate session with its own trace.
+Parent, breadcrumb, and immediate-child controls navigate by exact session ID;
+children remain directly loadable while being excluded from the normal
+top-level session list. See [SUBAGENT-TRACE-MODEL.md](SUBAGENT-TRACE-MODEL.md)
+for ancestry, launch, and span-link semantics.
+
 ## Kilo Code
 
 Kilo Code uses an OpenCode-compatible plugin surface. Setup installs the
@@ -1779,6 +1795,10 @@ Trajectory plugin under the Kilo config directory (`KILO_CONFIG_DIR` when set,
 otherwise `XDG_CONFIG_HOME/kilo` or `~/.config/kilo`), merges the plugin path
 plus a `trajectory` MCP entry into `opencode.json`, and writes the incognito
 skill into the Kilo skills directory.
+
+Kilo shares the OpenCode nested-session topology and local viewer navigation,
+including exact immediate ancestry on child sessions and separate semantic
+Task-launch correlation.
 
 The plugin SDK posts events to `/capture/kilo/...`; the server routes those
 events through the OpenCode-compatible capture path. Kilo can also send native

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -184,6 +184,24 @@ capture:
 
 In this example, users may still opt in to trace export from `config.yaml`, but automatic local-ui startup remains disabled because a managed `false` value is authoritative for that setting.
 
+### Refresh Organization Configuration
+
+Trajectory refreshes configured organization files automatically. To fetch
+them immediately, run:
+
+```bash
+trajectory config sync
+```
+
+The command uses the configured `org.config_source` or legacy
+`org.markers_repo`, validates and atomically writes every updated file, and
+reports what changed. It does not signal live processes. When managed defaults
+or cohort assignment changes, apply the refreshed runtime configuration with:
+
+```bash
+trajectory config reload --yes
+```
+
 ## Export And Credentials
 
 Set the Datadog site, store an API key, and validate the publish configuration:

--- a/docs/MANAGED-ENDPOINTS.md
+++ b/docs/MANAGED-ENDPOINTS.md
@@ -1,0 +1,91 @@
+# Managed Endpoint Deployment
+
+Trajectory 0.5.29 includes a provider-neutral `trajectory-mdm` administrator
+helper for preparing and verifying managed endpoint policy bundles. Keep this
+helper on an administrator workstation or deployment automation runner; it is
+not the Trajectory runtime installed for end users.
+
+## Download The Helper
+
+Choose the helper for the administrator workstation:
+
+| Platform | Release asset |
+| --- | --- |
+| macOS Intel | `trajectory-mdm-darwin-amd64` |
+| macOS Apple silicon | `trajectory-mdm-darwin-arm64` |
+| macOS universal | `trajectory-mdm-darwin-universal` |
+| Linux amd64 | `trajectory-mdm-linux-amd64` |
+| Linux arm64 | `trajectory-mdm-linux-arm64` |
+| Windows amd64 | `trajectory-mdm-windows-amd64.exe` |
+
+Verify the downloaded file against `checksums.sha256`. On macOS or Linux,
+mark it executable and optionally rename it to `trajectory-mdm`.
+
+```bash
+trajectory-mdm version
+trajectory-mdm prepare --interactive
+```
+
+The interactive workflow asks for the endpoint-management provider, target
+platform, deployment ID, approved coding-agent clients, and optional telemetry
+tags. It selects no coding agents by default and displays the complete plan
+before writing a bundle.
+
+## Source-Controlled Intent
+
+For repeatable deployments, define the administrator-owned intent as JSON:
+
+```json
+{
+  "schema_version": 1,
+  "deployment_id": "engineering-coding-agents",
+  "provider": "intune",
+  "platform": "windows",
+  "clients": ["cc", "codex"],
+  "tags": {
+    "environment": "production",
+    "team": "developer-experience"
+  }
+}
+```
+
+The intent contains bounded identifiers, not credentials or credential
+references. Prepare and verify the resulting bundle with the helper from the
+same Trajectory release:
+
+```bash
+trajectory-mdm prepare \
+  --file ./trajectory-managed.json \
+  --output ./trajectory-managed.zip
+
+trajectory-mdm verify --bundle ./trajectory-managed.zip
+```
+
+Do not hand-edit generated policy files. Change the intent and prepare a new
+bundle instead.
+
+## Verify An Endpoint
+
+Check machine-level state from an administrator context:
+
+```bash
+trajectory managed status --scope system --format json
+```
+
+Check and reconcile user integrations from the signed-in user's context:
+
+```bash
+trajectory managed status --scope all --format json
+trajectory managed reconcile --scope user --dry-run --format json
+trajectory managed reconcile --scope user --yes --format json
+trajectory managed repair --scope user --yes --format json
+```
+
+User reconciliation must run as the signed-in user rather than root or Windows
+SYSTEM. Treat `blocked`, `drifted`, or `failed` as non-compliant and use the
+reported `reason` and `next_step` fields for remediation.
+
+Provider-neutral bundles are not by themselves proof that every provider and
+platform combination has been certified in a live tenant. Validate the chosen
+provider, platform, package, detection, inventory, and user-reconciliation
+workflow before broad deployment.

--- a/docs/METRICS-REFERENCE.md
+++ b/docs/METRICS-REFERENCE.md
@@ -419,7 +419,7 @@ points. Their `trajectory.session.*` rollups remain session-end metrics.
 | `trajectory.turn.files_modified.additive` | count | file | Additive edit/write operation stream; this is not a global distinct-file count |
 | `trajectory.turn.files_read` | gauge | file | Read tool activity in the turn |
 | `trajectory.turn.files_read.additive` | count | file | Additive read operation stream; this is not a global distinct-file count |
-| `trajectory.turn.subagent_invocations` | gauge | invocation | Distinct source-backed subagent launches in the completed turn; zero is valid and emitted |
+| `trajectory.turn.subagent_invocations` | gauge | invocation | Distinct source-backed subagent launches in the completed turn; zero is valid and emitted. Claude Code, Codex, Cursor, GitHub Copilot CLI, and OpenCode share this canonical counting contract; unsupported or ambiguous source shapes fail closed. |
 | `trajectory.turn.subagent_invocations.additive` | count | invocation | Authoritative positive-only launch stream; use `sum:...as_count()` grouped by `session_id` for session totals |
 | `trajectory.turn.compactions` | gauge | compaction | Compactions observed in the turn |
 | `trajectory.turn.compactions.additive` | count | compaction | Additive completed-turn compaction stream |
@@ -943,8 +943,8 @@ its publication contract.
 | `trajectory.turn.skill_observations` | count | turn | Lower-confidence skill observations tagged by `skill_name`, `detected_from`, `source_scope`, and `signal_confidence` |
 | `trajectory.session.cli_tool_count` | gauge | session | Recognized shell command-line tool invocations grouped by normalized `tool`; use the `.completed_count` mirror for toplists |
 | `trajectory.turn.cli_tool_count` | count | turn | Per-turn recognized shell command-line tool invocations tagged by normalized `tool` |
-| `trajectory.session.subagents` | gauge | session | Built-in subagent count |
-| `trajectory.turn.subagents` | count | turn | Per-turn subagent spawn points |
+| `trajectory.session.subagents` | gauge | session | Deprecated compatibility marker for the built-in `Agent`-tool signal; do not combine it with source-backed launch lifecycle metrics. |
+| `trajectory.turn.subagents` | count | turn | Deprecated compatibility marker; use `trajectory.turn.subagent_invocations.additive` for authoritative cross-client launch totals. |
 | `trajectory.session.tests_written` | gauge | session | Built-in new-test count |
 | `trajectory.turn.tests_written` | count | turn | Per-turn new-test points |
 | `trajectory.session.force_pushes` | gauge | session | Built-in force-push count |
@@ -1189,6 +1189,7 @@ privacy/publish diagnostics.
 |---|---|---|---|
 | `trajectory.ops.install.current_state` | gauge | Canonical serve tags plus `managed`, `role`, `outcome`, `reason`, `setup_binary_status`, `setup_binary_version` | Managed setup summary. Current state emits `1`; prior state series are emitted as `0` when the setup state changes so dashboards can filter on the latest active state. |
 | `trajectory.ops.install.agent_state` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `agent_status`, `setup_outcome`, `setup_stage`, `setup_component`, `setup_capture_path`, `setup_next_step`, `reason`, `setup_binary_status`, `setup_binary_version` | Per-integration setup state for every selected client. Distinguishes registration failures from verification failures and degraded fallback paths such as MCP watcher fallback. |
+| `trajectory.ops.install.auto_instrument_state` | gauge | Canonical serve tags plus `install_owner`, `managed`, `auto_instrument_enabled`, `apply_enabled`, `allow_clients_configured`, `clients_hooked`, `publish_configured`, `reason` | Managed-host auto-instrument readiness. Emits `1` when effective policy will instrument at least one client and `0` for a publish-on/instrument-off gap. |
 | `trajectory.ops.agent.present` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source` | Daily local inventory signal for each known coding-agent client. Emits `1` when the client is detected on the machine and `0` when absent. Client aliases such as `cc` are reported as canonical runtime sources such as `claude-code`. |
 | `trajectory.ops.agent.version` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source`, `client_version`, `trajectory.client_version`, `version_source` | Daily installed-agent freshness signal. Emits `1` for detected clients with the best available CLI-probed version, or `client_version:unknown` when the client is present but the version probe is unavailable. |
 | `trajectory.ops.agent.active_sessions` | gauge | Canonical serve tags plus `client_source`, `trajectory.client_source` | Hourly count of fresh active sessions by canonical client source, deduped across concurrent `trajectory serve` processes using per-PID heartbeat sentinels. Emits `0` for known clients with no fresh active sessions. |
@@ -1198,6 +1199,8 @@ privacy/publish diagnostics.
 | `trajectory.ops.mcp.tool.completed` | count | MCP tool tags plus `trajectory.mcp_outcome` | One durable terminal count classified as `success`, `tool_error`, `handler_error`, `canceled`, or `panic`. |
 | `trajectory.ops.mcp.tool.duration_ms` | distribution | MCP tool tags plus `trajectory.mcp_outcome` | Registered handler duration. Export requires both the managed `mcp_tool_telemetry` feature and its separate destination policy. Arguments, results, queries, paths, session identity, prompts, errors, credentials, and arbitrary user tags are never included. |
 | `trajectory.publish.active_destinations` | gauge | Canonical tags plus top-level and destination tags on DD destinations | Number of active destinations seen for a session |
+| `trajectory.ops.required_destination.health` | gauge | Canonical serve tags plus `destination`, `incognito_exempt`, `destination_state` | Three-valued required-destination health: `1` active, `0` a proven gap, and `-1` not provable. Group by destination and state; alert on `0`, not values below `1`. |
+| `trajectory.ops.org_sync.success_age_seconds` | gauge | Canonical serve tags plus `verified` | Seconds since the last observed successful organization-config sync. `-1` means no verified success; alert on it separately from ordinary staleness. |
 | `trajectory.publish.turns` | count | OTLP publish path tags | Publish turn counter |
 | `trajectory.serve.incognito.enabled` | count | `client_source` | User or tool enabled incognito; intentionally not tagged by session ID; direct agentless OTLP submission |
 | `trajectory.serve.process.start_total` | count | `start_source` | Capture server listener started; `start_source:rescue_hook` identifies hook-driven recovery after a dead listener |
@@ -1209,6 +1212,7 @@ privacy/publish diagnostics.
 | `trajectory.serve.local_state.instrumentation_health_records` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Count of records retained in the rolling local instrumentation-health diagnostic buffer during the local-state health scan |
 | `trajectory.serve.local_state.serve_log_bytes` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Current `trajectory-serve.log` size in bytes at the local-state health scan |
 | `trajectory.serve.local_state.serve_diag_bytes` | gauge | Canonical serve tags plus `stage`, `warning`, `scan_error` | Current `serve-diag.ndjson` size in bytes at the local-state health scan |
+| `trajectory.serve.local_state.publish_ledger_held_claims` | gauge | Canonical serve tags plus `artifact_scope` | Read-only count of publish-ledger claims held past a plausible live publish. `artifact_scope:final_session` is the operator-actionable orphan count; recover with `trajectory publish ledger status` and `trajectory publish ledger repair`. |
 | `trajectory.serve.publish.sensitivity_suppressed` | count | `client_source`, `destination`, `category`, `label` | Sensitive spans dropped for a destination |
 | `trajectory.serve.publish.sensitivity_held` | count | `client_source`, `destination`, `reason` | Spans held while classification is pending or unresolved |
 | `trajectory.serve.publish.spans_suppressed_total` | count | `client_source`, `destination`, `category`, `label` | Number of spans suppressed by sensitivity policy |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,71 @@
+# Trajectory Security
+
+Trajectory Security adds AI Guard and AI-EDR controls to supported coding
+agents without coupling those controls to the core observability plugin.
+
+The `trajectory-security` package is an independently installable plugin for
+Claude Code, Codex, and Cursor. It requires the Trajectory binary at
+`~/.trajectory/bin/trajectory` or the path selected by `TRAJECTORY_BINARY`.
+
+## Set Up Security
+
+Enable observe mode for selected clients:
+
+```bash
+trajectory security setup --mode observe --clients cc,codex,cursor
+```
+
+The command installs the standalone marketplace plugin for Claude Code and
+Codex, synchronizes Cursor's native hooks, and enables Agent Security. It is
+safe to run again when clients or configuration change.
+
+Observe mode records decisions without blocking agent actions. Enforce mode
+can block actions and therefore requires explicit confirmation:
+
+```bash
+trajectory security setup --mode enforce --clients cc --yes
+```
+
+Inspect or disable the active configuration with:
+
+```bash
+trajectory security status
+trajectory security disable
+trajectory security disable --clients cc,codex,cursor --remove-hooks
+```
+
+`--remove-hooks` removes the selected standalone plugin surfaces while
+preserving Trajectory's baseline observability hooks.
+
+## Configure A Destination
+
+Agent Security results can use an existing Datadog destination with an
+application-key secret reference:
+
+```bash
+trajectory security destination add \
+  --destination <existing-destination> \
+  --app-key-ref <secret-ref>
+```
+
+Store secret values through Trajectory's OS-keychain-backed secret interface.
+Do not place API or application keys in YAML or command arguments:
+
+```bash
+trajectory config set-secret dd_api_key --stdin
+trajectory config set-secret dd_app_key --stdin
+```
+
+The built-in AI Guard configuration uses `dd_api_key` and `dd_app_key` by
+default. Existing `DD_API_KEY` and `DD_APP_KEY` environment values remain
+compatible with the same credential resolver.
+
+## Plugin Ownership
+
+The core `trajectory` plugin owns session capture. The standalone
+`trajectory-security` plugin owns Security decision hooks and dispatches them
+through `hook-dispatch --product-plugin datadog-security`. Installing or
+removing one package does not transfer ownership to the other.
+
+Security event-stream logs are a separate managed destination capability. See
+[SECURITY-EVENT-STREAM.md](SECURITY-EVENT-STREAM.md) for that contract.

--- a/docs/SUBAGENT-TRACE-MODEL.md
+++ b/docs/SUBAGENT-TRACE-MODEL.md
@@ -25,6 +25,20 @@ existing parent span.
 The child session remains its own trace in every mode. The parent turn trace
 must not directly parent child-session turns, tools, or LLM spans.
 
+## Metrics Contract
+
+Claude Code, Codex, Cursor, GitHub Copilot CLI, and OpenCode use the same
+canonical launch-count contract: one distinct, source-backed `subagent_start`
+increments `trajectory.turn.subagent_invocations` and its positive-only
+`.additive` companion once. Stable launch or child identity deduplicates
+replayed lifecycle. Missing, failed, or ambiguous provider evidence emits no
+launch.
+
+The older `trajectory.session.subagents` and `trajectory.turn.subagents`
+marker metrics are compatibility views of an Agent-tool signal. They are not
+cross-client lifecycle metrics and must not be combined with the canonical
+invocation family.
+
 ## Client Validation Matrix
 
 | Client | Current subagent source shape | Expected rendering |
@@ -36,8 +50,27 @@ must not directly parent child-session turns, tools, or LLM spans.
 | Gemini CLI | No native lifecycle hook; Trajectory synthesizes `subagent_start` and `subagent_stop` from `kind:"subagent"` chat artifacts during session end. | Synthetic subagent lifecycle attaches under the synthesized launch tool. |
 | Antigravity CLI (`agy`) | Gemini-compatible hook path; Trajectory synthesizes subagent lifecycle from `kind:"subagent"` chat artifacts during session end when Antigravity emits the same files. | Synthetic subagent lifecycle attaches under the synthesized launch tool. |
 | Factory Droid | Current hook set includes `SubagentStop` but not `SubagentStart`. | Stop-only lifecycle falls back to a standalone active-turn subagent span. |
-| OpenCode and Kilo | The plugin pairs exactly one pending `Task` call with a child `session.created` event carrying parent and child session IDs; child idle, deletion, or plugin disposal closes the link. | The normalized launch carries both child and launch-tool identity. Multiple pending Task calls fail closed, and generic agent metadata alone never creates parentage. |
+| OpenCode | Every observed child `session.created` carries exact parent and child IDs, recorded as immediate ancestry on the child's first `SessionStart`. A semantic launch additionally requires exactly one pending `Task` call. | Immediate ancestry supports navigation on its own. A launch span is emitted only for the one-candidate Task pairing; ambiguous Task calls keep ancestry but emit no launch. |
+| Kilo | OpenCode-compatible plugin events use the same immediate-ancestry and one-candidate launch rules. | Identical to OpenCode: ancestry supports navigation, while only a proven Task pairing emits a launch span. |
 | Pi | Current extension records normal session, prompt, tool, turn, compaction, model, and fork events but no dedicated child-session subagent lifecycle. | No semantic subagent parentage is inferred from fork or agent metadata alone. |
+
+## OpenCode And Kilo Nested Sessions
+
+OpenCode and Kilo record two independent facts for nested sessions:
+
+- `parent_session_id` is the exact immediate provider parent and powers parent,
+  breadcrumb, and immediate-child navigation.
+- Semantic launch lifecycle requires an exact Task-to-child correlation and is
+  the only fact that increments the canonical subagent invocation metrics.
+
+An ancestry-only child remains navigable but does not claim a launch. With
+multiple concurrent candidate Task calls, Trajectory retains exact ancestry
+and fails closed on launch attribution rather than guessing. Recursive children
+keep immediate edges, so a grandchild points to its child parent instead of
+being flattened to the root.
+
+Each child remains a separate, directly loadable trace. The local viewer
+derives root and breadcrumb navigation from those immediate edges.
 
 ## When Adding A Client Pattern
 

--- a/docs/SUPPORTED-CLIENTS.md
+++ b/docs/SUPPORTED-CLIENTS.md
@@ -43,7 +43,7 @@ supported range by itself.
 |--------|-------------------|-------------------|-----------------------|----------------|---------------------------|
 | Claude Code | `trajectory setup --clients cc` (`--install-client-shims` optional) | Supported | 2.0+ | HTTP hooks + MCP; optional transparent `trajectory claude` launcher | Claude native OTLP can be relayed through Trajectory |
 | Claude Desktop (macOS) | On by default; optionally `trajectory setup --clients claude-desktop` | Capture (near-real-time watcher + backfill) | macOS GUI app (bundle `com.anthropic.claudefordesktop`); no CLI | Darwin `serve` audit.jsonl watcher (near-real-time) + filesystem backfill (`--from-claude-desktop`) | Audit JSONL live capture + backfill (`client_source=claude-desktop`); incognito honored; serve-side native-OTLP attribution ready; on by default, `claude_desktop_capture` is the kill switch |
-| Codex CLI | `trajectory setup --clients codex` (`--install-client-shims` optional) | Supported | 0.128.0+ | Three boundary command hooks plus rollout detail/terminal by default; ten-hook compatibility and optional transparent `trajectory codex` launcher | Complete Responses API request/response spans and rollout backfill |
+| Codex CLI | `trajectory setup --clients codex` (`--install-client-shims` optional) | Supported | 0.128.0+ | CLI and Desktop session, prompt, Stop, and SessionEnd boundary hooks plus rollout reconciliation by default; eleven-hook compatibility and optional transparent `trajectory codex` launcher | Complete Responses API request/response spans and rollout backfill; Desktop is attributed as `codex-app` |
 | GitHub Copilot CLI | `trajectory setup --clients copilot`; optional `copilot_cli_durable_history` watcher | Beta | Public plugin hook and session-state contracts; no stable minimum pinned | Copilot plugin command hooks + MCP + provider history backfill/watcher | Fixture-proven hooks, durable watcher, and Lapdog readback; protected live CLI gate pending |
 | Gemini CLI | `trajectory setup --clients gemini` | Supported | 0.30.0+ | Managed command hooks + MCP | Hook payload token/cost fields |
 | Antigravity CLI (`agy`) | `trajectory setup --clients agy` | Supported | 1.0.12 and 1.1.2 inspected | Native Antigravity plugin hooks + MCP; optional exact prompt-history watcher | Current-schema fixture, local plugin validation, real 1.1.2 `agy --print` hook-delivery proof, and provider-history/local-ui fixture proof; successful provider response not claimed |
@@ -966,13 +966,15 @@ Earlier versions may have partial support (marketplace without hook discovery, o
 
 The default-on `codex_boundary_capture` feature activates `SessionStart`,
 `UserPromptSubmit`, and `Stop` plus `^Bash$`-matched `PreToolUse` and
-`PostToolUse`. The paired Bash hooks capture immediate PR-work evidence only;
+`PostToolUse`, plus `SessionEnd`. The paired Bash hooks capture immediate
+PR-work evidence only;
 the rollout watcher tails
 `$CODEX_HOME/sessions/` (normally `~/.codex/sessions/`) and provides tool
 phases, assistant messages, reasoning, permissions, compaction, subagent
-activity, model and token metadata, and terminal completion. Codex does not
-currently expose a `SessionEnd` hook, so watcher-observed `shutdown_complete`
-performs the final drain and exact-once `session_end`.
+activity, model and token metadata, and terminal completion. Hook-delivered
+`SessionEnd` and watcher-observed `shutdown_complete` both wake one
+generation-fenced final reconciler, which performs the final drain and
+exact-once `session_end`.
 
 Current Codex rollouts prove a subagent launch through a successful
 `spawn_agent` function-call output with a stable call id. Trajectory counts
@@ -992,8 +994,8 @@ the two paths and prevents duplicate non-message events.
 Boundary reads drain every complete durable rollout record and commit their
 source cursor only after canonical persistence succeeds.
 
-The plugin retains definitions for all ten events supported by current Codex.
-Disabling `codex_boundary_capture` activates all ten and restores direct
+The plugin retains definitions for all eleven events supported by current Codex.
+Disabling `codex_boundary_capture` activates all eleven and restores direct
 per-tool hook fidelity at higher process CPU. Run one of these before starting
 a new Codex session:
 
@@ -1007,9 +1009,9 @@ A running Codex process keeps the hook snapshot it loaded at startup. Feature
 changes reconcile the installed plugin's enabled states for new sessions; they
 do not install a second extension or opt an unconfigured user into setup.
 During setup, Trajectory asks Codex's app server to enumerate the exact hooks
-loaded from the installed plugin cache, validates that all ten belong to
+loaded from the installed plugin cache, validates that all eleven belong to
 `trajectory@trajectory`, and asks Codex to persist its own reported current
-hashes. A readback must report all ten as trusted before setup succeeds.
+hashes. A readback must report all eleven as trusted before setup succeeds.
 Trajectory preserves those Codex-owned hashes during later mode, update, and
 startup repair runs. Codex's separate first-use workspace trust prompt is
 unchanged.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -53,10 +53,21 @@ mutate client hooks or Datadog configuration.
 `trajectory plugins list` shows opt-in product activation profiles layered over
 compiled modules. Baseline `trajectory setup` remains observability-only; use
 `trajectory security setup --mode observe --clients cc,codex,cursor` to enable
-the Datadog Security plugin for explicit supported clients. Enforce mode can
-block agent actions and requires `--yes`. Use `trajectory security disable
---clients ... --remove-hooks` to disable config and remove stale
-Trajectory-managed dispatcher hooks while preserving baseline capture hooks.
+and install the Datadog Security plugin for explicit supported clients. The
+command installs the standalone marketplace plugin for Claude Code and Codex
+and synchronizes Cursor's native hooks. Enforce mode can block agent actions
+and requires `--yes`. Use `trajectory security disable --clients ...
+--remove-hooks` to disable config, uninstall the selected standalone plugins,
+and remove stale Trajectory-managed dispatcher hooks while preserving baseline
+capture hooks.
+
+The Trajectory marketplace includes `trajectory-security` as an independently
+installable plugin alongside the core `trajectory` plugin. Use `trajectory
+security destination add --destination <name> --app-key-ref <ref>` to enable
+native `agent-security` module spans and application-key readback on an
+existing Datadog destination. Store secret values with `trajectory config
+set-secret <ref> --stdin`; do not put key values in YAML or command arguments.
+See [SECURITY.md](SECURITY.md) for the complete setup and ownership contract.
 
 Agent Cost Guidance is also disabled by default and is advisory-only. End users
 can run `trajectory cost-guidance setup --clients codex` for local visibility;
@@ -131,7 +142,7 @@ configurations; and names the strongest reconciliation claim each data shape
 can support.
 
 
-Use `trajectory flare` as the critical debug/support action when you need to share a redacted ZIP under `~/.trajectory/` with doctor output, process state, metrics fast-path diagnostics, config files, managed `config.defaults.yaml`, cohort overlay files, log tails, and version/pricing metadata. `trajectory doctor --support-bundle` remains available for the older single-JSON support summary.
+Use `trajectory flare` as the critical debug/support action when you need to share a redacted ZIP under `~/.trajectory/` with doctor output, process state, metrics fast-path diagnostics, config files, managed `config.defaults.yaml`, cohort overlay files, log tails, and version/pricing metadata. When support needs raw evidence for one session, use `trajectory flare --privileged --session <id>` and review the ZIP before sharing. `trajectory doctor --support-bundle` remains available for the older single-JSON support summary.
 
 For slow Codex launch or exit reports, the default doctor output includes recent Trajectory MCP lifecycle timing and any existing Codex startup traces. If attribution is unclear, run `trajectory doctor --codex-startup` to launch a bounded Codex startup probe. The probe records whether Codex is delayed before `thread_spawn`, before Trajectory MCP is launched, or inside Trajectory itself.
 
@@ -147,6 +158,7 @@ For repeated Codex turns or malformed LLM Obs spans, check the capture and publi
 ```bash
 trajectory config show               # View merged runtime config
 trajectory config set <key> <value>  # Set a config value
+trajectory config sync               # Refresh organization-managed config now
 trajectory config reload             # Dry-run live serve reload/restart plan
 trajectory config reload --yes       # Ask the exact adopted owner to hot-reload config
 trajectory update converge --dry-run # Preview managed desired-version convergence
@@ -792,7 +804,7 @@ sensitivity classification and segmentation.
 | Client | Live capture | Tool/model events | Token/cost usage | Backfill | Resume |
 |--------|--------------|-------------------|------------------|----------|--------|
 | Claude Code | HTTP hooks | Yes | Yes | Transcript backfill | Yes |
-| Codex CLI | Three boundary hooks plus rollout detail/terminal; optional ten-hook compatibility | Yes, except default explicit-ephemeral detail gap | Yes when rollout data exists | Codex rollout backfill | Yes |
+| Codex CLI | CLI and Desktop use four boundary hooks plus rollout reconciliation; optional eleven-hook compatibility | Yes, except default explicit-ephemeral detail gap | Yes when rollout data exists | Codex rollout backfill | Yes |
 | GitHub Copilot CLI | Beta Copilot plugin command hooks plus provider session-state backfill | Live command lifecycle/prompt/tool/session events; history adds assistant text/reasoning, tool results, permissions, and subagents | Session-only shutdown aggregate with cache categories separated | Copilot session-state backfill | Not yet |
 | Gemini CLI | Managed command hooks | Yes | Yes | Gemini transcript backfill | Yes |
 | Antigravity CLI (`agy`) | Antigravity plugin command hooks plus optional `antigravity_durable_history` prompt/usage watcher | Tool input/completion/error, invocation wake signals, Stop metadata, exact provider JSONL prompts, and current schema-v1 generation models when enabled | Exact provider uncached-input, total-output, and cache-read counts; output includes thinking, no reasoning breakdown or provider-billed cost | Default-off watcher baselines existing JSONL/SQLite rows, then reconciles later appends/sessions; no manual pre-baseline replay | No setup-managed resume |

--- a/plugin/trajectory-codex/README.md
+++ b/plugin/trajectory-codex/README.md
@@ -4,17 +4,17 @@ Codex marketplace plugin for trajectory agent observability.
 
 ## What It Does
 
-- **10 supported lifecycle hooks** provide the full compatibility surface. Setup enables `SessionStart`, `UserPromptSubmit`, and `Stop` plus Bash-only paired `PreToolUse` and `PostToolUse` by default, derives canonical detail and terminal completion from the rollout, and uses the paired hooks only for immediate PR-work evidence; `codex_boundary_capture` can restore all ten.
+- **11 supported lifecycle hooks** provide the full compatibility surface. Setup enables `SessionStart`, `UserPromptSubmit`, `Stop`, and `SessionEnd` plus Bash-only paired `PreToolUse` and `PostToolUse` by default, derives canonical detail and terminal completion from the rollout, and uses the paired hooks only for immediate PR-work evidence; `codex_boundary_capture` can restore all eleven.
 - **MCP server** provides introspection tools (status, sessions, queries, incognito, flush, markers)
 - **`/incognito` skill** toggles publish suppression for the current session while local JSONL capture continues
 
-Codex capture is intentionally hybrid. Three lifecycle/turn hooks plus paired
+Codex capture is intentionally hybrid. Four lifecycle/turn hooks plus paired
 Bash-only evidence hooks provide ordered boundaries and immediate before/after
 Git snapshots, while Codex rollout JSONL under
 `~/.codex/sessions/` supplies tool phases, assistant messages, reasoning,
 permissions, compaction, subagent activity, model/token metadata, and
-`shutdown_complete`. Current Codex has no `SessionEnd` hook; the watcher emits
-the terminal event. Trajectory merges those sources in `trajectory serve`
+`shutdown_complete`. Hook `SessionEnd` and watcher `shutdown_complete` converge
+on one quiescent terminal reconciler. Trajectory merges those sources in `trajectory serve`
 before writing normalized session JSONL under `~/.trajectory/trajectories/`.
 
 The built-in Codex watcher (rollout file tailing) serves as a fallback for
@@ -25,13 +25,13 @@ owns checkpoint reconciliation, duplicate suppression, rollout cursor
 advancement, and token/model enrichment.
 Boundary mode drains every complete rollout record and commits its source
 cursor only after canonical persistence succeeds. Setup and update retain all
-ten hooks while an old, different-home, or ambiguous capture owner is running;
+eleven hooks while an old, different-home, or ambiguous capture owner is running;
 updated-owner startup self-repairs to paired boundary mode after proving same-home support.
 
 `codex exec --ephemeral` writes no rollout, so default boundary mode cannot
 derive its per-tool detail. Disable `codex_boundary_capture` before a new
 ephemeral run when full direct-hook fidelity is required. Manual plugin installs
-do not receive setup-managed per-hook state and therefore use the full ten-hook
+do not receive setup-managed per-hook state and therefore use the full eleven-hook
 compatibility surface.
 
 For CLI usage, run `trajectory user-guide` or see `docs/USER-GUIDE.md`.

--- a/plugin/trajectory-codex/hooks.json
+++ b/plugin/trajectory-codex/hooks.json
@@ -15,6 +15,9 @@
     "Stop": [{ "matcher": "", "hooks": [
       { "type": "command", "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" TRAJECTORY_PORT=\"${TRAJECTORY_PORT:-19222}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" capture-hook --client codex --ensure-serve --ensure-serve-wait 2s --wait-notify 2s Stop >/dev/null 2>&1 || true", "timeout": 10 }
     ] }],
+    "SessionEnd": [{ "matcher": "", "hooks": [
+      { "type": "command", "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" TRAJECTORY_PORT=\"${TRAJECTORY_PORT:-19222}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" capture-hook --client codex --ensure-serve --ensure-serve-wait 2s --wait-notify 2s SessionEnd >/dev/null 2>&1 || true", "timeout": 3 }
+    ] }],
     "PreCompact": [{ "matcher": "", "hooks": [
       { "type": "command", "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" TRAJECTORY_PORT=\"${TRAJECTORY_PORT:-19222}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" capture-hook --client codex --ensure-serve --ensure-serve-wait 2s --wait-notify 2s PreCompact >/dev/null 2>&1 || true", "timeout": 8 }
     ] }],

--- a/plugin/trajectory-kilo/src/index.ts
+++ b/plugin/trajectory-kilo/src/index.ts
@@ -1,6 +1,23 @@
-const CAPTURE_URL = "http://localhost:19222/capture/kilo";
+const DEFAULT_CAPTURE_PORT = 19222;
+
+function resolveCapturePort(): number {
+    const rawPort = (
+        globalThis as typeof globalThis & {
+            process?: { env?: Record<string, string | undefined> };
+        }
+    ).process?.env?.TRAJECTORY_PORT;
+    if (typeof rawPort !== "string" || !/^\d+$/.test(rawPort)) return DEFAULT_CAPTURE_PORT;
+
+    const port = Number(rawPort);
+    return Number.isSafeInteger(port) && port >= 1 && port <= 65535 ? port : DEFAULT_CAPTURE_PORT;
+}
+
+const CAPTURE_URL = "http://localhost:" + resolveCapturePort() + "/capture/kilo";
 const POST_TIMEOUT_MS = 5000;
 const MAX_TRACKED_SESSIONS = 128;
+const MAX_RETAINED_SESSIONS = 512;
+const MAX_PENDING_STOP_TURN_SNAPSHOTS = 8;
+const MAX_COALESCED_STOP_PLACEHOLDERS = 128;
 const MAX_TRACKED_MESSAGES_PER_TURN = 128;
 const MAX_BUFFERED_TEXT_PARTS_PER_TURN = 64;
 const MAX_BUFFERED_TEXT_CHARS_PER_TURN = 1024 * 1024;
@@ -48,9 +65,21 @@ interface BufferedAssistantPart {
 
 interface SessionRuntimeState {
     started: boolean;
-    turnOpen: boolean;
-    nativeAgentMessageSeen: boolean;
+    creationObserved: boolean;
+    parentSessionID?: string;
     model?: string;
+    launchedTaskCalls: Set<string>;
+    pendingTaskCalls: Set<string>;
+    subagentLink?: SubagentLink;
+    activeTurn?: TurnRuntimeState;
+    pendingStopTurns: TurnRuntimeState[];
+    coalescedStopCount: number;
+    stopInFlight?: Promise<void>;
+}
+
+interface TurnRuntimeState {
+    model?: string;
+    nativeAgentMessageSeen: boolean;
     assistantMessages: Map<string, AssistantMessageMeta>;
     bufferedTextParts: Map<string, BufferedAssistantPart>;
     bufferedTextChars: number;
@@ -279,14 +308,22 @@ function permissionPayload(properties: KiloPayload, event?: KiloPayload): KiloPa
 
 export const server = async (input: KiloPayload) => {
     const sessionStates = new Map<string, SessionRuntimeState>();
-    const pendingTaskCalls = new Map<string, Set<string>>();
-    const subagentLinks = new Map<string, SubagentLink>();
     let lastSessionID: string | undefined;
 
     function createSessionState(): SessionRuntimeState {
         return {
             started: false,
-            turnOpen: false,
+            creationObserved: false,
+            launchedTaskCalls: new Set(),
+            pendingTaskCalls: new Set(),
+            pendingStopTurns: [],
+            coalescedStopCount: 0,
+        };
+    }
+
+    function createTurnState(model: string | undefined): TurnRuntimeState {
+        return {
+            model,
             nativeAgentMessageSeen: false,
             assistantMessages: new Map(),
             bufferedTextParts: new Map(),
@@ -294,6 +331,31 @@ export const server = async (input: KiloPayload) => {
             sentAgentMessages: new Set(),
             sentUsageMessages: new Set(),
         };
+    }
+
+    function isProtectedSessionState(state: SessionRuntimeState): boolean {
+        return (
+            state.activeTurn !== undefined ||
+            state.stopInFlight !== undefined ||
+            state.subagentLink !== undefined ||
+            state.pendingTaskCalls.size > 0 ||
+            state.launchedTaskCalls.size > 0 ||
+            state.parentSessionID !== undefined
+        );
+    }
+
+    function evictDormantSession(): boolean {
+        for (const [sessionID, state] of sessionStates) {
+            if (isProtectedSessionState(state)) continue;
+            sessionStates.delete(sessionID);
+            return true;
+        }
+        return false;
+    }
+
+    function evictOldestSession(): void {
+        const oldest = sessionStates.keys().next().value;
+        if (typeof oldest === "string") sessionStates.delete(oldest);
     }
 
     function sessionState(sessionID: string): SessionRuntimeState {
@@ -304,32 +366,25 @@ export const server = async (input: KiloPayload) => {
             return existing;
         }
         while (sessionStates.size >= MAX_TRACKED_SESSIONS) {
-            const oldest = sessionStates.keys().next().value;
-            if (typeof oldest !== "string") break;
-            sessionStates.delete(oldest);
+            if (!evictDormantSession()) break;
         }
+        if (sessionStates.size >= MAX_RETAINED_SESSIONS) evictOldestSession();
         const created = createSessionState();
         sessionStates.set(sessionID, created);
         return created;
     }
 
-    function resetTurnState(state: SessionRuntimeState): void {
-        state.nativeAgentMessageSeen = false;
-        state.assistantMessages.clear();
-        state.bufferedTextParts.clear();
-        state.bufferedTextChars = 0;
-        state.sentAgentMessages.clear();
-        state.sentUsageMessages.clear();
-    }
-
     function recordSessionModel(sessionID: string, model: unknown): void {
-        if (isNonEmptyString(model)) sessionState(sessionID).model = model;
+        if (!isNonEmptyString(model)) return;
+        const state = sessionState(sessionID);
+        state.model = model;
+        if (state.activeTurn) state.activeTurn.model = model;
     }
 
-    function markTurnOpen(sessionID: string): void {
+    function markTurnOpen(sessionID: string): TurnRuntimeState {
         const state = sessionState(sessionID);
-        if (!state.turnOpen) resetTurnState(state);
-        state.turnOpen = true;
+        if (!state.activeTurn) state.activeTurn = createTurnState(state.model);
+        return state.activeTurn;
     }
 
     function rememberBounded(set: Set<string>, value: string): void {
@@ -346,23 +401,23 @@ export const server = async (input: KiloPayload) => {
         const info = payload(rawInfo);
         const messageID = firstString(info.id, info.messageID, info.message_id);
         if (!messageID) return;
-        const state = sessionState(sessionID);
         if (info.role === "user") {
             markTurnOpen(sessionID);
             return;
         }
         if (info.role !== "assistant") return;
-        state.assistantMessages.delete(messageID);
-        state.assistantMessages.set(messageID, {
+        const turn = markTurnOpen(sessionID);
+        turn.assistantMessages.delete(messageID);
+        turn.assistantMessages.set(messageID, {
             model: info.modelID ?? info.model?.modelID,
             provider: info.providerID ?? info.model?.providerID,
             timestamp: normalizeTimestamp(info.time?.completed ?? info.time?.created),
             usage: nativeMessageUsage(info),
         });
-        while (state.assistantMessages.size > MAX_TRACKED_MESSAGES_PER_TURN) {
-            const oldest = state.assistantMessages.keys().next().value;
+        while (turn.assistantMessages.size > MAX_TRACKED_MESSAGES_PER_TURN) {
+            const oldest = turn.assistantMessages.keys().next().value;
             if (typeof oldest !== "string") break;
-            state.assistantMessages.delete(oldest);
+            turn.assistantMessages.delete(oldest);
         }
     }
 
@@ -372,33 +427,37 @@ export const server = async (input: KiloPayload) => {
         const messageID = firstString(part.messageID, part.message_id);
         const partID = firstString(part.id, part.partID, part.part_id);
         if (!messageID || !partID) return;
-        markTurnOpen(sessionID);
-        const state = sessionState(sessionID);
+        const turn = markTurnOpen(sessionID);
         const key = messageID + ":" + partID;
-        const existing = state.bufferedTextParts.get(key);
+        const existing = turn.bufferedTextParts.get(key);
         if (existing) {
-            state.bufferedTextChars -= existing.text.length;
-            state.bufferedTextParts.delete(key);
+            turn.bufferedTextChars -= existing.text.length;
+            turn.bufferedTextParts.delete(key);
         }
         const normalized = part.text.trim();
         const text = normalized.slice(0, MAX_AGENT_MESSAGE_CHARS);
         if (text.length === 0) return;
         while (
-            state.bufferedTextParts.size > 0 &&
-            (state.bufferedTextParts.size >= MAX_BUFFERED_TEXT_PARTS_PER_TURN ||
-                state.bufferedTextChars + text.length > MAX_BUFFERED_TEXT_CHARS_PER_TURN)
+            turn.bufferedTextParts.size > 0 &&
+            (turn.bufferedTextParts.size >= MAX_BUFFERED_TEXT_PARTS_PER_TURN ||
+                turn.bufferedTextChars + text.length > MAX_BUFFERED_TEXT_CHARS_PER_TURN)
         ) {
-            const oldestKey = state.bufferedTextParts.keys().next().value;
+            const oldestKey = turn.bufferedTextParts.keys().next().value;
             if (typeof oldestKey !== "string") break;
-            const removed = state.bufferedTextParts.get(oldestKey);
-            if (removed) state.bufferedTextChars -= removed.text.length;
-            state.bufferedTextParts.delete(oldestKey);
+            const removed = turn.bufferedTextParts.get(oldestKey);
+            if (removed) turn.bufferedTextChars -= removed.text.length;
+            turn.bufferedTextParts.delete(oldestKey);
         }
-        state.bufferedTextParts.set(key, { messageID, partID, text, originalLength: normalized.length });
-        state.bufferedTextChars += text.length;
+        turn.bufferedTextParts.set(key, { messageID, partID, text, originalLength: normalized.length });
+        turn.bufferedTextChars += text.length;
     }
 
-    async function emitAgentMessage(sessionID: string, text: unknown, meta: Record<string, unknown> = {}): Promise<void> {
+    async function emitAgentMessage(
+        sessionID: string,
+        turn: TurnRuntimeState,
+        text: unknown,
+        meta: Record<string, unknown> = {},
+    ): Promise<void> {
         if (!isNonEmptyString(text)) return;
         const normalized = text.trim();
         const boundedText = normalized.slice(0, MAX_AGENT_MESSAGE_CHARS);
@@ -412,18 +471,16 @@ export const server = async (input: KiloPayload) => {
             : isNonEmptyString(messageID)
               ? sessionID + ":message:" + messageID
               : sessionID + ":text:" + normalized.length + ":" + boundedText.slice(0, 1024);
-        markTurnOpen(sessionID);
-        const state = sessionState(sessionID);
-        if (state.sentAgentMessages.has(key)) return;
-        rememberBounded(state.sentAgentMessages, key);
-        state.nativeAgentMessageSeen = true;
+        if (turn.sentAgentMessages.has(key)) return;
+        rememberBounded(turn.sentAgentMessages, key);
+        turn.nativeAgentMessageSeen = true;
 
         await postEvent("AgentMessage", {
             session_id: sessionID,
             text: boundedText,
             message_truncated: boundedText.length !== originalLength,
             message_original_length: originalLength,
-            model: meta?.model ?? state.model,
+            model: meta?.model ?? turn.model,
             provider: meta?.provider,
             message_index: meta?.message_index,
             message_timestamp: meta?.message_timestamp,
@@ -431,17 +488,16 @@ export const server = async (input: KiloPayload) => {
             agent: meta?.agent,
             usage: meta?.usage,
         });
-        if (isNonEmptyString(messageID) && meta?.usage) rememberBounded(state.sentUsageMessages, messageID);
+        if (isNonEmptyString(messageID) && meta?.usage) rememberBounded(turn.sentUsageMessages, messageID);
     }
 
-    async function flushAssistantMessages(sessionID: string): Promise<void> {
-        const state = sessionState(sessionID);
-        if (state.nativeAgentMessageSeen) return;
+    async function flushAssistantMessages(sessionID: string, turn: TurnRuntimeState): Promise<void> {
+        if (turn.nativeAgentMessageSeen) return;
         let index = 0;
-        for (const part of state.bufferedTextParts.values()) {
-            const meta = state.assistantMessages.get(part.messageID);
+        for (const part of turn.bufferedTextParts.values()) {
+            const meta = turn.assistantMessages.get(part.messageID);
             if (!meta) continue;
-            await emitAgentMessage(sessionID, part.text, {
+            await emitAgentMessage(sessionID, turn, part.text, {
                 messageID: part.messageID,
                 partID: part.partID,
                 model: meta.model,
@@ -455,20 +511,27 @@ export const server = async (input: KiloPayload) => {
         }
     }
 
-    async function flushAssistantUsage(sessionID: string): Promise<void> {
-        const state = sessionState(sessionID);
-        for (const [messageID, meta] of state.assistantMessages) {
-            if (!meta.usage || state.sentUsageMessages.has(messageID)) continue;
-            rememberBounded(state.sentUsageMessages, messageID);
+    async function flushAssistantUsage(sessionID: string, turn: TurnRuntimeState): Promise<void> {
+        for (const [messageID, meta] of turn.assistantMessages) {
+            if (!meta.usage || turn.sentUsageMessages.has(messageID)) continue;
+            rememberBounded(turn.sentUsageMessages, messageID);
             await postEvent("AgentUsage", {
                 session_id: sessionID,
                 message_id: messageID,
-                model: meta.model ?? state.model,
+                model: meta.model ?? turn.model,
                 provider: meta.provider,
                 timestamp: meta.timestamp,
                 usage: meta.usage,
             });
         }
+    }
+
+    function recordSessionParent(sessionID: string, parentSessionID: string | undefined): SessionRuntimeState {
+        const state = sessionState(sessionID);
+        if (parentSessionID && parentSessionID !== sessionID && !state.parentSessionID) {
+            state.parentSessionID = parentSessionID;
+        }
+        return state;
     }
 
     async function ensureSessionStarted(sessionID: string): Promise<void> {
@@ -481,6 +544,7 @@ export const server = async (input: KiloPayload) => {
             cwd: input.directory,
             project_dir: input.worktree || input.directory,
             client_source: "kilo",
+            parent_session_id: state.parentSessionID,
         });
     }
 
@@ -491,14 +555,44 @@ export const server = async (input: KiloPayload) => {
         return sessionID;
     }
 
+    async function drainStops(sessionID: string, state: SessionRuntimeState): Promise<void> {
+        while (true) {
+            const turn = state.pendingStopTurns.shift();
+            if (turn) {
+                await flushAssistantMessages(sessionID, turn);
+                await flushAssistantUsage(sessionID, turn);
+                await postEvent("Stop", { session_id: sessionID });
+                continue;
+            }
+            if (state.coalescedStopCount > 0) {
+                state.coalescedStopCount--;
+                await postEvent("Stop", { session_id: sessionID, turn_snapshot_dropped: true });
+                continue;
+            }
+            state.stopInFlight = undefined;
+            return;
+        }
+    }
+
+    function enqueueStop(sessionID: string, state: SessionRuntimeState, turn: TurnRuntimeState): Promise<void> {
+        if (state.pendingStopTurns.length < MAX_PENDING_STOP_TURN_SNAPSHOTS) {
+            state.pendingStopTurns.push(turn);
+        } else {
+            state.coalescedStopCount = Math.min(state.coalescedStopCount + 1, MAX_COALESCED_STOP_PLACEHOLDERS);
+        }
+        if (!state.stopInFlight) state.stopInFlight = drainStops(sessionID, state);
+        return state.stopInFlight;
+    }
+
     async function ensureSessionStopped(sessionID: string): Promise<void> {
         const state = sessionState(sessionID);
-        if (!state.turnOpen) return;
-        await flushAssistantMessages(sessionID);
-        await flushAssistantUsage(sessionID);
-        state.turnOpen = false;
-        resetTurnState(state);
-        await postEvent("Stop", { session_id: sessionID });
+        const turn = state.activeTurn;
+        let drain = state.stopInFlight;
+        if (turn) {
+            state.activeTurn = undefined;
+            drain = enqueueStop(sessionID, state, turn);
+        }
+        if (drain) await drain;
     }
 
     async function endSession(sessionID: string): Promise<void> {
@@ -512,9 +606,10 @@ export const server = async (input: KiloPayload) => {
     }
 
     async function completeSubagent(childSessionID: string): Promise<void> {
-        const link = subagentLinks.get(childSessionID);
+        const state = sessionStates.get(childSessionID);
+        const link = state?.subagentLink;
         if (!link) return;
-        subagentLinks.delete(childSessionID);
+        state.subagentLink = undefined;
         await postEvent("SubagentStop", {
             session_id: link.parentSessionID,
             parent_session_id: link.parentSessionID,
@@ -523,6 +618,37 @@ export const server = async (input: KiloPayload) => {
             tool_use_id: link.toolUseID,
             agent_type: "task",
         });
+    }
+
+    async function startSubagent(parentSessionID: string, childSessionID: string, toolUseID: string): Promise<boolean> {
+        if (parentSessionID === childSessionID) return false;
+        const parentState = sessionState(parentSessionID);
+        if (parentState.launchedTaskCalls.has(toolUseID)) return false;
+        const state = sessionState(childSessionID);
+        if (state.subagentLink) return false;
+        rememberBounded(parentState.launchedTaskCalls, toolUseID);
+        state.subagentLink = { parentSessionID, childSessionID, toolUseID };
+        await postEvent("SubagentStart", {
+            session_id: parentSessionID,
+            parent_session_id: parentSessionID,
+            agent_id: childSessionID,
+            child_session_id: childSessionID,
+            tool_use_id: toolUseID,
+            agent_type: "task",
+        });
+        return true;
+    }
+
+    function resumedTaskSessionID(inp: KiloPayload, out: KiloPayload): string | undefined {
+        const args = payload(firstValue(out?.args, inp?.args));
+        return normalizeSessionID(args?.task_id);
+    }
+
+    function isIdleSessionEvent(type: unknown, properties: KiloPayload | undefined): boolean {
+        if (type === "session.idle") return true;
+        if (type !== "session.status") return false;
+        const statusType = payload(properties?.status).type;
+        return typeof statusType === "string" && statusType.trim().toLowerCase() === "idle";
     }
 
     return {
@@ -543,23 +669,28 @@ export const server = async (input: KiloPayload) => {
                 const info = payload(properties?.info);
                 const childSessionID = normalizeSessionID(info?.id);
                 const parentSessionID = normalizeSessionID(info?.parentID ?? info?.parentId ?? info?.parent_id);
-                const candidates = parentSessionID ? pendingTaskCalls.get(parentSessionID) : undefined;
-                if (childSessionID && parentSessionID && childSessionID !== parentSessionID && candidates?.size === 1) {
-                    const toolUseID = candidates.values().next().value;
-                    if (typeof toolUseID === "string") {
-                        candidates.delete(toolUseID);
-                        if (candidates.size === 0) pendingTaskCalls.delete(parentSessionID);
-                        subagentLinks.set(childSessionID, { parentSessionID, childSessionID, toolUseID });
-                        await postEvent("SubagentStart", {
-                            session_id: parentSessionID,
-                            parent_session_id: parentSessionID,
-                            agent_id: childSessionID,
-                            child_session_id: childSessionID,
-                            tool_use_id: toolUseID,
-                            agent_type: "task",
-                        });
+                if (childSessionID) {
+                    const childState = recordSessionParent(childSessionID, parentSessionID);
+                    if (!childState.creationObserved) {
+                        childState.creationObserved = true;
+                        const parentState = parentSessionID ? sessionStates.get(parentSessionID) : undefined;
+                        const candidates = parentState?.pendingTaskCalls;
+                        if (parentSessionID && childSessionID !== parentSessionID && candidates?.size === 1) {
+                            const toolUseID = candidates.values().next().value;
+                            if (typeof toolUseID === "string" && (await startSubagent(parentSessionID, childSessionID, toolUseID))) {
+                                candidates.delete(toolUseID);
+                            }
+                        }
                     }
                 }
+            }
+            if (isIdleSessionEvent(type, properties)) {
+                const sessionID = (await resolveAndStartSession(ev, event, properties)) || lastSessionID;
+                if (sessionID) {
+                    await ensureSessionStopped(sessionID);
+                    await completeSubagent(sessionID);
+                }
+                return;
             }
             const sessionID = (await resolveAndStartSession(ev, event, properties)) || lastSessionID;
             if (!sessionID) return;
@@ -573,13 +704,16 @@ export const server = async (input: KiloPayload) => {
             }
 
             if (type === "session.next.text.ended") {
-                await emitAgentMessage(sessionID, properties?.text, {
-                    messageID: properties?.messageID,
-                    partID: properties?.partID,
-                    model: properties?.modelID ?? properties?.model?.modelID,
-                    provider: properties?.providerID ?? properties?.model?.providerID,
-                    message_timestamp: normalizeTimestamp(properties?.time?.completed ?? properties?.time?.created),
-                });
+                if (isNonEmptyString(properties?.text)) {
+                    const turn = markTurnOpen(sessionID);
+                    await emitAgentMessage(sessionID, turn, properties.text, {
+                        messageID: properties?.messageID,
+                        partID: properties?.partID,
+                        model: properties?.modelID ?? properties?.model?.modelID,
+                        provider: properties?.providerID ?? properties?.model?.providerID,
+                        message_timestamp: normalizeTimestamp(properties?.time?.completed ?? properties?.time?.created),
+                    });
+                }
             }
 
             if (type === "permission.asked") {
@@ -602,14 +736,14 @@ export const server = async (input: KiloPayload) => {
                 });
             }
 
-            if (type === "session.idle") {
-                await ensureSessionStopped(sessionID);
-                await completeSubagent(sessionID);
-            }
         },
 
         async dispose() {
-            for (const sessionID of [...sessionStates.keys()]) {
+            const sessionIDs = [...sessionStates.keys()];
+            for (const sessionID of sessionIDs) {
+                await completeSubagent(sessionID);
+            }
+            for (const sessionID of sessionIDs) {
                 await endSession(sessionID);
             }
             sessionStates.clear();
@@ -635,9 +769,14 @@ export const server = async (input: KiloPayload) => {
             if (!sessionID) return;
             markTurnOpen(sessionID);
             if (typeof inp?.tool === "string" && inp.tool.trim().toLowerCase() === "task" && isNonEmptyString(inp?.callID)) {
-                const calls = pendingTaskCalls.get(sessionID) ?? new Set<string>();
-                rememberBounded(calls, inp.callID.trim());
-                pendingTaskCalls.set(sessionID, calls);
+                const toolUseID = inp.callID.trim();
+                const resumedChildSessionID = resumedTaskSessionID(inp, out);
+                if (resumedChildSessionID) {
+                    sessionState(sessionID).pendingTaskCalls.delete(toolUseID);
+                    await startSubagent(sessionID, resumedChildSessionID, toolUseID);
+                } else {
+                    rememberBounded(sessionState(sessionID).pendingTaskCalls, toolUseID);
+                }
             }
             await postEvent("PreToolUse", {
                 session_id: sessionID,
@@ -654,9 +793,7 @@ export const server = async (input: KiloPayload) => {
             const toolError = stringifyError(out?.error ?? out?.metadata?.error);
             markTurnOpen(sessionID);
             if (typeof inp?.tool === "string" && inp.tool.trim().toLowerCase() === "task" && isNonEmptyString(inp?.callID)) {
-                const calls = pendingTaskCalls.get(sessionID);
-                calls?.delete(inp.callID.trim());
-                if (calls?.size === 0) pendingTaskCalls.delete(sessionID);
+                sessionStates.get(sessionID)?.pendingTaskCalls.delete(inp.callID.trim());
             }
             await postEvent("PostToolUse", {
                 session_id: sessionID,
@@ -673,7 +810,9 @@ export const server = async (input: KiloPayload) => {
         async "experimental.text.complete"(inp: KiloPayload, out: KiloPayload) {
             const sessionID = await resolveAndStartSession(inp, out);
             if (!sessionID) return;
-            await emitAgentMessage(sessionID, out?.text, {
+            if (!isNonEmptyString(out?.text)) return;
+            const turn = markTurnOpen(sessionID);
+            await emitAgentMessage(sessionID, turn, out.text, {
                 messageID: inp?.messageID,
                 partID: inp?.partID,
             });

--- a/plugin/trajectory-opencode/src/index.ts
+++ b/plugin/trajectory-opencode/src/index.ts
@@ -1,6 +1,23 @@
-const CAPTURE_URL = "http://localhost:19222/capture/opencode";
+const DEFAULT_CAPTURE_PORT = 19222;
+
+function resolveCapturePort(): number {
+    const rawPort = (
+        globalThis as typeof globalThis & {
+            process?: { env?: Record<string, string | undefined> };
+        }
+    ).process?.env?.TRAJECTORY_PORT;
+    if (typeof rawPort !== "string" || !/^\d+$/.test(rawPort)) return DEFAULT_CAPTURE_PORT;
+
+    const port = Number(rawPort);
+    return Number.isSafeInteger(port) && port >= 1 && port <= 65535 ? port : DEFAULT_CAPTURE_PORT;
+}
+
+const CAPTURE_URL = "http://localhost:" + resolveCapturePort() + "/capture/opencode";
 const POST_TIMEOUT_MS = 5000;
 const MAX_TRACKED_SESSIONS = 128;
+const MAX_RETAINED_SESSIONS = 512;
+const MAX_PENDING_STOP_TURN_SNAPSHOTS = 8;
+const MAX_COALESCED_STOP_PLACEHOLDERS = 128;
 const MAX_TRACKED_MESSAGES_PER_TURN = 128;
 const MAX_BUFFERED_TEXT_PARTS_PER_TURN = 64;
 const MAX_BUFFERED_TEXT_CHARS_PER_TURN = 1024 * 1024;
@@ -48,9 +65,21 @@ interface BufferedAssistantPart {
 
 interface SessionRuntimeState {
     started: boolean;
-    turnOpen: boolean;
-    nativeAgentMessageSeen: boolean;
+    creationObserved: boolean;
+    parentSessionID?: string;
     model?: string;
+    launchedTaskCalls: Set<string>;
+    pendingTaskCalls: Set<string>;
+    subagentLink?: SubagentLink;
+    activeTurn?: TurnRuntimeState;
+    pendingStopTurns: TurnRuntimeState[];
+    coalescedStopCount: number;
+    stopInFlight?: Promise<void>;
+}
+
+interface TurnRuntimeState {
+    model?: string;
+    nativeAgentMessageSeen: boolean;
     assistantMessages: Map<string, AssistantMessageMeta>;
     bufferedTextParts: Map<string, BufferedAssistantPart>;
     bufferedTextChars: number;
@@ -279,14 +308,22 @@ function permissionPayload(properties: OpenCodePayload, event?: OpenCodePayload)
 
 export const server = async (input: OpenCodePayload) => {
     const sessionStates = new Map<string, SessionRuntimeState>();
-    const pendingTaskCalls = new Map<string, Set<string>>();
-    const subagentLinks = new Map<string, SubagentLink>();
     let lastSessionID: string | undefined;
 
     function createSessionState(): SessionRuntimeState {
         return {
             started: false,
-            turnOpen: false,
+            creationObserved: false,
+            launchedTaskCalls: new Set(),
+            pendingTaskCalls: new Set(),
+            pendingStopTurns: [],
+            coalescedStopCount: 0,
+        };
+    }
+
+    function createTurnState(model: string | undefined): TurnRuntimeState {
+        return {
+            model,
             nativeAgentMessageSeen: false,
             assistantMessages: new Map(),
             bufferedTextParts: new Map(),
@@ -294,6 +331,31 @@ export const server = async (input: OpenCodePayload) => {
             sentAgentMessages: new Set(),
             sentUsageMessages: new Set(),
         };
+    }
+
+    function isProtectedSessionState(state: SessionRuntimeState): boolean {
+        return (
+            state.activeTurn !== undefined ||
+            state.stopInFlight !== undefined ||
+            state.subagentLink !== undefined ||
+            state.pendingTaskCalls.size > 0 ||
+            state.launchedTaskCalls.size > 0 ||
+            state.parentSessionID !== undefined
+        );
+    }
+
+    function evictDormantSession(): boolean {
+        for (const [sessionID, state] of sessionStates) {
+            if (isProtectedSessionState(state)) continue;
+            sessionStates.delete(sessionID);
+            return true;
+        }
+        return false;
+    }
+
+    function evictOldestSession(): void {
+        const oldest = sessionStates.keys().next().value;
+        if (typeof oldest === "string") sessionStates.delete(oldest);
     }
 
     function sessionState(sessionID: string): SessionRuntimeState {
@@ -304,32 +366,25 @@ export const server = async (input: OpenCodePayload) => {
             return existing;
         }
         while (sessionStates.size >= MAX_TRACKED_SESSIONS) {
-            const oldest = sessionStates.keys().next().value;
-            if (typeof oldest !== "string") break;
-            sessionStates.delete(oldest);
+            if (!evictDormantSession()) break;
         }
+        if (sessionStates.size >= MAX_RETAINED_SESSIONS) evictOldestSession();
         const created = createSessionState();
         sessionStates.set(sessionID, created);
         return created;
     }
 
-    function resetTurnState(state: SessionRuntimeState): void {
-        state.nativeAgentMessageSeen = false;
-        state.assistantMessages.clear();
-        state.bufferedTextParts.clear();
-        state.bufferedTextChars = 0;
-        state.sentAgentMessages.clear();
-        state.sentUsageMessages.clear();
-    }
-
     function recordSessionModel(sessionID: string, model: unknown): void {
-        if (isNonEmptyString(model)) sessionState(sessionID).model = model;
+        if (!isNonEmptyString(model)) return;
+        const state = sessionState(sessionID);
+        state.model = model;
+        if (state.activeTurn) state.activeTurn.model = model;
     }
 
-    function markTurnOpen(sessionID: string): void {
+    function markTurnOpen(sessionID: string): TurnRuntimeState {
         const state = sessionState(sessionID);
-        if (!state.turnOpen) resetTurnState(state);
-        state.turnOpen = true;
+        if (!state.activeTurn) state.activeTurn = createTurnState(state.model);
+        return state.activeTurn;
     }
 
     function rememberBounded(set: Set<string>, value: string): void {
@@ -346,23 +401,23 @@ export const server = async (input: OpenCodePayload) => {
         const info = payload(rawInfo);
         const messageID = firstString(info.id, info.messageID, info.message_id);
         if (!messageID) return;
-        const state = sessionState(sessionID);
         if (info.role === "user") {
             markTurnOpen(sessionID);
             return;
         }
         if (info.role !== "assistant") return;
-        state.assistantMessages.delete(messageID);
-        state.assistantMessages.set(messageID, {
+        const turn = markTurnOpen(sessionID);
+        turn.assistantMessages.delete(messageID);
+        turn.assistantMessages.set(messageID, {
             model: info.modelID ?? info.model?.modelID,
             provider: info.providerID ?? info.model?.providerID,
             timestamp: normalizeTimestamp(info.time?.completed ?? info.time?.created),
             usage: nativeMessageUsage(info),
         });
-        while (state.assistantMessages.size > MAX_TRACKED_MESSAGES_PER_TURN) {
-            const oldest = state.assistantMessages.keys().next().value;
+        while (turn.assistantMessages.size > MAX_TRACKED_MESSAGES_PER_TURN) {
+            const oldest = turn.assistantMessages.keys().next().value;
             if (typeof oldest !== "string") break;
-            state.assistantMessages.delete(oldest);
+            turn.assistantMessages.delete(oldest);
         }
     }
 
@@ -372,33 +427,37 @@ export const server = async (input: OpenCodePayload) => {
         const messageID = firstString(part.messageID, part.message_id);
         const partID = firstString(part.id, part.partID, part.part_id);
         if (!messageID || !partID) return;
-        markTurnOpen(sessionID);
-        const state = sessionState(sessionID);
+        const turn = markTurnOpen(sessionID);
         const key = messageID + ":" + partID;
-        const existing = state.bufferedTextParts.get(key);
+        const existing = turn.bufferedTextParts.get(key);
         if (existing) {
-            state.bufferedTextChars -= existing.text.length;
-            state.bufferedTextParts.delete(key);
+            turn.bufferedTextChars -= existing.text.length;
+            turn.bufferedTextParts.delete(key);
         }
         const normalized = part.text.trim();
         const text = normalized.slice(0, MAX_AGENT_MESSAGE_CHARS);
         if (text.length === 0) return;
         while (
-            state.bufferedTextParts.size > 0 &&
-            (state.bufferedTextParts.size >= MAX_BUFFERED_TEXT_PARTS_PER_TURN ||
-                state.bufferedTextChars + text.length > MAX_BUFFERED_TEXT_CHARS_PER_TURN)
+            turn.bufferedTextParts.size > 0 &&
+            (turn.bufferedTextParts.size >= MAX_BUFFERED_TEXT_PARTS_PER_TURN ||
+                turn.bufferedTextChars + text.length > MAX_BUFFERED_TEXT_CHARS_PER_TURN)
         ) {
-            const oldestKey = state.bufferedTextParts.keys().next().value;
+            const oldestKey = turn.bufferedTextParts.keys().next().value;
             if (typeof oldestKey !== "string") break;
-            const removed = state.bufferedTextParts.get(oldestKey);
-            if (removed) state.bufferedTextChars -= removed.text.length;
-            state.bufferedTextParts.delete(oldestKey);
+            const removed = turn.bufferedTextParts.get(oldestKey);
+            if (removed) turn.bufferedTextChars -= removed.text.length;
+            turn.bufferedTextParts.delete(oldestKey);
         }
-        state.bufferedTextParts.set(key, { messageID, partID, text, originalLength: normalized.length });
-        state.bufferedTextChars += text.length;
+        turn.bufferedTextParts.set(key, { messageID, partID, text, originalLength: normalized.length });
+        turn.bufferedTextChars += text.length;
     }
 
-    async function emitAgentMessage(sessionID: string, text: unknown, meta: Record<string, unknown> = {}): Promise<void> {
+    async function emitAgentMessage(
+        sessionID: string,
+        turn: TurnRuntimeState,
+        text: unknown,
+        meta: Record<string, unknown> = {},
+    ): Promise<void> {
         if (!isNonEmptyString(text)) return;
         const normalized = text.trim();
         const boundedText = normalized.slice(0, MAX_AGENT_MESSAGE_CHARS);
@@ -412,18 +471,16 @@ export const server = async (input: OpenCodePayload) => {
             : isNonEmptyString(messageID)
               ? sessionID + ":message:" + messageID
               : sessionID + ":text:" + normalized.length + ":" + boundedText.slice(0, 1024);
-        markTurnOpen(sessionID);
-        const state = sessionState(sessionID);
-        if (state.sentAgentMessages.has(key)) return;
-        rememberBounded(state.sentAgentMessages, key);
-        state.nativeAgentMessageSeen = true;
+        if (turn.sentAgentMessages.has(key)) return;
+        rememberBounded(turn.sentAgentMessages, key);
+        turn.nativeAgentMessageSeen = true;
 
         await postEvent("AgentMessage", {
             session_id: sessionID,
             text: boundedText,
             message_truncated: boundedText.length !== originalLength,
             message_original_length: originalLength,
-            model: meta?.model ?? state.model,
+            model: meta?.model ?? turn.model,
             provider: meta?.provider,
             message_index: meta?.message_index,
             message_timestamp: meta?.message_timestamp,
@@ -431,17 +488,16 @@ export const server = async (input: OpenCodePayload) => {
             agent: meta?.agent,
             usage: meta?.usage,
         });
-        if (isNonEmptyString(messageID) && meta?.usage) rememberBounded(state.sentUsageMessages, messageID);
+        if (isNonEmptyString(messageID) && meta?.usage) rememberBounded(turn.sentUsageMessages, messageID);
     }
 
-    async function flushAssistantMessages(sessionID: string): Promise<void> {
-        const state = sessionState(sessionID);
-        if (state.nativeAgentMessageSeen) return;
+    async function flushAssistantMessages(sessionID: string, turn: TurnRuntimeState): Promise<void> {
+        if (turn.nativeAgentMessageSeen) return;
         let index = 0;
-        for (const part of state.bufferedTextParts.values()) {
-            const meta = state.assistantMessages.get(part.messageID);
+        for (const part of turn.bufferedTextParts.values()) {
+            const meta = turn.assistantMessages.get(part.messageID);
             if (!meta) continue;
-            await emitAgentMessage(sessionID, part.text, {
+            await emitAgentMessage(sessionID, turn, part.text, {
                 messageID: part.messageID,
                 partID: part.partID,
                 model: meta.model,
@@ -455,20 +511,27 @@ export const server = async (input: OpenCodePayload) => {
         }
     }
 
-    async function flushAssistantUsage(sessionID: string): Promise<void> {
-        const state = sessionState(sessionID);
-        for (const [messageID, meta] of state.assistantMessages) {
-            if (!meta.usage || state.sentUsageMessages.has(messageID)) continue;
-            rememberBounded(state.sentUsageMessages, messageID);
+    async function flushAssistantUsage(sessionID: string, turn: TurnRuntimeState): Promise<void> {
+        for (const [messageID, meta] of turn.assistantMessages) {
+            if (!meta.usage || turn.sentUsageMessages.has(messageID)) continue;
+            rememberBounded(turn.sentUsageMessages, messageID);
             await postEvent("AgentUsage", {
                 session_id: sessionID,
                 message_id: messageID,
-                model: meta.model ?? state.model,
+                model: meta.model ?? turn.model,
                 provider: meta.provider,
                 timestamp: meta.timestamp,
                 usage: meta.usage,
             });
         }
+    }
+
+    function recordSessionParent(sessionID: string, parentSessionID: string | undefined): SessionRuntimeState {
+        const state = sessionState(sessionID);
+        if (parentSessionID && parentSessionID !== sessionID && !state.parentSessionID) {
+            state.parentSessionID = parentSessionID;
+        }
+        return state;
     }
 
     async function ensureSessionStarted(sessionID: string): Promise<void> {
@@ -481,6 +544,7 @@ export const server = async (input: OpenCodePayload) => {
             cwd: input.directory,
             project_dir: input.worktree || input.directory,
             client_source: "opencode",
+            parent_session_id: state.parentSessionID,
         });
     }
 
@@ -491,14 +555,44 @@ export const server = async (input: OpenCodePayload) => {
         return sessionID;
     }
 
+    async function drainStops(sessionID: string, state: SessionRuntimeState): Promise<void> {
+        while (true) {
+            const turn = state.pendingStopTurns.shift();
+            if (turn) {
+                await flushAssistantMessages(sessionID, turn);
+                await flushAssistantUsage(sessionID, turn);
+                await postEvent("Stop", { session_id: sessionID });
+                continue;
+            }
+            if (state.coalescedStopCount > 0) {
+                state.coalescedStopCount--;
+                await postEvent("Stop", { session_id: sessionID, turn_snapshot_dropped: true });
+                continue;
+            }
+            state.stopInFlight = undefined;
+            return;
+        }
+    }
+
+    function enqueueStop(sessionID: string, state: SessionRuntimeState, turn: TurnRuntimeState): Promise<void> {
+        if (state.pendingStopTurns.length < MAX_PENDING_STOP_TURN_SNAPSHOTS) {
+            state.pendingStopTurns.push(turn);
+        } else {
+            state.coalescedStopCount = Math.min(state.coalescedStopCount + 1, MAX_COALESCED_STOP_PLACEHOLDERS);
+        }
+        if (!state.stopInFlight) state.stopInFlight = drainStops(sessionID, state);
+        return state.stopInFlight;
+    }
+
     async function ensureSessionStopped(sessionID: string): Promise<void> {
         const state = sessionState(sessionID);
-        if (!state.turnOpen) return;
-        await flushAssistantMessages(sessionID);
-        await flushAssistantUsage(sessionID);
-        state.turnOpen = false;
-        resetTurnState(state);
-        await postEvent("Stop", { session_id: sessionID });
+        const turn = state.activeTurn;
+        let drain = state.stopInFlight;
+        if (turn) {
+            state.activeTurn = undefined;
+            drain = enqueueStop(sessionID, state, turn);
+        }
+        if (drain) await drain;
     }
 
     async function endSession(sessionID: string): Promise<void> {
@@ -512,9 +606,10 @@ export const server = async (input: OpenCodePayload) => {
     }
 
     async function completeSubagent(childSessionID: string): Promise<void> {
-        const link = subagentLinks.get(childSessionID);
+        const state = sessionStates.get(childSessionID);
+        const link = state?.subagentLink;
         if (!link) return;
-        subagentLinks.delete(childSessionID);
+        state.subagentLink = undefined;
         await postEvent("SubagentStop", {
             session_id: link.parentSessionID,
             parent_session_id: link.parentSessionID,
@@ -523,6 +618,37 @@ export const server = async (input: OpenCodePayload) => {
             tool_use_id: link.toolUseID,
             agent_type: "task",
         });
+    }
+
+    async function startSubagent(parentSessionID: string, childSessionID: string, toolUseID: string): Promise<boolean> {
+        if (parentSessionID === childSessionID) return false;
+        const parentState = sessionState(parentSessionID);
+        if (parentState.launchedTaskCalls.has(toolUseID)) return false;
+        const state = sessionState(childSessionID);
+        if (state.subagentLink) return false;
+        rememberBounded(parentState.launchedTaskCalls, toolUseID);
+        state.subagentLink = { parentSessionID, childSessionID, toolUseID };
+        await postEvent("SubagentStart", {
+            session_id: parentSessionID,
+            parent_session_id: parentSessionID,
+            agent_id: childSessionID,
+            child_session_id: childSessionID,
+            tool_use_id: toolUseID,
+            agent_type: "task",
+        });
+        return true;
+    }
+
+    function resumedTaskSessionID(inp: OpenCodePayload, out: OpenCodePayload): string | undefined {
+        const args = payload(firstValue(out?.args, inp?.args));
+        return normalizeSessionID(args?.task_id);
+    }
+
+    function isIdleSessionEvent(type: unknown, properties: OpenCodePayload | undefined): boolean {
+        if (type === "session.idle") return true;
+        if (type !== "session.status") return false;
+        const statusType = payload(properties?.status).type;
+        return typeof statusType === "string" && statusType.trim().toLowerCase() === "idle";
     }
 
     return {
@@ -543,23 +669,28 @@ export const server = async (input: OpenCodePayload) => {
                 const info = payload(properties?.info);
                 const childSessionID = normalizeSessionID(info?.id);
                 const parentSessionID = normalizeSessionID(info?.parentID ?? info?.parentId ?? info?.parent_id);
-                const candidates = parentSessionID ? pendingTaskCalls.get(parentSessionID) : undefined;
-                if (childSessionID && parentSessionID && childSessionID !== parentSessionID && candidates?.size === 1) {
-                    const toolUseID = candidates.values().next().value;
-                    if (typeof toolUseID === "string") {
-                        candidates.delete(toolUseID);
-                        if (candidates.size === 0) pendingTaskCalls.delete(parentSessionID);
-                        subagentLinks.set(childSessionID, { parentSessionID, childSessionID, toolUseID });
-                        await postEvent("SubagentStart", {
-                            session_id: parentSessionID,
-                            parent_session_id: parentSessionID,
-                            agent_id: childSessionID,
-                            child_session_id: childSessionID,
-                            tool_use_id: toolUseID,
-                            agent_type: "task",
-                        });
+                if (childSessionID) {
+                    const childState = recordSessionParent(childSessionID, parentSessionID);
+                    if (!childState.creationObserved) {
+                        childState.creationObserved = true;
+                        const parentState = parentSessionID ? sessionStates.get(parentSessionID) : undefined;
+                        const candidates = parentState?.pendingTaskCalls;
+                        if (parentSessionID && childSessionID !== parentSessionID && candidates?.size === 1) {
+                            const toolUseID = candidates.values().next().value;
+                            if (typeof toolUseID === "string" && (await startSubagent(parentSessionID, childSessionID, toolUseID))) {
+                                candidates.delete(toolUseID);
+                            }
+                        }
                     }
                 }
+            }
+            if (isIdleSessionEvent(type, properties)) {
+                const sessionID = (await resolveAndStartSession(ev, event, properties)) || lastSessionID;
+                if (sessionID) {
+                    await ensureSessionStopped(sessionID);
+                    await completeSubagent(sessionID);
+                }
+                return;
             }
             const sessionID = (await resolveAndStartSession(ev, event, properties)) || lastSessionID;
             if (!sessionID) return;
@@ -573,13 +704,16 @@ export const server = async (input: OpenCodePayload) => {
             }
 
             if (type === "session.next.text.ended") {
-                await emitAgentMessage(sessionID, properties?.text, {
-                    messageID: properties?.messageID,
-                    partID: properties?.partID,
-                    model: properties?.modelID ?? properties?.model?.modelID,
-                    provider: properties?.providerID ?? properties?.model?.providerID,
-                    message_timestamp: normalizeTimestamp(properties?.time?.completed ?? properties?.time?.created),
-                });
+                if (isNonEmptyString(properties?.text)) {
+                    const turn = markTurnOpen(sessionID);
+                    await emitAgentMessage(sessionID, turn, properties.text, {
+                        messageID: properties?.messageID,
+                        partID: properties?.partID,
+                        model: properties?.modelID ?? properties?.model?.modelID,
+                        provider: properties?.providerID ?? properties?.model?.providerID,
+                        message_timestamp: normalizeTimestamp(properties?.time?.completed ?? properties?.time?.created),
+                    });
+                }
             }
 
             if (type === "permission.asked") {
@@ -602,14 +736,14 @@ export const server = async (input: OpenCodePayload) => {
                 });
             }
 
-            if (type === "session.idle") {
-                await ensureSessionStopped(sessionID);
-                await completeSubagent(sessionID);
-            }
         },
 
         async dispose() {
-            for (const sessionID of [...sessionStates.keys()]) {
+            const sessionIDs = [...sessionStates.keys()];
+            for (const sessionID of sessionIDs) {
+                await completeSubagent(sessionID);
+            }
+            for (const sessionID of sessionIDs) {
                 await endSession(sessionID);
             }
             sessionStates.clear();
@@ -635,9 +769,14 @@ export const server = async (input: OpenCodePayload) => {
             if (!sessionID) return;
             markTurnOpen(sessionID);
             if (typeof inp?.tool === "string" && inp.tool.trim().toLowerCase() === "task" && isNonEmptyString(inp?.callID)) {
-                const calls = pendingTaskCalls.get(sessionID) ?? new Set<string>();
-                rememberBounded(calls, inp.callID.trim());
-                pendingTaskCalls.set(sessionID, calls);
+                const toolUseID = inp.callID.trim();
+                const resumedChildSessionID = resumedTaskSessionID(inp, out);
+                if (resumedChildSessionID) {
+                    sessionState(sessionID).pendingTaskCalls.delete(toolUseID);
+                    await startSubagent(sessionID, resumedChildSessionID, toolUseID);
+                } else {
+                    rememberBounded(sessionState(sessionID).pendingTaskCalls, toolUseID);
+                }
             }
             await postEvent("PreToolUse", {
                 session_id: sessionID,
@@ -654,9 +793,7 @@ export const server = async (input: OpenCodePayload) => {
             const toolError = stringifyError(out?.error ?? out?.metadata?.error);
             markTurnOpen(sessionID);
             if (typeof inp?.tool === "string" && inp.tool.trim().toLowerCase() === "task" && isNonEmptyString(inp?.callID)) {
-                const calls = pendingTaskCalls.get(sessionID);
-                calls?.delete(inp.callID.trim());
-                if (calls?.size === 0) pendingTaskCalls.delete(sessionID);
+                sessionStates.get(sessionID)?.pendingTaskCalls.delete(inp.callID.trim());
             }
             await postEvent("PostToolUse", {
                 session_id: sessionID,
@@ -673,7 +810,9 @@ export const server = async (input: OpenCodePayload) => {
         async "experimental.text.complete"(inp: OpenCodePayload, out: OpenCodePayload) {
             const sessionID = await resolveAndStartSession(inp, out);
             if (!sessionID) return;
-            await emitAgentMessage(sessionID, out?.text, {
+            if (!isNonEmptyString(out?.text)) return;
+            const turn = markTurnOpen(sessionID);
+            await emitAgentMessage(sessionID, turn, out.text, {
                 messageID: inp?.messageID,
                 partID: inp?.partID,
             });

--- a/plugin/trajectory-security/.claude-plugin/plugin.json
+++ b/plugin/trajectory-security/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "trajectory-security",
+  "description": "AI Guard and AI-EDR security controls for coding agents, powered by Trajectory",
+  "version": "0.1.0",
+  "author": {
+    "name": "Datadog",
+    "email": "no-reply@datadoghq.com"
+  },
+  "commands": "./commands",
+  "skills": "./skills/"
+}

--- a/plugin/trajectory-security/.codex-plugin/plugin.json
+++ b/plugin/trajectory-security/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "trajectory-security",
+  "version": "0.1.0",
+  "description": "AI Guard and AI-EDR security controls for coding agents, powered by Trajectory.",
+  "author": {
+    "name": "Datadog",
+    "url": "https://github.com/datadog-labs/trajectory"
+  },
+  "homepage": "https://github.com/datadog-labs/trajectory",
+  "repository": "https://github.com/datadog-labs/trajectory",
+  "license": "Apache-2.0",
+  "keywords": ["trajectory", "security", "datadog", "ai-guard", "ai-edr"],
+  "hooks": "./codex-hooks.json",
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Trajectory Security",
+    "shortDescription": "AI Guard and AI-EDR controls for coding agents.",
+    "longDescription": "Installs standalone agent-security hooks and exposes status, enable, disable, and destination setup workflows without requiring the core Trajectory marketplace plugin.",
+    "developerName": "Datadog",
+    "category": "Security",
+    "capabilities": [],
+    "websiteURL": "https://github.com/datadog-labs/trajectory",
+    "defaultPrompt": [
+      "Check Trajectory Security status",
+      "Configure a destination for agent-security results"
+    ]
+  }
+}

--- a/plugin/trajectory-security/.cursor-plugin/plugin.json
+++ b/plugin/trajectory-security/.cursor-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "trajectory-security",
+  "displayName": "Trajectory Security",
+  "version": "0.1.0",
+  "description": "AI Guard and AI-EDR security controls for coding agents, powered by Trajectory.",
+  "publisher": "Datadog",
+  "license": "Apache-2.0",
+  "category": "Security",
+  "hooks": "./cursor-hooks.json",
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/"
+}

--- a/plugin/trajectory-security/.mcp.json
+++ b/plugin/trajectory-security/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "trajectory": {
+      "command": "bash",
+      "args": ["-c", "exec \"$HOME/.trajectory/bin/trajectory\" mcp"]
+    }
+  }
+}

--- a/plugin/trajectory-security/README.md
+++ b/plugin/trajectory-security/README.md
@@ -1,0 +1,22 @@
+# Trajectory Security Marketplace Plugin
+
+This is the independently installable Agent Security plugin in the existing Trajectory marketplace, alongside the core `trajectory` plugin. It includes Claude Code, Codex, and Cursor surfaces for the `agent-security` module. Installing it does not require the core plugin; it requires only the Trajectory binary at `~/.trajectory/bin/trajectory` (or `TRAJECTORY_BINARY`).
+
+`trajectory security setup --mode observe --clients cc,codex,cursor`
+idempotently installs this plugin for Claude Code and Codex, synchronizes
+Cursor's native hooks, and enables Datadog Security. The first client session
+also runs `trajectory security setup --marketplace --clients <client>` as a
+bootstrap. That bootstrap preserves an existing enforce mode and respects an
+explicitly disabled module.
+
+Use the bundled command/skill surface for status, enable, disable, and destination configuration. To publish Agent Security result spans and read results back with an application key:
+
+```bash
+trajectory security destination add --destination <existing-destination> --app-key-ref <secret-ref>
+```
+
+Store the secret separately with `trajectory config set-secret <secret-ref> --stdin`; never place a key value in a manifest or command argument.
+
+AI Guard uses the standard Trajectory secret references `dd_api_key` and
+`dd_app_key` by default, so an installer only needs to store both references
+and run the security setup command.

--- a/plugin/trajectory-security/codex-hooks.json
+++ b/plugin/trajectory-security/codex-hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "\"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" security setup --marketplace --clients codex >/dev/null 2>&1 || true",
+        "timeout": 5
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client codex --event UserPromptSubmit --phase foreground_decision",
+        "timeout": 3
+      }]
+    }],
+    "PreToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client codex --event PreToolUse --phase foreground_decision",
+        "timeout": 3
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client codex --event PostToolUse --phase foreground_decision",
+        "timeout": 3
+      }]
+    }]
+  }
+}

--- a/plugin/trajectory-security/commands/security-destination.md
+++ b/plugin/trajectory-security/commands/security-destination.md
@@ -1,0 +1,6 @@
+---
+description: Configure a Datadog destination for Agent Security results
+argument-hint: --destination NAME --app-key-ref REF
+---
+
+Ask for the existing destination name and app-key secret reference if they were not supplied. Then run `trajectory security destination add --destination <name> --app-key-ref <ref>`. Never ask the user to paste the application key into chat; direct them to `trajectory config set-secret <ref> --stdin` when the secret does not exist.

--- a/plugin/trajectory-security/commands/security-disable.md
+++ b/plugin/trajectory-security/commands/security-disable.md
@@ -1,0 +1,5 @@
+---
+description: Disable Trajectory Security
+---
+
+Run `trajectory security disable`. Explain that the security plugin hooks remain installed but become fail-open because the module is disabled; uninstall `trajectory-security` from the Trajectory marketplace to remove its hook surface completely.

--- a/plugin/trajectory-security/commands/security-enable.md
+++ b/plugin/trajectory-security/commands/security-enable.md
@@ -1,0 +1,5 @@
+---
+description: Enable Trajectory Security for this coding agent
+---
+
+Run `trajectory security setup --marketplace --clients cc`. This enables observe mode without installing or requiring the core Trajectory marketplace plugin. Explain that enforce mode is an explicit separate choice because it can block agent actions.

--- a/plugin/trajectory-security/commands/security-status.md
+++ b/plugin/trajectory-security/commands/security-status.md
@@ -1,0 +1,5 @@
+---
+description: Show Trajectory Security activation and evaluator status
+---
+
+Run `trajectory security status` and summarize whether Agent Security is enabled, its mode, and any warnings. Do not change configuration.

--- a/plugin/trajectory-security/cursor-hooks.json
+++ b/plugin/trajectory-security/cursor-hooks.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [{
+      "command": "\"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" security setup --marketplace --clients cursor >/dev/null 2>&1 || true",
+      "timeout": 5
+    }],
+    "beforeSubmitPrompt": [{
+      "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cursor --event beforeSubmitPrompt --phase foreground_decision",
+      "timeout": 3
+    }],
+    "preToolUse": [{
+      "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cursor --event preToolUse --phase foreground_decision",
+      "timeout": 3
+    }],
+    "postToolUse": [{
+      "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cursor --event postToolUse --phase foreground_decision",
+      "timeout": 3
+    }],
+    "postToolUseFailure": [{
+      "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cursor --event postToolUseFailure --phase foreground_decision",
+      "timeout": 3
+    }]
+  }
+}

--- a/plugin/trajectory-security/hooks/hooks.json
+++ b/plugin/trajectory-security/hooks/hooks.json
@@ -1,0 +1,44 @@
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "\"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" security setup --marketplace --clients cc >/dev/null 2>&1 || true",
+        "timeout": 5
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cc --event UserPromptSubmit --phase foreground_decision",
+        "timeout": 3
+      }]
+    }],
+    "PreToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cc --event PreToolUse --phase foreground_decision",
+        "timeout": 3
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cc --event PostToolUse --phase foreground_decision",
+        "timeout": 3
+      }]
+    }],
+    "PostToolUseFailure": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TRAJECTORY_HOME=\"${TRAJECTORY_HOME:-${HOME}/.trajectory}\" \"${TRAJECTORY_BINARY:-${HOME}/.trajectory/bin/trajectory}\" hook-dispatch --product-plugin datadog-security --client cc --event PostToolUseFailure --phase foreground_decision",
+        "timeout": 3
+      }]
+    }]
+  }
+}

--- a/plugin/trajectory-security/skills/security/SKILL.md
+++ b/plugin/trajectory-security/skills/security/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: trajectory-security
+description: Manage Datadog AI Guard and AI-EDR security controls for coding agents. Use for Trajectory Security status, enable, disable, enforcement, hook setup, destination configuration, or agent-security scan-result readback.
+---
+
+# Trajectory Security
+
+Use the installed Trajectory binary for every operation. Do not duplicate security policy in the plugin.
+
+- Status: run `trajectory security status`.
+- Enable the security plugin hooks for the current client: run `trajectory security setup --marketplace --clients <cc|codex|cursor>`.
+- Enable enforcement only after explicit confirmation: run `trajectory security enable --mode enforce --clients <client> --yes`.
+- Disable evaluation: run `trajectory security disable`.
+- Configure result publishing: collect the existing destination name and an app-key secret reference, then run `trajectory security destination add --destination <name> --app-key-ref <ref>`.
+
+Never request or display an application-key value. If validation reports that the reference is missing, tell the user to store it with `trajectory config set-secret <ref> --stdin` or use `dd_app_key` with `DD_APP_KEY`.

--- a/plugin/trajectory/.claude-plugin/plugin.json
+++ b/plugin/trajectory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trajectory",
   "description": "Turnkey observability for AI coding agents - captures sessions and exports to Datadog LLM Observability",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "author": {
     "name": "Datadog",
     "email": "no-reply@datadoghq.com"

--- a/plugin/trajectory/hooks/hooks.json
+++ b/plugin/trajectory/hooks/hooks.json
@@ -5,23 +5,23 @@
       { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/capture-with-serve.sh UserPromptSubmit 2s", "timeout": 8 }
     ] }],
     "PreToolUse": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/PreToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/PreToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
     "PostToolUse": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
     "PostToolUseFailure": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUseFailure?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUseFailure?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
     "Stop": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/Stop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 10, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/Stop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 10, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
-    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PreCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "PostCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PostCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionRequest?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "PermissionDenied": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionDenied?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "SubagentStart": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStart?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.14", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PreCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PostCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PostCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionRequest?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PermissionDenied": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionDenied?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "SubagentStart": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStart?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
     "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "\"${HOME}/.trajectory/bin/trajectory\" capture-hook --background-after-read --ensure-serve --ensure-serve-wait 2s --wait-notify 2s SessionEnd", "timeout": 2 }] }]
   }
 }


### PR DESCRIPTION
## Summary
- update stable and beta release metadata for Trajectory 0.5.29
- add the standalone Trajectory Security marketplace plugin for Claude Code, Codex, and Cursor
- refresh Codex, OpenCode, Kilo, Security, managed endpoint, configuration, and metrics documentation