### PR TITLE
fix(trajectory-plugin): bound capture-hook call to avoid lost hook output

### DIFF
--- a/plugin/trajectory/hooks/capture-with-serve.sh
+++ b/plugin/trajectory/hooks/capture-with-serve.sh
@@ -25,4 +25,25 @@ if [ ! -x "$BINARY" ]; then
     exit 0
 fi
 
-exec "$BINARY" capture-hook --wait-notify "$WAIT_NOTIFY" "$EVENT_TYPE"
+# The shared serve daemon can be busy for tens of seconds on other work (batch
+# repairs, marker evaluation, publish retries). Without a bound here, Claude
+# Code's own hook timeout eventually SIGKILLs this process and discards the
+# hook's output. Fail open before that happens instead.
+CAPTURE_TIMEOUT="${TRAJECTORY_CAPTURE_HOOK_TIMEOUT_SECONDS:-5}"
+case "$CAPTURE_TIMEOUT" in
+    ''|*[!0-9]*) CAPTURE_TIMEOUT=5 ;;
+esac
+
+TIMEOUT_BIN=""
+for candidate in timeout gtimeout; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        TIMEOUT_BIN="$candidate"
+        break
+    fi
+done
+
+if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$CAPTURE_TIMEOUT" "$BINARY" capture-hook --wait-notify "$WAIT_NOTIFY" "$EVENT_TYPE" || exit 0
+else
+    exec "$BINARY" capture-hook --wait-notify "$WAIT_NOTIFY" "$EVENT_TYPE"
+fi


### PR DESCRIPTION
Fixes #54

`capture-with-serve.sh` execed `trajectory capture-hook` with no timeout of its own, relying entirely on Claude Code's outer hook timeout. When the shared serve daemon is busy for 20-30s+ on unrelated work (batch repairs, marker evaluation, publish retries — observed a 32s `markers_session_end` publish stall against OTLP), the hook gets hard-killed by the host tool and its output is discarded, regardless of how high the host tool's own timeout is raised.

This wraps the final `capture-hook` call in `timeout`/`gtimeout` (default 5s, overridable via `TRAJECTORY_CAPTURE_HOOK_TIMEOUT_SECONDS`) so a busy daemon causes a fast, clean `exit 0` instead of an eventual hard kill with discarded output. If neither `timeout` nor `gtimeout` is present (stock macOS without coreutils), it falls back to the original unbounded `exec`, so behavior is unchanged on those systems.

Verified with `bash -n` and running locally against a real busy-daemon scenario without regressions.