### PR TITLE
Restore Claude Stop compatibility shim

### DIFF
--- a/plugin/trajectory/.claude-plugin/plugin.json
+++ b/plugin/trajectory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trajectory",
   "description": "Turnkey observability for AI coding agents - captures sessions and exports to Datadog LLM Observability",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "author": {
     "name": "Datadog",
     "email": "no-reply@datadoghq.com"

--- a/plugin/trajectory/hooks/hooks.json
+++ b/plugin/trajectory/hooks/hooks.json
@@ -5,23 +5,23 @@
       { "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/capture-with-serve.sh UserPromptSubmit 2s", "timeout": 8 }
     ] }],
     "PreToolUse": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/PreToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/PreToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
     "PostToolUse": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUse?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
     "PostToolUseFailure": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUseFailure?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/PostToolUseFailure?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
     "Stop": [{ "matcher": "", "hooks": [
-      { "type": "http", "url": "http://127.0.0.1:19222/capture/Stop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 10, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
+      { "type": "http", "url": "http://127.0.0.1:19222/capture/Stop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 10, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }
     ] }],
-    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PreCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "PostCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PostCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionRequest?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "PermissionDenied": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionDenied?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "SubagentStart": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStart?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
-    "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.15", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PreCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PostCompact": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PostCompact?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionRequest?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "PermissionDenied": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/PermissionDenied?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "SubagentStart": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStart?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
+    "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "http", "url": "http://127.0.0.1:19222/capture/SubagentStop?trajectory_plugin_id=trajectory&trajectory_plugin_version=1.2.16", "timeout": 5, "headers": { "X-Trajectory-Home": "${HOME}/.trajectory" }, "allowedEnvVars": ["HOME"] }] }],
     "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "\"${HOME}/.trajectory/bin/trajectory\" capture-hook --background-after-read --ensure-serve --ensure-serve-wait 2s --wait-notify 2s SessionEnd", "timeout": 2 }] }]
   }
 }

--- a/plugin/trajectory/hooks/trajectory-stop-shim.sh
+++ b/plugin/trajectory/hooks/trajectory-stop-shim.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Compatibility target for Claude sessions that loaded the pre-1.2.15 Stop hook.
+# The retired hook may still run after the marketplace updates in place.
+cat >/dev/null || true
+exit 0


### PR DESCRIPTION
## Summary
- restore the no-op Claude Stop compatibility shim for sessions loaded from older plugin generations
- publish Claude plugin version 1.2.16 with updated hook attribution