### PR TITLE
docs(user-guide): clarify backfill-my-metrics --yes scope

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1257,6 +1257,12 @@ trajectory repair metrics                              # Local-only historical m
 trajectory backfill-my-metrics --since 2026-07-05 --until 2026-08-05 --yes # user-driven Codex cost repair
 ```
 
+`--my-usage` and `--task-metrics` only shape the dry-run preview; they do not
+change what `--yes` executes. `--yes` alone always runs either the Codex-source
+cost repair described below or a `--campaign`-gated managed replay. There is
+currently no self-service `--yes` path that publishes non-Codex historical
+data (e.g. Claude Code) without a managed campaign.
+
 The explicit user-driven Codex repair can cover up to the effective
 `capture.retention_days` age window (`0` keeps history forever), reads only the
 user's Codex/Codex.app rollout history, requires `--yes` for publication, and


### PR DESCRIPTION
Fixes #53

`--my-usage` and `--task-metrics` weren't documented anywhere in USER-GUIDE.md or METRICS-REFERENCE.md as being dry-run-only presets with no real-execution path of their own. This led to reading the `-dry-run` flag's help text ("use --my-usage --yes or --task-metrics --yes for an authorized historical repair") as implying a real publish path for non-Codex clients, when in practice `--yes` always executes either the Codex-source cost repair or a `--campaign`-gated managed replay, regardless of which preset flag is passed.

This adds a short clarifying note right after the existing Codex-repair example in USER-GUIDE.md, stating that plainly.

Docs-only change; no code/test impact.