### PR TITLE
Release Trajectory 0.5.35

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -1,12 +1,12 @@
 {
   "stable": {
-    "version": "0.5.34",
-    "tag": "v0.5.34",
-    "released_at": "2026-08-07T20:13:08Z"
+    "version": "0.5.35",
+    "tag": "v0.5.35",
+    "released_at": "2026-08-12T12:41:36Z"
   },
   "beta": {
-    "version": "0.5.34",
-    "tag": "v0.5.34",
-    "released_at": "2026-08-07T20:13:08Z"
+    "version": "0.5.35",
+    "tag": "v0.5.35",
+    "released_at": "2026-08-12T12:41:36Z"
   }
 }


### PR DESCRIPTION
Advance public release metadata to Trajectory v0.5.35.

The corresponding public GitHub release and MASS artifacts are being published from the exact protected release receipt.