### PR TITLE
release: publish Trajectory 0.5.30 metadata

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.29",
-    "tag": "v0.5.29",
-    "released_at": "2026-07-31T10:44:28Z"
+    "version": "0.5.30",
+    "tag": "v0.5.30",
+    "released_at": "2026-07-31T17:05:41Z"
   },
   "beta": {
-    "version": "0.5.29",
-    "tag": "v0.5.29",
-    "released_at": "2026-07-31T10:44:28Z"
+    "version": "0.5.30",
+    "tag": "v0.5.30",
+    "released_at": "2026-07-31T17:05:41Z"
   }
 }


### PR DESCRIPTION
## Summary

- advance the stable and beta release channels to Trajectory 0.5.30
- retain the release publication timestamp in public metadata