### PR TITLE
Release Trajectory 0.5.30

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.29",
-    "tag": "v0.5.29",
-    "released_at": "2026-07-31T10:44:28Z"
+    "version": "0.5.30",
+    "tag": "v0.5.30",
+    "released_at": "2026-07-31T17:05:41Z"
   },
   "beta": {
-    "version": "0.5.29",
-    "tag": "v0.5.29",
-    "released_at": "2026-07-31T10:44:28Z"
+    "version": "0.5.30",
+    "tag": "v0.5.30",
+    "released_at": "2026-07-31T17:05:41Z"
   }
 }

--- a/docs/SECURITY-EVENT-STREAM.md
+++ b/docs/SECURITY-EVENT-STREAM.md
@@ -78,6 +78,11 @@ The log body includes event-stream metadata such as
 profile. Event-stream schema version 2 adds the vendor-neutral
 `tool_operation` detection contract and makes `security` full-fidelity.
 
+Resolved identity fields are emitted as trusted top-level attributes:
+`trajectory.user` on every log, plus `trajectory.user_email`, `git.email`, and
+`github.username` when available. Locally resolved values override same-named
+captured event fields.
+
 Registered common tools retain three complementary identities:
 
 - `tool_operation`, such as `shell.execute`, is the vendor-neutral field for


### PR DESCRIPTION
## Summary

- update stable and beta release metadata for Trajectory 0.5.30
- document resolved identity attributes in security event-stream logs