### PR TITLE
fix(release): expose safe STS claim diagnostics

### DIFF
--- a/.github/scripts/public_release_mirror.py
+++ b/.github/scripts/public_release_mirror.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import http.client
 import json
@@ -39,6 +40,15 @@ PUBLIC_DOWNLOAD_SUFFIXES = (
     ".githubusercontent.com",
 )
 CHUNK_SIZE = 1024 * 1024
+OIDC_DIAGNOSTIC_CLAIMS = (
+    "sub",
+    "repository",
+    "ref",
+    "event_name",
+    "environment",
+    "workflow_ref",
+    "job_workflow_ref",
+)
 
 
 class MirrorError(RuntimeError):
@@ -990,6 +1000,22 @@ def request_json_url(url: str, headers: dict[str, str]) -> dict[str, Any]:
     return value
 
 
+def oidc_claim_diagnostics(token: str) -> str:
+    """Return only non-secret identity claims needed to diagnose STS policy mismatches."""
+    try:
+        encoded_payload = token.split(".")[1]
+        padded_payload = encoded_payload + "=" * (-len(encoded_payload) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded_payload))
+    except (IndexError, ValueError, json.JSONDecodeError):
+        return "unavailable"
+    if not isinstance(payload, dict):
+        return "unavailable"
+    return json.dumps(
+        {key: payload[key] for key in OIDC_DIAGNOSTIC_CLAIMS if key in payload},
+        sort_keys=True,
+    )
+
+
 def exchange_source_token(contract: dict[str, Any]) -> str:
     oidc_url = require_string(
         os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL"),
@@ -1023,10 +1049,15 @@ def exchange_source_token(contract: dict[str, Any]) -> str:
             }
         )
     )
-    exchanged = request_json_url(
-        exchange_url,
-        {"Authorization": f"Bearer {oidc_token}"},
-    )
+    try:
+        exchanged = request_json_url(
+            exchange_url,
+            {"Authorization": f"Bearer {oidc_token}"},
+        )
+    except MirrorError as error:
+        raise MirrorError(
+            f"{error}; GitHub OIDC claims: {oidc_claim_diagnostics(oidc_token)}"
+        ) from error
     return require_string(exchanged.get("token"), "Octo STS source token")
 
 

--- a/tests/test_public_release_mirror.py
+++ b/tests/test_public_release_mirror.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import base64
 import hashlib
 import importlib.util
 import json
@@ -1112,6 +1113,40 @@ class PublicReleaseMirrorTests(unittest.TestCase):
         self.assertIn("scope=DataDog%2Ftrajectory", calls[1][0])
         self.assertIn("identity=trajectory-labs.public-release-read", calls[1][0])
         self.assertEqual(calls[1][1]["Authorization"], "Bearer oidc-token")
+
+    def test_source_token_exchange_failure_reports_only_safe_identity_claims(self) -> None:
+        payload = {
+            "sub": "repo:datadog-labs/trajectory:environment:public-release-mirror",
+            "repository": "datadog-labs/trajectory",
+            "ref": "refs/heads/main",
+            "event_name": "workflow_dispatch",
+            "environment": "public-release-mirror",
+            "workflow_ref": (
+                "datadog-labs/trajectory/.github/workflows/"
+                "public-release-mirror.yml@refs/heads/main"
+            ),
+            "repository_id": "secret-adjacent-unneeded-value",
+        }
+        encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        oidc_token = f"header.{encoded}.signature"
+        environment = {
+            "ACTIONS_ID_TOKEN_REQUEST_URL": (
+                "https://pipelines.actions.githubusercontent.com/token?api-version=2.0"
+            ),
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-token",
+        }
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.object(
+            MIRROR,
+            "request_json_url",
+            side_effect=[{"value": oidc_token}, MIRROR.MirrorError("STS denied")],
+        ), self.assertRaisesRegex(MIRROR.MirrorError, "GitHub OIDC claims") as raised:
+            MIRROR.exchange_source_token(self.contract)
+
+        message = str(raised.exception)
+        self.assertIn("public-release-mirror", message)
+        self.assertNotIn(oidc_token, message)
+        self.assertNotIn("runner-token", message)
+        self.assertNotIn("secret-adjacent-unneeded-value", message)
 
     def test_github_client_creates_draft_and_sets_latest_only_on_publish(self) -> None:
         request, _, _ = build_fixture()


### PR DESCRIPTION
## Summary
- report only allowlisted GitHub OIDC identity claims when source-token exchange is denied
- never log the signed token or runner request token
- add regression coverage for the diagnostic boundary

## Validation
- `python3 tests/test_public_release_mirror.py` (34 passed)